### PR TITLE
feat: add rq worker and tests

### DIFF
--- a/services/worker/tests/test_jobs.py
+++ b/services/worker/tests/test_jobs.py
@@ -1,0 +1,26 @@
+import sys
+from pathlib import Path
+
+import fakeredis
+from rq import Queue, SimpleWorker
+
+# Make the worker package importable when tests are executed from the repo root
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from worker.jobs import analyze_track, compute_embeddings
+
+
+def test_jobs_are_executed():
+    """Jobs enqueued on RQ queues should be picked up and executed."""
+    connection = fakeredis.FakeRedis()
+
+    analysis_q = Queue("analysis", connection=connection)
+    scoring_q = Queue("scoring", connection=connection)
+
+    job1 = analysis_q.enqueue(analyze_track, "42")
+    job2 = scoring_q.enqueue(compute_embeddings, [1.0, 2.0, 3.0])
+
+    worker = SimpleWorker([analysis_q, scoring_q], connection=connection)
+    worker.work(burst=True)
+
+    assert job1.result == "analysis-complete:42"
+    assert job2.result == [round(x, 4) for x in [1/3, 2/3, 1.0]]

--- a/services/worker/worker/__init__.py
+++ b/services/worker/worker/__init__.py
@@ -1,0 +1,4 @@
+# Worker package exposing background job functions.
+from .jobs import analyze_track, compute_embeddings
+
+__all__ = ["analyze_track", "compute_embeddings"]

--- a/services/worker/worker/jobs.py
+++ b/services/worker/worker/jobs.py
@@ -1,0 +1,40 @@
+"""Background job implementations for the worker service."""
+from __future__ import annotations
+
+from typing import List
+import time
+
+
+def analyze_track(track_id: str) -> str:
+    """Simulate analyzing an audio track.
+
+    Args:
+        track_id: Identifier for the track to analyze.
+
+    Returns:
+        A message indicating the track has been analyzed.
+    """
+    # Simulate some work being done
+    time.sleep(0.1)
+    result = f"analysis-complete:{track_id}"
+    print(f"[worker] analyzed track {track_id}")
+    return result
+
+
+def compute_embeddings(data: List[float]) -> List[float]:
+    """Compute a simple normalised embedding vector.
+
+    Args:
+        data: List of floats representing raw features.
+
+    Returns:
+        A list of floats normalised by the maximum value.
+    """
+    if not data:
+        return []
+    max_val = max(data)
+    if max_val == 0:
+        return [0 for _ in data]
+    embeddings = [round(x / max_val, 4) for x in data]
+    print("[worker] computed embeddings")
+    return embeddings

--- a/services/worker/worker/run.py
+++ b/services/worker/worker/run.py
@@ -1,16 +1,24 @@
+"""Entry point for the RQ worker."""
+from __future__ import annotations
+
 import os
-import time
+import redis
+from rq import Connection, Queue, Worker
+
+# Import job functions so the worker process knows about them.
+from . import jobs  # noqa: F401
 
 
-def main():
-    print("[worker] stub ready")
-    try:
-        while True:
-            time.sleep(5)
-    except KeyboardInterrupt:
-        print("[worker] stopping")
+def main() -> None:
+    """Start an RQ worker listening to analysis queues."""
+    redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+    connection = redis.from_url(redis_url)
+
+    queues = ["analysis", "scoring"]
+    with Connection(connection):
+        worker = Worker([Queue(name) for name in queues])
+        worker.work()
 
 
 if __name__ == "__main__":
     main()
-


### PR DESCRIPTION
## Summary
- add RQ-based worker listening to `analysis` and `scoring` queues
- implement example jobs `analyze_track` and `compute_embeddings`
- test that jobs can be enqueued and executed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba01ba206483338f6a565b6fbe74c3