### PR TITLE
feat: add public API base configuration for UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,9 @@ NEXTAUTH_SECRET=supersecretlongrandom
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 
+# UI
+NEXT_PUBLIC_API_BASE=http://localhost:8000
+
 # Paths
 AUDIO_ROOT=/audio
 CACHE_DIR=/tmp/vibescope

--- a/README.md
+++ b/README.md
@@ -464,6 +464,10 @@ cp .env.example .env
 #    - Authorized redirect URI: https://your.domain/api/auth/callback/google
 #    - Put GOOGLE_CLIENT_ID/SECRET into .env and set NEXTAUTH_URL
 
+# 2b) API base for UI fetches (default: http://localhost:8000)
+#     - NEXT_PUBLIC_API_BASE points the Next.js UI at the API
+#     - Override in production, e.g., https://api.your.domain
+
 # 3) Build and start
 docker compose up -d --build
 

--- a/services/ui/app/api-status.tsx
+++ b/services/ui/app/api-status.tsx
@@ -1,10 +1,11 @@
 'use client';
 import { useEffect, useState } from 'react';
+import { apiFetch } from '../lib/api';
 
 export default function ApiStatus() {
   const [status, setStatus] = useState<string>('loading...');
   useEffect(() => {
-    fetch(process.env.NEXT_PUBLIC_API_BASE ? `${process.env.NEXT_PUBLIC_API_BASE}/health` : '/api/health')
+    apiFetch('/health')
       .then(r => r.json())
       .then(j => setStatus(`${j.status} (db: ${j.db})`))
       .catch(() => setStatus('error'));

--- a/services/ui/app/moods/page.tsx
+++ b/services/ui/app/moods/page.tsx
@@ -1,7 +1,8 @@
+import { apiFetch } from '../../lib/api';
+
 async function getAgg() {
-  const base = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
   // Use trajectory weeks and then pull radar for each to assemble a simple table
-  const trajRes = await fetch(`${base}/dashboard/trajectory`, { next: { revalidate: 0 } });
+  const trajRes = await apiFetch('/dashboard/trajectory', { next: { revalidate: 0 } });
   if (!trajRes.ok) return { points: [] };
   const traj = await trajRes.json();
   return traj;

--- a/services/ui/app/radar/page.tsx
+++ b/services/ui/app/radar/page.tsx
@@ -1,12 +1,13 @@
+import { apiFetch } from '../../lib/api';
+
 async function getRadar() {
-  const base = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
   // Pull trajectory to discover the most recent week, then build radar
-  const trajRes = await fetch(`${base}/dashboard/trajectory`, { next: { revalidate: 0 } });
+  const trajRes = await apiFetch('/dashboard/trajectory', { next: { revalidate: 0 } });
   const traj = await trajRes.json();
   const last = traj.points?.[traj.points.length - 1];
   const week = last?.week;
   if (!week) return { week: null, axes: {}, baseline: {} };
-  const res = await fetch(`${base}/dashboard/radar?week=${encodeURIComponent(week)}`, { next: { revalidate: 0 } });
+  const res = await apiFetch(`/dashboard/radar?week=${encodeURIComponent(week)}`, { next: { revalidate: 0 } });
   if (!res.ok) throw new Error('Failed to fetch radar');
   return res.json();
 }

--- a/services/ui/app/trajectory/page.tsx
+++ b/services/ui/app/trajectory/page.tsx
@@ -1,6 +1,7 @@
+import { apiFetch } from '../../lib/api';
+
 async function getTrajectory() {
-  const base = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
-  const res = await fetch(`${base}/dashboard/trajectory`, { next: { revalidate: 0 } });
+  const res = await apiFetch('/dashboard/trajectory', { next: { revalidate: 0 } });
   if (!res.ok) throw new Error('Failed to fetch trajectory');
   return res.json();
 }

--- a/services/ui/lib/api.ts
+++ b/services/ui/lib/api.ts
@@ -1,0 +1,7 @@
+export const API_BASE =
+  process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
+
+export function apiFetch(path: string, init?: RequestInit) {
+  return fetch(`${API_BASE}${path}`, init);
+}
+


### PR DESCRIPTION
## Summary
- expose `NEXT_PUBLIC_API_BASE` in example env
- funnel Next.js fetches through a helper that respects `NEXT_PUBLIC_API_BASE`
- document overriding API base in production

## Testing
- `npm run lint` *(fails: prompts for interactive ESLint setup)*
- `cd services/api && pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ba01cbfcec8333bfbdc39311e724c5