### PR TITLE
Persist user labels and add tests

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -15,6 +15,7 @@ from .models import (
     Listen,
     MoodScore,
     MoodAggWeek,
+    UserLabel,
     LastfmTags,
 )
 
@@ -481,7 +482,20 @@ def dashboard_radar(week: str = Query(...), db: Session = Depends(get_db)):
 
 
 @app.post("/labels")
-def submit_label(user_id: str, track_id: int, axis: str, value: float):
-    if axis not in {"energy", "valence", "danceability", "brightness", "pumpiness"}:
+def submit_label(
+    user_id: str, track_id: int, axis: str, value: float, db: Session = Depends(get_db)
+):
+    if axis not in AXES:
         raise HTTPException(status_code=400, detail="Unknown axis")
-    return {"detail": "accepted", "user_id": user_id, "track_id": track_id, "axis": axis, "value": value}
+    lbl = UserLabel(user_id=user_id, track_id=track_id, axis=axis, value=value)
+    db.add(lbl)
+    db.commit()
+    db.refresh(lbl)
+    return {
+        "detail": "accepted",
+        "id": lbl.id,
+        "user_id": lbl.user_id,
+        "track_id": lbl.track_id,
+        "axis": lbl.axis,
+        "value": lbl.value,
+    }

--- a/services/api/tests/test_labels.py
+++ b/services/api/tests/test_labels.py
@@ -1,0 +1,78 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+# Ensure repository root on sys.path and configure SQLite for tests
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+os.environ["DATABASE_URL"] = "sqlite:///./test.db"
+
+from services.api.app.main import app  # noqa: E402  (import after setting env)
+from services.api.app.db import SessionLocal, engine, get_db  # noqa: E402
+from services.api.app.models import Base, Track, UserLabel  # noqa: E402
+
+
+Base.metadata.create_all(bind=engine)
+
+
+def override_get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+app.dependency_overrides[get_db] = override_get_db
+client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def clear_db():
+    """Clear tables between tests."""
+    with SessionLocal() as db:
+        db.query(UserLabel).delete()
+        db.query(Track).delete()
+        db.commit()
+
+
+def _create_track() -> int:
+    with SessionLocal() as db:
+        tr = Track(title="test")
+        db.add(tr)
+        db.commit()
+        db.refresh(tr)
+        return tr.track_id
+
+
+def test_submit_label_stores_label():
+    tid = _create_track()
+    resp = client.post(
+        "/labels",
+        params={"user_id": "u1", "track_id": tid, "axis": "energy", "value": 0.5},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["detail"] == "accepted"
+    assert data["axis"] == "energy"
+
+    with SessionLocal() as db:
+        lbl = db.execute(select(UserLabel)).scalar_one()
+        assert lbl.user_id == "u1"
+        assert lbl.axis == "energy"
+        assert lbl.value == 0.5
+
+
+def test_submit_label_rejects_unknown_axis():
+    tid = _create_track()
+    resp = client.post(
+        "/labels",
+        params={"user_id": "u1", "track_id": tid, "axis": "invalid", "value": 0.5},
+    )
+    assert resp.status_code == 400
+    with SessionLocal() as db:
+        assert db.execute(select(UserLabel)).first() is None
+


### PR DESCRIPTION
## Summary
- persist user submitted labels via /labels endpoint
- add tests verifying label storage and axis validation

## Testing
- `pytest services/api/tests/test_labels.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba01d6dcbc8333a1d5a9b6cd48355e