### PR TITLE
Use Redis queue for track analysis

### DIFF
--- a/services/api/tests/test_analyze_track.py
+++ b/services/api/tests/test_analyze_track.py
@@ -7,8 +7,10 @@ os.environ.setdefault("AUTO_MIGRATE", "1")
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
+import fakeredis
+from rq import Queue
 from fastapi.testclient import TestClient
-from app.main import app, ANALYSIS_QUEUE
+from app import main as app_main
 from app.db import SessionLocal, maybe_create_all
 from app.models import Track
 
@@ -17,32 +19,36 @@ maybe_create_all()
 
 
 def test_analyze_track_schedules_job():
-    ANALYSIS_QUEUE.clear()
+    connection = fakeredis.FakeRedis()
+    app_main._REDIS_CONN = connection
     with SessionLocal() as db:
         tr = Track(title="test", path_local="song.mp3")
         db.add(tr)
         db.commit()
         tid = tr.track_id
-    with TestClient(app) as client:
+    with TestClient(app_main.app) as client:
         resp = client.post(f"/analyze/track/{tid}")
         assert resp.status_code == 200
         assert resp.json()["status"] == "scheduled"
-    assert tid in ANALYSIS_QUEUE
+    q = Queue("analysis", connection=connection)
+    jobs = q.jobs
+    assert jobs and jobs[0].args[0] == tid
 
 
 def test_analyze_track_not_found():
-    with TestClient(app) as client:
+    with TestClient(app_main.app) as client:
         resp = client.post("/analyze/track/9999")
         assert resp.status_code == 404
 
 
 def test_analyze_track_missing_path():
-    ANALYSIS_QUEUE.clear()
+    connection = fakeredis.FakeRedis()
+    app_main._REDIS_CONN = connection
     with SessionLocal() as db:
         tr = Track(title="nop")
         db.add(tr)
         db.commit()
         tid = tr.track_id
-    with TestClient(app) as client:
+    with TestClient(app_main.app) as client:
         resp = client.post(f"/analyze/track/{tid}")
         assert resp.status_code == 400

--- a/services/worker/tests/test_jobs.py
+++ b/services/worker/tests/test_jobs.py
@@ -1,26 +1,51 @@
+import os
 import sys
 from pathlib import Path
 
 import fakeredis
+import numpy as np
+import soundfile as sf
 from rq import Queue, SimpleWorker
+
+# Configure database before importing app modules
+os.environ.setdefault("DATABASE_URL", "sqlite:///./test_worker.db")
+os.environ.setdefault("AUTO_MIGRATE", "1")
 
 # Make the worker package importable when tests are executed from the repo root
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from worker.jobs import analyze_track, compute_embeddings
+
+# Make app package importable for database access
+sys.path.append(str(Path(__file__).resolve().parents[2] / "api"))
+from app.db import SessionLocal, maybe_create_all
+from app.models import Track, Feature
+
+maybe_create_all()
 
 
 def test_jobs_are_executed():
     """Jobs enqueued on RQ queues should be picked up and executed."""
     connection = fakeredis.FakeRedis()
 
+    with SessionLocal() as db:
+        audio_path = "test_worker.wav"
+        sf.write(audio_path, np.zeros(1024), 22050)
+        tr = Track(title="t", path_local=audio_path)
+        db.add(tr)
+        db.commit()
+        track_id = tr.track_id
+
     analysis_q = Queue("analysis", connection=connection)
     scoring_q = Queue("scoring", connection=connection)
 
-    job1 = analysis_q.enqueue(analyze_track, "42")
+    job1 = analysis_q.enqueue(analyze_track, track_id)
     job2 = scoring_q.enqueue(compute_embeddings, [1.0, 2.0, 3.0])
 
     worker = SimpleWorker([analysis_q, scoring_q], connection=connection)
     worker.work(burst=True)
 
-    assert job1.result == "analysis-complete:42"
+    with SessionLocal() as db:
+        feat = db.get(Feature, job1.result)
+        assert feat and feat.track_id == track_id
+
     assert job2.result == [round(x, 4) for x in [1/3, 2/3, 1.0]]

--- a/services/worker/worker/run.py
+++ b/services/worker/worker/run.py
@@ -14,7 +14,7 @@ def main() -> None:
     redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
     connection = redis.from_url(redis_url)
 
-    queues = ["analysis", "scoring"]
+    queues = ["analysis"]
     with Connection(connection):
         worker = Worker([Queue(name) for name in queues])
         worker.work()


### PR DESCRIPTION
## Summary
- enqueue track analysis jobs onto a Redis-backed `analysis` queue
- add worker job that extracts basic audio features and stores them
- run worker process on the `analysis` queue

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb586d889c83339d42250bcc9b3218