### PR TITLE
Add logistic regression scoring with model versions and confidence

### DIFF
--- a/services/api/app/constants.py
+++ b/services/api/app/constants.py
@@ -2,4 +2,4 @@ AXES = ["energy", "valence", "danceability", "brightness", "pumpiness"]
 
 # default scoring methods
 DEFAULT_METHOD = "zero"  # zero-shot using embeddings
-SUPPORTED_METHODS = {"zero", "super"}
+SUPPORTED_METHODS = {"zero", "logreg"}

--- a/services/api/app/model_data/logreg_v1.json
+++ b/services/api/app/model_data/logreg_v1.json
@@ -1,0 +1,7 @@
+{
+  "energy": {"bias": 0.0, "weights": {"bpm": 0.01, "pumpiness": 0.5, "percussive_harmonic_ratio": 0.2}},
+  "valence": {"bias": -0.1, "weights": {"bpm": 0.0, "pumpiness": 0.3, "percussive_harmonic_ratio": 0.7}},
+  "danceability": {"bias": 0.2, "weights": {"bpm": 0.005, "pumpiness": 0.4, "percussive_harmonic_ratio": 0.1}},
+  "brightness": {"bias": 0.0, "weights": {"bpm": 0.002, "pumpiness": 0.2, "percussive_harmonic_ratio": 0.5}},
+  "pumpiness": {"bias": 0.0, "weights": {"bpm": 0.001, "pumpiness": 1.0, "percussive_harmonic_ratio": 0.3}}
+}


### PR DESCRIPTION
## Summary
- add pluggable scoring interface that loads logistic regression models from disk
- expose model version selection and confidence metrics in `/score/track/{track_id}`
- test zero-shot and logistic regression scoring paths

## Testing
- `pytest services/api/tests/test_scoring.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb5884ba0c83338f25b8ce1d1b5484