### PR TITLE
Add user settings API and integrate UI

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -22,6 +22,7 @@ from .models import (
     UserLabel,
     LastfmTags,
     Feature,
+    UserSettings,
 )
 from .constants import AXES, DEFAULT_METHOD
 from . import scoring
@@ -83,6 +84,16 @@ class ListenIn(BaseModel):
 
 class TrackPathIn(BaseModel):
     path_local: str
+
+
+class SettingsIn(BaseModel):
+    listenBrainzUser: Optional[str] = None
+    listenBrainzToken: Optional[str] = None
+    lastfmUser: Optional[str] = None
+    lastfmApiKey: Optional[str] = None
+    useGpu: bool = False
+    useStems: bool = False
+    useExcerpts: bool = False
 
 
 def _week_start(dt: datetime) -> date:
@@ -211,6 +222,56 @@ def _lastfm_fetch_tags(artist: str, track: str, api_key: str) -> dict:
         if name:
             out[name] = cnt
     return out
+
+
+@app.get("/settings")
+def get_settings(
+    db: Session = Depends(get_db),
+    user_id: str = Depends(get_current_user),
+):
+    row = db.get(UserSettings, user_id)
+    if not row:
+        return {}
+    return {
+        "listenBrainzUser": row.listenbrainz_user,
+        "listenBrainzToken": row.listenbrainz_token,
+        "lastfmUser": row.lastfm_user,
+        "lastfmApiKey": row.lastfm_api_key,
+        "useGpu": row.use_gpu,
+        "useStems": row.use_stems,
+        "useExcerpts": row.use_excerpts,
+    }
+
+
+@app.post("/settings")
+def post_settings(
+    payload: SettingsIn,
+    db: Session = Depends(get_db),
+    user_id: str = Depends(get_current_user),
+):
+    errors = []
+    if bool(payload.listenBrainzUser) ^ bool(payload.listenBrainzToken):
+        errors.append("ListenBrainz user and token required together")
+    if bool(payload.lastfmUser) ^ bool(payload.lastfmApiKey):
+        errors.append("Last.fm user and API key required together")
+    if errors:
+        raise HTTPException(status_code=400, detail=errors)
+
+    row = db.get(UserSettings, user_id)
+    if not row:
+        row = UserSettings(user_id=user_id)
+
+    row.listenbrainz_user = payload.listenBrainzUser
+    row.listenbrainz_token = payload.listenBrainzToken
+    row.lastfm_user = payload.lastfmUser
+    row.lastfm_api_key = payload.lastfmApiKey
+    row.use_gpu = payload.useGpu
+    row.use_stems = payload.useStems
+    row.use_excerpts = payload.useExcerpts
+
+    db.add(row)
+    db.commit()
+    return {"ok": True}
 
 
 @app.get("/health")

--- a/services/api/app/models.py
+++ b/services/api/app/models.py
@@ -163,3 +163,16 @@ class LastfmTags(Base):
     source: Mapped[str] = mapped_column(String(16), default="track")
     tags: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow)
+
+
+class UserSettings(Base):
+    __tablename__ = "user_settings"
+
+    user_id: Mapped[str] = mapped_column(String(128), primary_key=True)
+    listenbrainz_user: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
+    listenbrainz_token: Mapped[Optional[str]] = mapped_column(String(256), nullable=True)
+    lastfm_user: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
+    lastfm_api_key: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
+    use_gpu: Mapped[bool] = mapped_column(Boolean, default=False)
+    use_stems: Mapped[bool] = mapped_column(Boolean, default=False)
+    use_excerpts: Mapped[bool] = mapped_column(Boolean, default=False)

--- a/services/ui/app/api/settings/route.ts
+++ b/services/ui/app/api/settings/route.ts
@@ -1,24 +1,26 @@
 import { NextRequest, NextResponse } from 'next/server';
 
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
+
 export async function GET(req: NextRequest) {
-  const cookie = req.cookies.get('settings');
-  let data = {};
-  if (cookie) {
-    try {
-      data = JSON.parse(cookie.value);
-    } catch {
-      data = {};
-    }
-  }
-  return NextResponse.json(data);
+  const headers: Record<string, string> = {};
+  const uid = req.headers.get('x-user-id');
+  if (uid) headers['X-User-Id'] = uid;
+  const r = await fetch(`${API_BASE}/settings`, { headers });
+  const data = await r.json().catch(() => ({}));
+  return NextResponse.json(data, { status: r.status });
 }
 
 export async function POST(req: NextRequest) {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  const uid = req.headers.get('x-user-id');
+  if (uid) headers['X-User-Id'] = uid;
   const body = await req.json();
-  const res = NextResponse.json({ ok: true });
-  res.cookies.set('settings', JSON.stringify(body), {
-    httpOnly: false,
-    path: '/',
+  const r = await fetch(`${API_BASE}/settings`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
   });
-  return res;
+  const data = await r.json().catch(() => ({}));
+  return NextResponse.json(data, { status: r.status });
 }

--- a/services/ui/app/settings/page.test.tsx
+++ b/services/ui/app/settings/page.test.tsx
@@ -4,7 +4,9 @@ import Settings from './page';
 
 describe('Settings page', () => {
   beforeEach(() => {
-    global.fetch = jest.fn().mockResolvedValue({ json: () => Promise.resolve({}) });
+    global.fetch = jest
+      .fn()
+      .mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
   });
 
   afterEach(() => {
@@ -22,8 +24,14 @@ describe('Settings page', () => {
   });
 
   it('saves settings when valid', async () => {
-    (fetch as jest.Mock).mockResolvedValueOnce({ json: () => Promise.resolve({}) }); // GET
-    (fetch as jest.Mock).mockResolvedValueOnce({ json: () => Promise.resolve({ ok: true }) }); // POST
+    (fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({}),
+    }); // GET
+    (fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ ok: true }),
+    }); // POST
 
     render(<Settings />);
     await userEvent.type(screen.getByPlaceholderText('ListenBrainz username'), 'lbuser');

--- a/services/ui/app/settings/page.tsx
+++ b/services/ui/app/settings/page.tsx
@@ -62,11 +62,21 @@ export default function Settings() {
       useStems,
       useExcerpts,
     };
-    await fetch('/api/settings', {
+    const res = await fetch('/api/settings', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     });
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      const serverErrors = Array.isArray(data.detail)
+        ? data.detail
+        : data.detail
+        ? [data.detail]
+        : ['Error saving settings'];
+      setErrors(serverErrors);
+      return;
+    }
     setMessage('Settings saved');
   }
 


### PR DESCRIPTION
## Summary
- store per-user settings in new `user_settings` table
- expose `/settings` GET/POST endpoints in API
- proxy UI settings API and handle validation errors

## Testing
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb587bde30833390e0413d81cd15b9