### PR TITLE
Use logging in scheduler and worker modules

### DIFF
--- a/services/scheduler/scheduler/run.py
+++ b/services/scheduler/scheduler/run.py
@@ -2,6 +2,10 @@ import os
 import time
 import schedule
 import requests
+import logging
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s:%(message)s")
+logger = logging.getLogger("scheduler")
 
 API = os.getenv("API_URL", "http://api:8000")
 user_id = os.getenv("DEFAULT_USER_ID")
@@ -14,9 +18,9 @@ def ingest_listens():
             timeout=10,
             headers={"X-User-Id": user_id},
         )
-        print("[scheduler] ingest listens:", r.status_code)
-    except Exception as e:
-        print("[scheduler] ingest listens error:", e)
+        logger.info("ingest listens: %s", r.status_code)
+    except Exception:
+        logger.exception("ingest listens error")
 
 
 def sync_lastfm_tags():
@@ -26,9 +30,9 @@ def sync_lastfm_tags():
             timeout=10,
             headers={"X-User-Id": user_id},
         )
-        print("[scheduler] lastfm sync:", r.status_code)
-    except Exception as e:
-        print("[scheduler] lastfm sync error:", e)
+        logger.info("lastfm sync: %s", r.status_code)
+    except Exception:
+        logger.exception("lastfm sync error")
 
 
 def aggregate_weeks():
@@ -38,9 +42,9 @@ def aggregate_weeks():
             timeout=30,
             headers={"X-User-Id": user_id},
         )
-        print("[scheduler] aggregate weeks:", r.status_code)
-    except Exception as e:
-        print("[scheduler] aggregate weeks error:", e)
+        logger.info("aggregate weeks: %s", r.status_code)
+    except Exception:
+        logger.exception("aggregate weeks error")
 
 
 def schedule_jobs():
@@ -54,7 +58,7 @@ def schedule_jobs():
 
 def main():
     schedule_jobs()
-    print("[scheduler] started")
+    logger.info("started")
     while True:
         schedule.run_pending()
         time.sleep(1)

--- a/services/worker/worker/jobs.py
+++ b/services/worker/worker/jobs.py
@@ -7,6 +7,10 @@ from typing import List
 
 import numpy as np
 import librosa
+import logging
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s:%(message)s")
+logger = logging.getLogger("worker")
 
 sys.path.append(str(Path(__file__).resolve().parents[2] / "api"))
 from app.db import SessionLocal  # type: ignore
@@ -62,5 +66,5 @@ def compute_embeddings(data: List[float]) -> List[float]:
     if max_val == 0:
         return [0 for _ in data]
     embeddings = [round(x / max_val, 4) for x in data]
-    print("[worker] computed embeddings")
+    logger.info("computed embeddings")
     return embeddings


### PR DESCRIPTION
## Summary
- replace print statements with `logging` in scheduler and worker
- configure basic logging format and level for these modules

## Testing
- `pytest services/scheduler/test_scheduler.py`
- `pytest services/worker/tests/test_jobs.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb5be2227083338bcea4b8f86c6d86