### PR TITLE
Remove redundant AXES constant in main API module

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -51,9 +51,6 @@ def get_current_user(x_user_id: str = Header(...)) -> str:
     return x_user_id
 
 
-AXES = ["energy", "valence", "danceability", "brightness", "pumpiness"]
-
-
 from rq import Queue
 import redis
 


### PR DESCRIPTION
## Summary
- remove local `AXES` list from `main.py`
- rely on shared `AXES` constant for per-axis scoring and validation

## Testing
- `pytest services/api/tests/test_scoring.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb62b507948333b4bbc30a745e03f9