### PR TITLE
feat(api): share HTTP session for ListenBrainz and MusicBrainz calls

### DIFF
--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -28,6 +28,8 @@ from .models import (
 from .constants import AXES, DEFAULT_METHOD
 from . import scoring
 
+HTTP_SESSION = requests.Session()
+
 app = FastAPI(title="SideTrack API", version="0.1.0")
 app.add_middleware(
     CORSMiddleware,

--- a/services/api/app/routes/listens.py
+++ b/services/api/app/routes/listens.py
@@ -7,7 +7,6 @@ from typing import Dict, List, Optional
 import json
 import os
 
-import requests
 from fastapi import APIRouter, Body, Depends, HTTPException, Query
 from pydantic import BaseModel
 from sqlalchemy import and_, select
@@ -15,7 +14,7 @@ from sqlalchemy.orm import Session
 
 from ..db import get_db
 from ..models import Artist, Listen, Release, Track
-from ..main import get_current_user
+from ..main import get_current_user, HTTP_SESSION
 
 
 router = APIRouter()
@@ -70,7 +69,7 @@ def _lb_fetch_listens(
             datetime.combine(since, datetime.min.time(), tzinfo=timezone.utc).timestamp()
         )
     url = f"{base}/{user}/listens"
-    r = requests.get(url, params=params, timeout=30)
+    r = HTTP_SESSION.get(url, params=params, timeout=30)
     r.raise_for_status()
     data = r.json()
     return data.get("listens", [])

--- a/services/api/app/routes/musicbrainz.py
+++ b/services/api/app/routes/musicbrainz.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import Session
 
 from ..db import get_db
 from ..models import Artist, Release, Track
+from ..main import HTTP_SESSION
 
 
 router = APIRouter()
@@ -48,7 +49,7 @@ def _mb_fetch_release(mbid: str) -> dict:
     url = f"https://musicbrainz.org/ws/2/release/{mbid}"
     params = {"inc": "recordings+artists", "fmt": "json"}
     headers = {"User-Agent": "SideTrack/0.1 (+https://example.com)"}
-    r = requests.get(url, params=params, headers=headers, timeout=30)
+    r = HTTP_SESSION.get(url, params=params, headers=headers, timeout=30)
     r.raise_for_status()
     return r.json()
 

--- a/services/api/tests/test_musicbrainz_ingest.py
+++ b/services/api/tests/test_musicbrainz_ingest.py
@@ -45,7 +45,7 @@ def _setup_app(tmp_path, monkeypatch):
 
     app.dependency_overrides[get_db] = override_get_db
 
-    # mock requests.get
+    # mock HTTP session .get
     def fake_get(url, params=None, headers=None, timeout=30):
         import copy
 
@@ -58,7 +58,7 @@ def _setup_app(tmp_path, monkeypatch):
 
         return Resp()
 
-    monkeypatch.setattr(main_mod.requests, "get", fake_get)
+    monkeypatch.setattr(main_mod.HTTP_SESSION, "get", fake_get)
     monkeypatch.setattr(main_mod.time, "sleep", lambda x: None)
     return app, SessionLocal
 
@@ -100,6 +100,6 @@ def test_ingest_musicbrainz_not_found(mb_client, monkeypatch):
         def json(self):
             return {}
 
-    monkeypatch.setattr(main_mod.requests, "get", lambda *a, **k: Resp())
+    monkeypatch.setattr(main_mod.HTTP_SESSION, "get", lambda *a, **k: Resp())
     resp = client.post("/ingest/musicbrainz", params={"release_mbid": "missing"})
     assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- create module-level HTTP session for API
- reuse shared session in ListenBrainz and MusicBrainz helpers
- adjust MusicBrainz ingestion tests to mock shared session

## Testing
- `pytest services/api/tests/test_musicbrainz_ingest.py -q`
- `pytest services/api/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb637a3c308333b0897959c8415f5f