### PR TITLE
feat(scheduler): add requirements file

### DIFF
--- a/services/scheduler/Dockerfile
+++ b/services/scheduler/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.11-slim
 WORKDIR /app
-RUN pip install --no-cache-dir requests==2.32.3 schedule==1.2.2
+COPY requirements.txt .
+RUN pip install -r requirements.txt
 COPY scheduler ./scheduler
 CMD ["python","-m","scheduler.run"]
 

--- a/services/scheduler/requirements.txt
+++ b/services/scheduler/requirements.txt
@@ -1,0 +1,2 @@
+requests==2.32.3
+schedule==1.2.2


### PR DESCRIPTION
## Summary
- add requirements file for scheduler service
- install dependencies from requirements in scheduler Dockerfile

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fakeredis')*
- `pytest services/scheduler/test_scheduler.py`
- `docker build -t scheduler-test services/scheduler` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6370f06c8333aab82e0006329c82