### PR TITLE
Package API and worker services

### DIFF
--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -10,12 +10,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-# Python deps
-COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
-
-# App code
-COPY app ./app
+COPY . .
+RUN pip install --no-cache-dir .
 
 EXPOSE 8000
 CMD ["uvicorn","app.main:app","--host","0.0.0.0","--port","8000"]

--- a/services/api/app/.gitkeep
+++ b/services/api/app/.gitkeep
@@ -1,1 +1,0 @@
-# Keep this directory in git

--- a/services/api/pyproject.toml
+++ b/services/api/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "sidetrack-api"
+version = "0.1.0"
+dependencies = [
+    "fastapi==0.111.1",
+    "uvicorn[standard]==0.30.1",
+    "pydantic==2.8.2",
+    "pydantic-settings==2.3.4",
+    "python-dotenv==1.0.1",
+    "psycopg[binary]==3.2.1",
+    "SQLAlchemy==2.0.32",
+    "alembic==1.13.2",
+    "requests==2.32.3",
+]
+
+[tool.setuptools]
+packages = ["app"]
+include-package-data = true
+
+[tool.setuptools.package-data]
+"app" = ["model_data/*.json"]

--- a/services/worker/Dockerfile
+++ b/services/worker/Dockerfile
@@ -1,6 +1,11 @@
 FROM python:3.11-slim
 WORKDIR /app
-RUN pip install --no-cache-dir rq==1.16.2 redis==5.0.7
-COPY worker ./worker
+
+COPY services/api /src/api
+RUN pip install --no-cache-dir /src/api
+
+COPY services/worker /src/worker
+RUN pip install --no-cache-dir /src/worker
+
 CMD ["python","-m","worker.run"]
 

--- a/services/worker/pyproject.toml
+++ b/services/worker/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "sidetrack-worker"
+version = "0.1.0"
+dependencies = [
+    "sidetrack-api",
+    "rq==1.16.2",
+    "redis==5.0.7",
+    "librosa",
+    "numpy",
+    "soundfile",
+    "fakeredis",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["worker*"]

--- a/services/worker/tests/test_jobs.py
+++ b/services/worker/tests/test_jobs.py
@@ -1,22 +1,14 @@
 import os
-import sys
-from pathlib import Path
 
 import fakeredis
 import numpy as np
 import soundfile as sf
 from rq import Queue, SimpleWorker
 
-# Configure database before importing app modules
 os.environ.setdefault("DATABASE_URL", "sqlite:///./test_worker.db")
 os.environ.setdefault("AUTO_MIGRATE", "1")
 
-# Make the worker package importable when tests are executed from the repo root
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 from worker.jobs import analyze_track, compute_embeddings
-
-# Make app package importable for database access
-sys.path.append(str(Path(__file__).resolve().parents[2] / "api"))
 from app.db import SessionLocal, maybe_create_all
 from app.models import Track, Feature
 

--- a/services/worker/worker/jobs.py
+++ b/services/worker/worker/jobs.py
@@ -1,20 +1,17 @@
 """Background job implementations for the worker service."""
 from __future__ import annotations
 
-import sys
-from pathlib import Path
 from typing import List
 
-import numpy as np
 import librosa
+import numpy as np
 import logging
+
+from app.db import SessionLocal
+from app.models import Track, Feature
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s:%(message)s")
 logger = logging.getLogger("worker")
-
-sys.path.append(str(Path(__file__).resolve().parents[2] / "api"))
-from app.db import SessionLocal  # type: ignore
-from app.models import Track, Feature  # type: ignore
 
 
 def _basic_features(path: str) -> dict[str, float]:


### PR DESCRIPTION
## Summary
- package api and worker as installable modules
- use standard imports in worker jobs and tests
- install packages in service Dockerfiles

## Testing
- `pytest services/worker/tests/test_jobs.py -q -p no:warnings`


------
https://chatgpt.com/codex/tasks/task_e_68bb682cd3208333971adcec615c1037