### PR TITLE
feat: add lastfm login integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,7 +16,7 @@ MUSICBRAINZ_RATE_LIMIT=1.0
 
 # Last.fm
 LASTFM_API_KEY=lfm_xxx
-LASTFM_USER=your_lastfm_username
+LASTFM_API_SECRET=lfm_secret
 
 # Auth.js (NextAuth) – Google OAuth
 NEXTAUTH_URL=https://your.domain

--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ LISTENBRAINZ_USER=your_user
 LISTENBRAINZ_TOKEN=lb_xxx
 MUSICBRAINZ_RATE_LIMIT=1.0   # req/sec
 
-# Last.fm (for web tag harvesting)
+# Last.fm
 LASTFM_API_KEY=lfm_xxx
-LASTFM_USER=your_lastfm_username
+LASTFM_API_SECRET=lfm_secret
 
 # Auth.js (NextAuth) – Google OAuth
 NEXTAUTH_URL=https://your.domain

--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -19,6 +19,7 @@ class Settings(BaseSettings):
     # Use the Compose service name for Redis by default
     redis_url: str = Field(default="redis://cache:6379/0", env="REDIS_URL")
     lastfm_api_key: str | None = Field(default=None, env="LASTFM_API_KEY")
+    lastfm_api_secret: str | None = Field(default=None, env="LASTFM_API_SECRET")
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 

--- a/services/common/models.py
+++ b/services/common/models.py
@@ -173,7 +173,9 @@ class UserSettings(Base):
     listenbrainz_user: Mapped[str | None] = mapped_column(String(128), nullable=True)
     listenbrainz_token: Mapped[str | None] = mapped_column(String(256), nullable=True)
     lastfm_user: Mapped[str | None] = mapped_column(String(128), nullable=True)
-    lastfm_api_key: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    lastfm_session_key: Mapped[str | None] = mapped_column(
+        "lastfm_api_key", String(128), nullable=True
+    )
     use_gpu: Mapped[bool] = mapped_column(Boolean, default=False)
     use_stems: Mapped[bool] = mapped_column(Boolean, default=False)
     use_excerpts: Mapped[bool] = mapped_column(Boolean, default=False)

--- a/services/ui/app/api/auth/lastfm/login/route.ts
+++ b/services/ui/app/api/auth/lastfm/login/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
+
+export async function GET(req: NextRequest) {
+  const callback = req.nextUrl.searchParams.get('callback') || '';
+  const headers: Record<string, string> = {};
+  const uid = req.headers.get('x-user-id');
+  if (uid) headers['X-User-Id'] = uid;
+  const r = await fetch(`${API_BASE}/auth/lastfm/login?callback=${encodeURIComponent(callback)}`, {
+    headers,
+  });
+  const data = await r.json().catch(() => ({}));
+  return NextResponse.json(data, { status: r.status });
+}

--- a/services/ui/app/api/auth/lastfm/session/route.ts
+++ b/services/ui/app/api/auth/lastfm/session/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
+
+export async function GET(req: NextRequest) {
+  const token = req.nextUrl.searchParams.get('token') || '';
+  const headers: Record<string, string> = {};
+  const uid = req.headers.get('x-user-id');
+  if (uid) headers['X-User-Id'] = uid;
+  const r = await fetch(`${API_BASE}/auth/lastfm/session?token=${encodeURIComponent(token)}`, {
+    headers,
+  });
+  const data = await r.json().catch(() => ({}));
+  return NextResponse.json(data, { status: r.status });
+}
+
+export async function DELETE(req: NextRequest) {
+  const headers: Record<string, string> = {};
+  const uid = req.headers.get('x-user-id');
+  if (uid) headers['X-User-Id'] = uid;
+  const r = await fetch(`${API_BASE}/auth/lastfm/session`, {
+    method: 'DELETE',
+    headers,
+  });
+  const data = await r.json().catch(() => ({}));
+  return NextResponse.json(data, { status: r.status });
+}

--- a/services/ui/app/lastfm/callback/page.tsx
+++ b/services/ui/app/lastfm/callback/page.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
+
+export default function LastfmCallback() {
+  const params = useSearchParams();
+  const router = useRouter();
+
+  useEffect(() => {
+    const token = params.get('token');
+    if (token) {
+      fetch(`/api/auth/lastfm/session?token=${token}`).finally(() => router.replace('/settings'));
+    } else {
+      router.replace('/settings');
+    }
+  }, [params, router]);
+
+  return <p>Connecting to Last.fm...</p>;
+}

--- a/services/ui/app/settings/page.test.tsx
+++ b/services/ui/app/settings/page.test.tsx
@@ -34,8 +34,6 @@ describe('Settings page', () => {
     render(<Settings />);
     await userEvent.type(screen.getByPlaceholderText('ListenBrainz username'), 'lbuser');
     await userEvent.type(screen.getByPlaceholderText('Token'), 'lbtoken');
-    await userEvent.type(screen.getByPlaceholderText('Last.fm username'), 'lfmuser');
-    await userEvent.type(screen.getByPlaceholderText('API key'), 'lfmkey');
     await userEvent.click(screen.getByLabelText('Use GPU'));
     await userEvent.click(screen.getByLabelText('Extract stems'));
     await userEvent.click(screen.getByLabelText('Use excerpts'));
@@ -46,8 +44,6 @@ describe('Settings page', () => {
     expect(body).toEqual({
       listenBrainzUser: 'lbuser',
       listenBrainzToken: 'lbtoken',
-      lastfmUser: 'lfmuser',
-      lastfmApiKey: 'lfmkey',
       useGpu: true,
       useStems: true,
       useExcerpts: true,


### PR DESCRIPTION
## Summary
- support Last.fm login and session storage
- expose Last.fm connect/disconnect flows in UI
- document Last.fm API key and secret in env and README

## Testing
- `pre-commit run --files .env.example README.md services/common/models.py services/api/app/config.py services/api/app/main.py services/ui/app/api/auth/lastfm/login/route.ts services/ui/app/api/auth/lastfm/session/route.ts services/ui/app/lastfm/callback/page.tsx services/ui/app/settings/page.tsx services/ui/app/settings/page.test.tsx`
- `npm test` (in services/ui)
- `pytest services/api/tests` *(fails: OperationalError: no such table: job)*

------
https://chatgpt.com/codex/tasks/task_e_68bb83a2084c8333af694f3bb41a51b4