### PR TITLE
feat: add login and account pages with lastfm connector

### DIFF
--- a/migrations/versions/a1b2c3d4e5f6_add_user_account.py
+++ b/migrations/versions/a1b2c3d4e5f6_add_user_account.py
@@ -1,0 +1,32 @@
+"""add user account table
+
+Revision ID: a1b2c3d4e5f6
+Revises: 4f5b2a1c9d9b
+Create Date: 2025-09-05 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, None] = "4f5b2a1c9d9b"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "user_account",
+        sa.Column("user_id", sa.String(length=128), nullable=False),
+        sa.Column("password_hash", sa.String(length=128), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("user_id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("user_account")

--- a/services/api/app/main.py
+++ b/services/api/app/main.py
@@ -532,8 +532,9 @@ def submit_label(
     }
 
 
-from .routes import dashboard, listens, musicbrainz
+from .routes import auth, dashboard, listens, musicbrainz
 
+app.include_router(auth.router)
 app.include_router(listens.router)
 app.include_router(musicbrainz.router)
 app.include_router(dashboard.router)

--- a/services/api/app/routes/auth.py
+++ b/services/api/app/routes/auth.py
@@ -1,0 +1,58 @@
+"""Authentication and account endpoints."""
+
+from datetime import datetime
+from hashlib import sha256
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from services.common.models import UserAccount, UserSettings
+
+from ..db import get_db
+from ..main import get_current_user
+
+router = APIRouter()
+
+
+class Credentials(BaseModel):
+    username: str
+    password: str
+
+
+@router.post("/auth/register")
+def register(creds: Credentials, db: Session = Depends(get_db)):
+    if db.get(UserAccount, creds.username):
+        raise HTTPException(status_code=400, detail="User already exists")
+    user = UserAccount(
+        user_id=creds.username,
+        password_hash=sha256(creds.password.encode()).hexdigest(),
+        created_at=datetime.utcnow(),
+    )
+    db.add(user)
+    db.commit()
+    return {"user_id": user.user_id}
+
+
+@router.post("/auth/login")
+def login(creds: Credentials, db: Session = Depends(get_db)):
+    user = db.get(UserAccount, creds.username)
+    if not user or user.password_hash != sha256(creds.password.encode()).hexdigest():
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    return {"user_id": user.user_id}
+
+
+@router.get("/auth/me")
+def me(
+    user_id: str = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    user = db.get(UserAccount, user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    settings = db.get(UserSettings, user_id)
+    return {
+        "user_id": user.user_id,
+        "lastfmUser": settings.lastfm_user if settings else None,
+        "lastfmConnected": bool(settings and settings.lastfm_session_key),
+    }

--- a/services/common/models.py
+++ b/services/common/models.py
@@ -179,3 +179,11 @@ class UserSettings(Base):
     use_gpu: Mapped[bool] = mapped_column(Boolean, default=False)
     use_stems: Mapped[bool] = mapped_column(Boolean, default=False)
     use_excerpts: Mapped[bool] = mapped_column(Boolean, default=False)
+
+
+class UserAccount(Base):
+    __tablename__ = "user_account"
+
+    user_id: Mapped[str] = mapped_column(String(128), primary_key=True)
+    password_hash: Mapped[str] = mapped_column(String(128))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow)

--- a/services/ui/app/account/page.tsx
+++ b/services/ui/app/account/page.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export default function AccountPage() {
+  const [user, setUser] = useState('');
+  const [lfmUser, setLfmUser] = useState('');
+  const [lfmConnected, setLfmConnected] = useState(false);
+
+  useEffect(() => {
+    const uid = localStorage.getItem('user_id') || '';
+    if (!uid) return;
+    fetch('/api/auth/me', { headers: { 'X-User-Id': uid } })
+      .then((r) => r.json())
+      .then((data) => {
+        setUser(data.user_id || '');
+        setLfmUser(data.lastfmUser || '');
+        setLfmConnected(!!data.lastfmConnected);
+      })
+      .catch(() => {
+        /* ignore */
+      });
+  }, []);
+
+  async function handleConnect() {
+    const callback = encodeURIComponent(`${window.location.origin}/lastfm/callback`);
+    const uid = localStorage.getItem('user_id') || '';
+    const res = await fetch(`/api/auth/lastfm/login?callback=${callback}`, {
+      headers: { 'X-User-Id': uid },
+    });
+    const data = await res.json().catch(() => ({}));
+    if (data.url) {
+      window.location.href = data.url;
+    }
+  }
+
+  async function handleDisconnect() {
+    const uid = localStorage.getItem('user_id') || '';
+    await fetch('/api/auth/lastfm/session', {
+      method: 'DELETE',
+      headers: { 'X-User-Id': uid },
+    });
+    setLfmConnected(false);
+    setLfmUser('');
+  }
+
+  return (
+    <section className="space-y-6">
+      <h2 className="text-2xl font-bold">Account</h2>
+      <p>Logged in as {user}</p>
+      <div>
+        <h3 className="text-xl font-semibold">Last.fm</h3>
+        {lfmConnected ? (
+          <div className="flex items-center gap-2">
+            <span>Connected as {lfmUser}</span>
+            <button
+              type="button"
+              onClick={handleDisconnect}
+              className="rounded bg-red-500 px-3 py-1 text-white"
+            >
+              Disconnect
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={handleConnect}
+            className="rounded bg-emerald-500 px-3 py-1 text-white"
+          >
+            Connect Last.fm
+          </button>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/services/ui/app/api/auth/login/route.ts
+++ b/services/ui/app/api/auth/login/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const r = await fetch(`${API_BASE}/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const data = await r.json().catch(() => ({}));
+  return NextResponse.json(data, { status: r.status });
+}

--- a/services/ui/app/api/auth/me/route.ts
+++ b/services/ui/app/api/auth/me/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
+
+export async function GET(req: NextRequest) {
+  const headers: Record<string, string> = {};
+  const uid = req.headers.get('x-user-id');
+  if (uid) headers['X-User-Id'] = uid;
+  const r = await fetch(`${API_BASE}/auth/me`, { headers });
+  const data = await r.json().catch(() => ({}));
+  return NextResponse.json(data, { status: r.status });
+}

--- a/services/ui/app/api/auth/register/route.ts
+++ b/services/ui/app/api/auth/register/route.ts
@@ -1,0 +1,14 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const r = await fetch(`${API_BASE}/auth/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const data = await r.json().catch(() => ({}));
+  return NextResponse.json(data, { status: r.status });
+}

--- a/services/ui/app/login/page.tsx
+++ b/services/ui/app/login/page.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { useState, FormEvent } from 'react';
+
+export default function LoginPage() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  async function handleLogin(e: FormEvent) {
+    e.preventDefault();
+    setError('');
+    const res = await fetch('/api/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      if (data.user_id) {
+        localStorage.setItem('user_id', data.user_id);
+        window.location.href = '/account';
+      }
+    } else {
+      setError('Login failed');
+    }
+  }
+
+  async function handleRegister() {
+    setError('');
+    const res = await fetch('/api/auth/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    });
+    if (res.ok) {
+      await handleLogin(new Event('submit') as unknown as FormEvent);
+    } else {
+      setError('Registration failed');
+    }
+  }
+
+  return (
+    <section className="max-w-sm mx-auto mt-20 space-y-4">
+      <h2 className="text-xl font-bold">Login</h2>
+      {error && (
+        <div role="alert" className="text-red-500">
+          {error}
+        </div>
+      )}
+      <form onSubmit={handleLogin} className="space-y-2">
+        <input
+          placeholder="Username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          className="w-full rounded border px-2 py-1 text-black"
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="w-full rounded border px-2 py-1 text-black"
+        />
+        <div className="flex gap-2">
+          <button type="submit" className="rounded bg-emerald-500 px-3 py-1 text-white">
+            Login
+          </button>
+          <button
+            type="button"
+            onClick={handleRegister}
+            className="rounded bg-sky-500 px-3 py-1 text-white"
+          >
+            Register
+          </button>
+        </div>
+      </form>
+    </section>
+  );
+}

--- a/services/ui/components/NavRail.tsx
+++ b/services/ui/components/NavRail.tsx
@@ -1,7 +1,7 @@
 'use client';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Compass, Activity, Radar, Target, Settings, Home } from 'lucide-react';
+import { Compass, Activity, Radar, Target, Settings, Home, User } from 'lucide-react';
 import clsx from 'clsx';
 import { motion } from 'framer-motion';
 
@@ -11,6 +11,7 @@ const nav = [
   { href: '/moods', label: 'Moods', icon: Activity },
   { href: '/radar', label: 'Radar', icon: Radar },
   { href: '/outliers', label: 'Outliers', icon: Target },
+  { href: '/account', label: 'Account', icon: User },
   { href: '/settings', label: 'Settings', icon: Settings },
 ];
 


### PR DESCRIPTION
## Summary
- introduce `UserAccount` model and migration for storing credentials
- add auth API for register/login and expose account info
- create login and account pages with Last.fm connect integration
- extend navigation with new Account link

## Testing
- `pre-commit run --files services/common/models.py migrations/versions/a1b2c3d4e5f6_add_user_account.py services/api/app/routes/auth.py services/api/app/main.py services/ui/components/NavRail.tsx services/ui/app/api/auth/login/route.ts services/ui/app/api/auth/register/route.ts services/ui/app/api/auth/me/route.ts services/ui/app/login/page.tsx services/ui/app/account/page.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68bb87264b688333b28c83f83c5475bc