### PR TITLE
Animate page transitions and sync feedback

### DIFF
--- a/services/ui/app/layout.tsx
+++ b/services/ui/app/layout.tsx
@@ -5,6 +5,7 @@ export const metadata = {
 
 import './globals.css';
 import AppShell from '../components/AppShell';
+import PageTransition from '../components/PageTransition';
 import { ThemeProvider } from 'next-themes';
 import { Inter } from 'next/font/google';
 
@@ -15,7 +16,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en" suppressHydrationWarning>
       <body className={`${inter.variable} font-sans antialiased`}>
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
-          <AppShell>{children}</AppShell>
+          <PageTransition>
+            <AppShell>{children}</AppShell>
+          </PageTransition>
         </ThemeProvider>
       </body>
     </html>

--- a/services/ui/components/AppShell.tsx
+++ b/services/ui/components/AppShell.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import { useState } from 'react';
-import { usePathname } from 'next/navigation';
-import { AnimatePresence, motion } from 'framer-motion';
 import clsx from 'clsx';
 
 import NavRail from '../components/NavRail';
@@ -14,7 +12,6 @@ import { NavContext } from './NavContext';
 
 export default function AppShell({ children }: { children: React.ReactNode }) {
   const [collapsed, setCollapsed] = useState(false);
-  const pathname = usePathname();
   return (
     <ToastProvider>
       <NavContext.Provider value={{ collapsed, setCollapsed }}>
@@ -40,20 +37,9 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
                 </span>
               </div>
             </header>
-            <AnimatePresence mode="wait">
-              <motion.div
-                key={pathname}
-                initial={{ opacity: 0, y: 10 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0, y: -10 }}
-                transition={{ duration: 0.2 }}
-                className="flex-1"
-              >
-                <main className="container mx-auto w-full max-w-6xl px-4 py-6">
-                  {children}
-                </main>
-              </motion.div>
-            </AnimatePresence>
+            <main className="container mx-auto w-full max-w-6xl flex-1 px-4 py-6">
+              {children}
+            </main>
           </div>
         </div>
         <MobileNav />

--- a/services/ui/components/FilterBar.tsx
+++ b/services/ui/components/FilterBar.tsx
@@ -1,4 +1,5 @@
-'use client';
+"use client";
+import { motion } from 'framer-motion';
 import clsx from 'clsx';
 
 type Option = { label: string; value: string };
@@ -11,22 +12,33 @@ type Props = {
 
 export default function FilterBar({ options, value, onChange }: Props) {
   return (
-    <div className="flex flex-wrap items-center gap-2">
-      {options.map((opt) => (
-        <button
-          key={opt.value}
-          type="button"
-          onClick={() => onChange?.(opt.value)}
-          className={clsx(
-            'rounded-full px-3 py-1 text-xs transition-colors',
-            value === opt.value
-              ? 'bg-emerald-500/15 text-emerald-300'
-              : 'bg-white/5 text-muted-foreground hover:text-foreground',
-          )}
-        >
-          {opt.label}
-        </button>
-      ))}
+    <div className="inline-flex items-center gap-1 rounded-full bg-white/5 p-1" role="group">
+      {options.map((opt) => {
+        const active = value === opt.value;
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            aria-pressed={active}
+            onClick={() => onChange?.(opt.value)}
+            className={clsx(
+              'relative rounded-full px-3 py-1 text-xs',
+              active
+                ? 'text-emerald-300'
+                : 'text-muted-foreground hover:text-foreground',
+            )}
+          >
+            {active && (
+              <motion.div
+                layout
+                layoutId="filter-bar-active"
+                className="absolute inset-0 rounded-full bg-emerald-500/15"
+              />
+            )}
+            <span className="relative z-10">{opt.label}</span>
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/services/ui/components/HeaderActions.tsx
+++ b/services/ui/components/HeaderActions.tsx
@@ -1,17 +1,40 @@
-'use client';
+"use client";
+import { useState } from 'react';
+import { motion } from 'framer-motion';
 import { useToast } from './ToastProvider';
 import { Sync } from 'lucide-react';
 
 export default function HeaderActions() {
   const { show } = useToast();
+  const [syncing, setSyncing] = useState(false);
+
+  const handleSync = async () => {
+    setSyncing(true);
+    show({ title: 'Sync started', description: 'Fetching listens…', kind: 'info' });
+    try {
+      await fetch('/api/lastfm/sync', { method: 'POST' });
+      show({ title: 'Sync complete', description: 'Listens updated', kind: 'success' });
+    } catch {
+      show({ title: 'Sync failed', description: 'Please try again later', kind: 'error' });
+    } finally {
+      setSyncing(false);
+    }
+  };
+
   return (
     <button
-      onClick={() =>
-        show({ title: 'Sync started', description: 'Fetching listens…', kind: 'info' })
-      }
-      className="inline-flex items-center gap-2 rounded-full bg-white/5 px-3 py-1 text-xs text-muted-foreground hover:text-foreground"
+      onClick={handleSync}
+      disabled={syncing}
+      className="inline-flex items-center gap-2 rounded-full bg-white/5 px-3 py-1 text-xs text-muted-foreground hover:text-foreground disabled:opacity-50"
     >
-      <Sync size={14} /> Sync
+      <motion.span
+        animate={syncing ? { rotate: 360 } : { rotate: 0 }}
+        transition={{ repeat: syncing ? Infinity : 0, duration: 1, ease: 'linear' }}
+        className="inline-block"
+      >
+        <Sync size={14} />
+      </motion.span>
+      Sync
     </button>
   );
 }

--- a/services/ui/components/PageTransition.tsx
+++ b/services/ui/components/PageTransition.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { AnimatePresence, motion } from 'framer-motion';
+import { usePathname } from 'next/navigation';
+
+export default function PageTransition({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  return (
+    <AnimatePresence mode="wait">
+      <motion.div
+        key={pathname}
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: -10 }}
+        transition={{ duration: 0.2 }}
+      >
+        {children}
+      </motion.div>
+    </AnimatePresence>
+  );
+}


### PR DESCRIPTION
## Summary
- Animate route changes with `AnimatePresence` in root layout
- Add ToggleGroup filter bar with sliding indicator
- Spin sync button and toast completion feedback

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_68bb8fea859483338d81889560af41de