### PR TITLE
feat(ui): add skeleton placeholders and dynamic charts

### DIFF
--- a/services/ui/app/moods/page.tsx
+++ b/services/ui/app/moods/page.tsx
@@ -1,10 +1,18 @@
 'use client';
-import { useEffect, useMemo, useState } from 'react';
+import { Suspense, useEffect, useMemo, useState } from 'react';
+import dynamic from 'next/dynamic';
 import { apiFetch } from '../../lib/api';
-import MoodsStreamgraph from '../../components/charts/MoodsStreamgraph';
 import ChartContainer from '../../components/ChartContainer';
 import FilterBar from '../../components/FilterBar';
-import { Card } from '../../components/ui/card';
+import Skeleton from '../../components/Skeleton';
+
+const MoodsStreamgraph = dynamic(
+  () => import('../../components/charts/MoodsStreamgraph'),
+  {
+    loading: () => <Skeleton className="h-[340px]" />,
+    ssr: false,
+  },
+);
 
 type Trajectory = { points: { week: string }[] };
 
@@ -47,9 +55,13 @@ export default function Moods() {
   }, []);
 
   const content = useMemo(() => {
-    if (loading) return <Card variant="glass" className="h-[340px] w-full" />;
+    if (loading) return <Skeleton className="h-[340px]" />;
     if (!series.length) return <div className="text-sm text-muted-foreground">No data yet.</div>;
-    return <MoodsStreamgraph data={series} axes={axes} />;
+    return (
+      <Suspense fallback={<Skeleton className="h-[340px]" />}>
+        <MoodsStreamgraph data={series} axes={axes} />
+      </Suspense>
+    );
   }, [loading, series, axes]);
 
   return (

--- a/services/ui/app/trajectory/page.tsx
+++ b/services/ui/app/trajectory/page.tsx
@@ -1,6 +1,16 @@
-import TrajectoryClient from '../../components/charts/TrajectoryClient';
+import { Suspense } from 'react';
+import dynamic from 'next/dynamic';
 import ChartContainer from '../../components/ChartContainer';
 import FilterBar from '../../components/FilterBar';
+import Skeleton from '../../components/Skeleton';
+
+const TrajectoryClient = dynamic(
+  () => import('../../components/charts/TrajectoryClient'),
+  {
+    loading: () => <Skeleton className="h-[380px]" />,
+    ssr: false,
+  },
+);
 
 export default async function Trajectory() {
   return (
@@ -20,7 +30,9 @@ export default async function Trajectory() {
         />
       </div>
       <ChartContainer title="Trajectory" subtitle="Recent weekly bubbles and positions">
-        <TrajectoryClient />
+        <Suspense fallback={<Skeleton className="h-[380px]" />}>
+          <TrajectoryClient />
+        </Suspense>
       </ChartContainer>
     </section>
   );

--- a/services/ui/components/Skeleton.tsx
+++ b/services/ui/components/Skeleton.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cn } from '../lib/utils';
+
+export interface SkeletonProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  asChild?: boolean;
+}
+
+const Skeleton = React.forwardRef<HTMLDivElement, SkeletonProps>(
+  ({ className, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'div';
+    return (
+      <Comp
+        ref={ref}
+        className={cn('animate-pulse rounded-lg bg-muted w-full', className)}
+        {...props}
+      />
+    );
+  },
+);
+Skeleton.displayName = 'Skeleton';
+
+export default Skeleton;

--- a/services/ui/components/charts/TrajectoryClient.tsx
+++ b/services/ui/components/charts/TrajectoryClient.tsx
@@ -1,7 +1,15 @@
 'use client';
-import { useEffect, useState } from 'react';
-import TrajectoryBubble, { TrajectoryData } from './TrajectoryBubble';
+import { Suspense, useEffect, useState } from 'react';
+import dynamic from 'next/dynamic';
 import { apiFetch } from '../../lib/api';
+import Skeleton from '../Skeleton';
+
+import type { TrajectoryData } from './TrajectoryBubble';
+
+const TrajectoryBubble = dynamic(() => import('./TrajectoryBubble'), {
+  loading: () => <Skeleton className="h-[380px]" />,
+  ssr: false,
+});
 
 export default function TrajectoryClient() {
   const [data, setData] = useState<TrajectoryData>({ points: [], arrows: [] });
@@ -27,7 +35,11 @@ export default function TrajectoryClient() {
     };
   }, []);
 
-  if (loading) return <div className="h-[380px] w-full rounded-lg glass p-3" />;
+  if (loading) return <Skeleton className="h-[380px]" />;
   if (error) return <div className="text-sm text-rose-400">{error}</div>;
-  return <TrajectoryBubble data={data} />;
+  return (
+    <Suspense fallback={<Skeleton className="h-[380px]" />}>
+      <TrajectoryBubble data={data} />
+    </Suspense>
+  );
 }


### PR DESCRIPTION
## Summary
- add reusable Skeleton component based on Radix Slot and Tailwind animations
- lazy-load chart components with next/dynamic and Suspense fallbacks
- use Skeleton placeholders when chart data is loading

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_68bb90f6e08483338732b92771decae6