### PR TITLE
Enhance chart interactivity with tooltips, legends, and zoom

### DIFF
--- a/services/ui/components/charts/MoodsStreamgraph.tsx
+++ b/services/ui/components/charts/MoodsStreamgraph.tsx
@@ -1,52 +1,129 @@
 'use client';
-import { AreaStack, AreaClosed } from '@visx/shape';
+import { AreaStack } from '@visx/shape';
 import { scaleLinear, scaleTime, scaleOrdinal } from '@visx/scale';
-import { extent } from 'd3-array';
+import { extent, bisector } from 'd3-array';
 import { motion } from 'framer-motion';
+import { useTooltip, TooltipWithBounds } from '@visx/tooltip';
+import { LegendOrdinal } from '@visx/legend';
+import { localPoint } from '@visx/event';
+import useMeasure from 'react-use-measure';
+import { useMemo } from 'react';
 
 type Series = { week: Date; [axis: string]: number | Date };
 
 export default function MoodsStreamgraph({ data, axes }: { data: Series[]; axes: string[] }) {
-  const width = 800;
-  const height = 320;
+  const [ref, bounds] = useMeasure();
+  const width = bounds.width || 800;
+  const height = bounds.height || 320;
   const margin = { top: 10, right: 10, bottom: 20, left: 10 };
-  const xDomain = extent(data, (d) => d.week as Date) as [Date, Date];
-  const xScale = scaleTime({ domain: xDomain, range: [margin.left, width - margin.right] });
-  const yScale = scaleLinear({ domain: [0, 1], range: [height - margin.bottom, margin.top] });
-  const color = scaleOrdinal<string, string>({
-    domain: axes,
-    range: ['#2FE08B', '#39D2FF', '#FFA84D', '#FF7A7A', '#A88BFF'],
-  });
+
+  const xDomain = useMemo(
+    () => extent(data, (d) => d.week as Date) as [Date, Date],
+    [data],
+  );
+  const xScale = useMemo(
+    () => scaleTime({ domain: xDomain, range: [margin.left, width - margin.right] }),
+    [xDomain, width, margin.left, margin.right],
+  );
+  const yScale = useMemo(
+    () => scaleLinear({ domain: [0, 1], range: [height - margin.bottom, margin.top] }),
+    [height, margin.bottom, margin.top],
+  );
+  const color = useMemo(
+    () =>
+      scaleOrdinal<string, string>({
+        domain: axes,
+        range: ['#2FE08B', '#39D2FF', '#FFA84D', '#FF7A7A', '#A88BFF'],
+      }),
+    [axes],
+  );
+
+  const { tooltipData, tooltipLeft, tooltipTop, showTooltip, hideTooltip } =
+    useTooltip<Series>();
+
+  const dateBisect = useMemo(
+    () => bisector<Series, Date>((d) => d.week as Date).left,
+    [],
+  );
+
+  const handleMouseMove = (event: React.MouseEvent<SVGRectElement>) => {
+    const point = localPoint(event);
+    if (!point) return;
+    const x0 = xScale.invert(point.x);
+    const index = dateBisect(data, x0, 1);
+    const d0 = data[index - 1];
+    const d1 = data[index];
+    let d = d0;
+    if (d1 && +x0 - +(d0.week as Date) > +(d1.week as Date) - +x0) {
+      d = d1;
+    }
+    showTooltip({
+      tooltipData: d,
+      tooltipLeft: xScale(d.week as Date),
+      tooltipTop: margin.top,
+    });
+  };
 
   return (
-    <motion.div
-      initial={{ opacity: 0, y: 8 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.4 }}
-    >
-      <svg width="100%" viewBox={`0 0 ${width} ${height}`} className="glass rounded-lg">
-        <AreaStack
-          keys={axes}
-          data={data}
-          x={(d) => xScale(d.week as Date) ?? 0}
-          y0={() => 0}
-          y1={(d) => yScale(d as number)}
-        >
-          {({ stacks, path }) =>
-            stacks.map((stack) => (
-              <AreaClosed
-                key={stack.key}
-                data={stack}
-                d={(d) => path(d) || ''}
-                fill={color(stack.key) ?? '#2FE08B'}
-                fillOpacity={0.35}
-                stroke={color(stack.key) ?? '#2FE08B'}
-                strokeWidth={1}
-              />
-            ))
-          }
-        </AreaStack>
-      </svg>
-    </motion.div>
+    <div ref={ref} className="relative w-full h-[320px]">
+      <motion.div
+        initial={{ opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
+      >
+        <svg width={width} height={height} className="glass rounded-lg">
+          <AreaStack
+            keys={axes}
+            data={data}
+            x={(d) => xScale(d.week as Date) ?? 0}
+            y0={() => 0}
+            y1={(d) => yScale(d as number)}
+          >
+            {({ stacks, path }) =>
+              stacks.map((stack) => {
+                const d = path(stack) || '';
+                return (
+                  <motion.path
+                    key={stack.key}
+                    d={d}
+                    fill={color(stack.key) ?? '#2FE08B'}
+                    fillOpacity={0.35}
+                    stroke={color(stack.key) ?? '#2FE08B'}
+                    strokeWidth={1}
+                    initial={{ d }}
+                    animate={{ d }}
+                    transition={{ duration: 0.5 }}
+                  />
+                );
+              })
+            }
+          </AreaStack>
+          <rect
+            width={width}
+            height={height}
+            fill="transparent"
+            onMouseMove={handleMouseMove}
+            onMouseLeave={hideTooltip}
+          />
+        </svg>
+        <div className="mt-2 flex justify-center">
+          <LegendOrdinal scale={color} direction="row" labelMargin="0 12px 0 0" />
+        </div>
+        {tooltipData && (
+          <TooltipWithBounds
+            left={tooltipLeft}
+            top={tooltipTop}
+            className="rounded-md bg-black/80 p-2 text-xs text-white"
+          >
+            <div className="font-medium">{(tooltipData.week as Date).toLocaleDateString()}</div>
+            {axes.map((axis) => (
+              <div key={axis} style={{ color: color(axis) }}>
+                {axis}: {(tooltipData[axis] as number).toFixed(2)}
+              </div>
+            ))}
+          </TooltipWithBounds>
+        )}
+      </motion.div>
+    </div>
   );
 }

--- a/services/ui/components/charts/TrajectoryBubble.tsx
+++ b/services/ui/components/charts/TrajectoryBubble.tsx
@@ -1,63 +1,178 @@
 'use client';
-import { XYChart, Tooltip, AnimatedAxis, AnimatedGrid, AnimatedScatterSeries } from '@visx/xychart';
+import { scaleLinear, scaleOrdinal } from '@visx/scale';
+import { AxisBottom, AxisLeft } from '@visx/axis';
+import { GridColumns, GridRows } from '@visx/grid';
+import { Group } from '@visx/group';
+import { Zoom } from '@visx/zoom';
+import { localPoint } from '@visx/event';
+import { useTooltip, TooltipWithBounds } from '@visx/tooltip';
+import useMeasure from 'react-use-measure';
 import { motion } from 'framer-motion';
+import { useMemo, useState } from 'react';
+import { LegendOrdinal } from '@visx/legend';
 
 type Point = { week: string; x: number; y: number; r?: number };
 type Arrow = { from: Point; to: Point };
 
 export type TrajectoryData = { points: Point[]; arrows: Arrow[] };
 
-const accessors = {
-  xAccessor: (d: Point) => d.x,
-  yAccessor: (d: Point) => d.y,
-};
-
 export default function TrajectoryBubble({ data }: { data: TrajectoryData }) {
-  const points = data.points ?? [];
-  const series = [{ id: 'weeks', data: points }];
+  const { points = [], arrows = [] } = data;
+  const [ref, bounds] = useMeasure();
+  const width = bounds.width || 800;
+  const height = bounds.height || 340;
+  const margin = { top: 10, right: 10, bottom: 40, left: 40 };
+  const innerWidth = width - margin.left - margin.right;
+  const innerHeight = height - margin.top - margin.bottom;
+  const color = '#2FE08B';
+
+  const xScale = useMemo(
+    () => scaleLinear<number>({ domain: [0, 1], range: [0, innerWidth] }),
+    [innerWidth],
+  );
+  const yScale = useMemo(
+    () => scaleLinear<number>({ domain: [0, 1], range: [innerHeight, 0] }),
+    [innerHeight],
+  );
+
+  const { tooltipData, tooltipLeft, tooltipTop, showTooltip, hideTooltip } =
+    useTooltip<Point>();
+  const [highlight, setHighlight] = useState<number | null>(null);
+
   return (
-    <motion.div
-      initial={{ opacity: 0, y: 8 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.4 }}
-    >
-      <div className="h-[380px] w-full rounded-lg glass p-3">
-        <XYChart
-          height={340}
-          xScale={{ type: 'linear', domain: [0, 1] }}
-          yScale={{ type: 'linear', domain: [0, 1] }}
+    <div ref={ref} className="relative w-full h-[380px]">
+      <motion.div
+        initial={{ opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
+      >
+        <Zoom<SVGSVGElement>
+          width={innerWidth}
+          height={innerHeight}
+          scaleXMin={0.5}
+          scaleXMax={4}
+          scaleYMin={0.5}
+          scaleYMax={4}
         >
-          <AnimatedGrid rows columns numTicks={4} />
-          <AnimatedAxis orientation="bottom" numTicks={4} />
-          <AnimatedAxis orientation="left" numTicks={4} />
-          <AnimatedScatterSeries
-            key="weeks"
-            dataKey="weeks"
-            data={series[0].data}
-            xAccessor={accessors.xAccessor}
-            yAccessor={accessors.yAccessor}
-            sizeAccessor={(d) => (d.r ? d.r : 40)}
-            colorAccessor={() => '#2FE08B'}
+          {(zoom) => (
+            <svg width={width} height={height} className="glass rounded-lg">
+              <rect
+                width={width}
+                height={height}
+                fill="transparent"
+                onMouseDown={zoom.dragStart}
+                onMouseMove={zoom.dragMove}
+                onMouseUp={zoom.dragEnd}
+                onMouseLeave={() => {
+                  zoom.dragEnd();
+                  hideTooltip();
+                  setHighlight(null);
+                }}
+                onWheel={zoom.handleWheel}
+              />
+              <Group left={margin.left} top={margin.top}>
+                <GridColumns
+                  scale={zoom.applyToScale(xScale)}
+                  height={innerHeight}
+                  stroke="#e0e0e0"
+                />
+                <GridRows
+                  scale={zoom.applyToScale(yScale)}
+                  width={innerWidth}
+                  stroke="#e0e0e0"
+                />
+                <AxisBottom
+                  top={innerHeight}
+                  scale={zoom.applyToScale(xScale)}
+                  numTicks={4}
+                />
+                <AxisLeft scale={zoom.applyToScale(yScale)} numTicks={4} />
+                <Group transform={zoom.toString()}>
+                  {arrows.map((a, i) => (
+                    <motion.line
+                      key={i}
+                      x1={xScale(a.from.x)}
+                      y1={yScale(a.from.y)}
+                      x2={xScale(a.to.x)}
+                      y2={yScale(a.to.y)}
+                      stroke="#999"
+                      strokeWidth={1}
+                      markerEnd="url(#arrow)"
+                      initial={{ x2: xScale(a.from.x), y2: yScale(a.from.y) }}
+                      animate={{ x2: xScale(a.to.x), y2: yScale(a.to.y) }}
+                      transition={{ duration: 0.5 }}
+                    />
+                  ))}
+                  {points.map((p, i) => (
+                    <motion.circle
+                      key={i}
+                      cx={xScale(p.x)}
+                      cy={yScale(p.y)}
+                      r={highlight === i ? (p.r ? p.r : 8) * 1.3 : p.r ? p.r : 8}
+                      fill={highlight === i ? '#FF7A7A' : color}
+                      onMouseMove={(event) => {
+                        const point = localPoint(event);
+                        if (!point) return;
+                        const inverted = zoom.applyInverseToPoint({
+                          x: point.x,
+                          y: point.y,
+                        });
+                        showTooltip({
+                          tooltipData: p,
+                          tooltipLeft: inverted.x + margin.left,
+                          tooltipTop: inverted.y + margin.top,
+                        });
+                        setHighlight(i);
+                      }}
+                      onMouseLeave={() => {
+                        hideTooltip();
+                        setHighlight(null);
+                      }}
+                      initial={{ cx: xScale(p.x), cy: yScale(p.y), r: 0 }}
+                      animate={{ cx: xScale(p.x), cy: yScale(p.y), r: p.r ? p.r : 8 }}
+                      transition={{ duration: 0.5 }}
+                    />
+                  ))}
+                </Group>
+                <defs>
+                  <marker
+                    id="arrow"
+                    viewBox="0 0 10 10"
+                    refX="5"
+                    refY="5"
+                    markerWidth="6"
+                    markerHeight="6"
+                    orient="auto-start-reverse"
+                  >
+                    <path d="M0 0L10 5L0 10z" fill="#999" />
+                  </marker>
+                </defs>
+              </Group>
+            </svg>
+          )}
+        </Zoom>
+        <div className="mt-2 flex justify-center">
+          <LegendOrdinal
+            scale={scaleOrdinal<string, string>({
+              domain: ['Trajectory'],
+              range: [color],
+            })}
+            direction="row"
           />
-          <Tooltip<Point>
-            snapTooltipToDatumX
-            snapTooltipToDatumY
-            showVerticalCrosshair
-            showHorizontalCrosshair
-            renderTooltip={({ tooltipData }) => {
-              const d = tooltipData?.nearestDatum?.datum as Point | undefined;
-              if (!d) return null;
-              return (
-                <div className="rounded-md bg-black/80 p-2 text-xs text-white">
-                  <div className="font-medium">Week {d.week}</div>
-                  <div>x: {d.x.toFixed(3)}</div>
-                  <div>y: {d.y.toFixed(3)}</div>
-                </div>
-              );
-            }}
-          />
-        </XYChart>
-      </div>
-    </motion.div>
+        </div>
+        {tooltipData && (
+          <TooltipWithBounds
+            left={tooltipLeft}
+            top={tooltipTop}
+            className="rounded-md bg-black/80 p-2 text-xs text-white"
+          >
+            <div className="font-medium">Week {tooltipData.week}</div>
+            <div>x: {tooltipData.x.toFixed(3)}</div>
+            <div>y: {tooltipData.y.toFixed(3)}</div>
+          </TooltipWithBounds>
+        )}
+      </motion.div>
+    </div>
   );
 }
+

--- a/services/ui/package-lock.json
+++ b/services/ui/package-lock.json
@@ -13,6 +13,7 @@
         "@tanstack/react-query": "^5.87.1",
         "@visx/axis": "3.3.0",
         "@visx/grid": "3.3.0",
+        "@visx/legend": "^3.12.0",
         "@visx/shape": "3.3.0",
         "@visx/tooltip": "3.3.0",
         "@visx/xychart": "3.10.1",
@@ -26,7 +27,8 @@
         "next": "14.2.5",
         "next-themes": "^0.2.1",
         "react": "18.3.1",
-        "react-dom": "18.3.1"
+        "react-dom": "18.3.1",
+        "react-use-measure": "^2.1.7"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "6.4.2",
@@ -2928,6 +2930,84 @@
       },
       "peerDependencies": {
         "react": "^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0"
+      }
+    },
+    "node_modules/@visx/legend": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@visx/legend/-/legend-3.12.0.tgz",
+      "integrity": "sha512-Tr6hdauEDXRXVNeNgIQ9JtCCrxn8Fbr8UCVlO9XsSxenk2hBC/2PIY5QPzpnKFEEEuH/C8vhj8T0JfFZV+D9zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*",
+        "@visx/group": "3.12.0",
+        "@visx/scale": "3.12.0",
+        "classnames": "^2.3.1",
+        "prop-types": "^15.5.10"
+      },
+      "peerDependencies": {
+        "react": "^16.3.0-0 || ^17.0.0-0 || ^18.0.0-0"
+      }
+    },
+    "node_modules/@visx/legend/node_modules/@visx/group": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@visx/group/-/group-3.12.0.tgz",
+      "integrity": "sha512-Dye8iS1alVXPv7nj/7M37gJe6sSKqJLH7x6sEWAsRQ9clI0kFvjbKcKgF+U3aAVQr0NCohheFV+DtR8trfK/Ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*",
+        "classnames": "^2.3.1",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0-0 || ^17.0.0-0 || ^18.0.0-0"
+      }
+    },
+    "node_modules/@visx/legend/node_modules/@visx/scale": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@visx/scale/-/scale-3.12.0.tgz",
+      "integrity": "sha512-+ubijrZ2AwWCsNey0HGLJ0YKNeC/XImEFsr9rM+Uef1CM3PNM43NDdNTrdBejSlzRq0lcfQPWYMYQFSlkLcPOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@visx/vendor": "3.12.0"
+      }
+    },
+    "node_modules/@visx/legend/node_modules/@visx/vendor": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@visx/vendor/-/vendor-3.12.0.tgz",
+      "integrity": "sha512-SVO+G0xtnL9dsNpGDcjCgoiCnlB3iLSM9KLz1sLbSrV7RaVXwY3/BTm2X9OWN1jH2a9M+eHt6DJ6sE6CXm4cUg==",
+      "license": "MIT and ISC",
+      "dependencies": {
+        "@types/d3-array": "3.0.3",
+        "@types/d3-color": "3.1.0",
+        "@types/d3-delaunay": "6.0.1",
+        "@types/d3-format": "3.0.1",
+        "@types/d3-geo": "3.1.0",
+        "@types/d3-interpolate": "3.0.1",
+        "@types/d3-scale": "4.0.2",
+        "@types/d3-time": "3.0.0",
+        "@types/d3-time-format": "2.1.0",
+        "d3-array": "3.2.1",
+        "d3-color": "3.1.0",
+        "d3-delaunay": "6.0.2",
+        "d3-format": "3.1.0",
+        "d3-geo": "3.1.0",
+        "d3-interpolate": "3.0.1",
+        "d3-scale": "4.0.2",
+        "d3-time": "3.1.0",
+        "d3-time-format": "4.1.0",
+        "internmap": "2.0.3"
+      }
+    },
+    "node_modules/@visx/legend/node_modules/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-gUY/qeHq/yNqqoCKNq4vtpFLdoCdvyNpWoC/KNjhGbhDuQpAM9sIQQKkXSNpXa9h5KySs/gzm7R88WkUutgwWQ==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@visx/point": {

--- a/services/ui/package.json
+++ b/services/ui/package.json
@@ -15,6 +15,7 @@
     "@tanstack/react-query": "^5.87.1",
     "@visx/axis": "3.3.0",
     "@visx/grid": "3.3.0",
+    "@visx/legend": "^3.12.0",
     "@visx/shape": "3.3.0",
     "@visx/tooltip": "3.3.0",
     "@visx/xychart": "3.10.1",
@@ -28,7 +29,8 @@
     "next": "14.2.5",
     "next-themes": "^0.2.1",
     "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react-dom": "18.3.1",
+    "react-use-measure": "^2.1.7"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "6.4.2",

--- a/services/ui/tsconfig.json
+++ b/services/ui/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
@@ -13,8 +17,20 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "plugins": [{ "name": "next" }]
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "esModuleInterop": true
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary
- Add responsive `react-use-measure` containers and animated transitions for mood streamgraph with tooltips and legend.
- Replace bubble trajectory chart with zoomable, pannable scatter plot featuring tooltips, point highlighting, and legend.
- Install `@visx/legend` and `react-use-measure` dependencies for new visual interactions.

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_68bb92de01ec8333bc8f27a497dd0087