### PR TITLE
feat(ui): add avatar component and dynamic icons

### DIFF
--- a/services/ui/app/page.tsx
+++ b/services/ui/app/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { motion } from 'framer-motion';
 import ChartContainer from '../components/ChartContainer';
 import FilterBar from '../components/FilterBar';
+import Avatar from '../components/ui/Avatar';
 
 export default function Home() {
   return (
@@ -103,7 +104,7 @@ export default function Home() {
                   transition={{ duration: 0.3, delay: 0.05 * i }}
                   whileHover={{ scale: 1.01 }}
                 >
-                  <div className="h-8 w-8 rounded-full bg-gradient-to-br from-emerald-400 to-sky-400" />
+                  <Avatar size={32} />
                   <div className="flex-1">
                     <div className="text-sm">Track {i}</div>
                     <div className="text-xs text-muted-foreground">Artist</div>

--- a/services/ui/components/AppShell.tsx
+++ b/services/ui/components/AppShell.tsx
@@ -9,6 +9,7 @@ import ToastProvider from './ToastProvider';
 import HeaderActions from './HeaderActions';
 import MobileNav from './MobileNav';
 import { NavContext } from './NavContext';
+import Avatar from './ui/Avatar';
 
 export default function AppShell({ children }: { children: React.ReactNode }) {
   const [collapsed, setCollapsed] = useState(false);
@@ -33,7 +34,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
           <div className="flex min-h-dvh flex-1 flex-col">
             <header className="sticky top-0 z-10 glass flex items-center justify-between px-4 py-3">
               <div className="flex items-center gap-2">
-                <div className="hidden h-8 w-8 rounded-full bg-gradient-to-br from-emerald-400 to-sky-400 md:block" />
+                <Avatar size={32} className="hidden md:block" />
                 <span className="text-sm text-muted-foreground">Your taste dashboard</span>
               </div>
               <div className="flex items-center gap-3 text-sm text-muted-foreground">

--- a/services/ui/components/HeaderActions.tsx
+++ b/services/ui/components/HeaderActions.tsx
@@ -2,7 +2,9 @@
 import { useState } from 'react';
 import { motion } from 'framer-motion';
 import { useToast } from './ToastProvider';
-import { Sync } from 'lucide-react';
+import dynamic from 'next/dynamic';
+
+const Sync = dynamic(() => import('lucide-react/lib/esm/icons/sync'));
 
 export default function HeaderActions() {
   const toast = useToast();

--- a/services/ui/components/NavRail.tsx
+++ b/services/ui/components/NavRail.tsx
@@ -1,21 +1,22 @@
 'use client';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import {
-  Compass,
-  Activity,
-  Radar,
-  Target,
-  Settings,
-  Home,
-  User,
-  ChevronLeft,
-  ChevronRight,
-} from 'lucide-react';
+import dynamic from 'next/dynamic';
 import clsx from 'clsx';
 import { motion } from 'framer-motion';
 import * as Tooltip from '@radix-ui/react-tooltip';
 import { useNav } from './NavContext';
+import Avatar from './ui/Avatar';
+
+const Home = dynamic(() => import('lucide-react/lib/esm/icons/home'));
+const Compass = dynamic(() => import('lucide-react/lib/esm/icons/compass'));
+const Activity = dynamic(() => import('lucide-react/lib/esm/icons/activity'));
+const Radar = dynamic(() => import('lucide-react/lib/esm/icons/radar'));
+const Target = dynamic(() => import('lucide-react/lib/esm/icons/target'));
+const Settings = dynamic(() => import('lucide-react/lib/esm/icons/settings'));
+const User = dynamic(() => import('lucide-react/lib/esm/icons/user'));
+const ChevronLeft = dynamic(() => import('lucide-react/lib/esm/icons/chevron-left'));
+const ChevronRight = dynamic(() => import('lucide-react/lib/esm/icons/chevron-right'));
 
 export const nav = [
   { href: '/', label: 'Overview', icon: Home },
@@ -33,7 +34,7 @@ export default function NavRail() {
   return (
     <div className="flex h-full flex-col gap-2 p-3 glass">
       <div className="flex items-center gap-2 px-2 py-3">
-        <div className="h-8 w-8 rounded-full bg-gradient-to-br from-emerald-400 to-sky-400" />
+        <Avatar size={32} />
         {!collapsed && <strong className="text-lg">SideTrack</strong>}
       </div>
       <Tooltip.Provider>

--- a/services/ui/components/ui/Avatar.tsx
+++ b/services/ui/components/ui/Avatar.tsx
@@ -1,0 +1,28 @@
+import Image from 'next/image';
+import type { HTMLAttributes } from 'react';
+import dynamic from 'next/dynamic';
+import { cn } from '../../lib/utils';
+
+const UserIcon = dynamic(() => import('lucide-react/lib/esm/icons/user'));
+
+export interface AvatarProps extends HTMLAttributes<HTMLDivElement> {
+  src?: string;
+  alt?: string;
+  size?: number;
+}
+
+export default function Avatar({ src, alt = 'avatar', size = 32, className, ...props }: AvatarProps) {
+  return (
+    <div
+      className={cn('flex items-center justify-center overflow-hidden rounded-full bg-white/5', className)}
+      style={{ width: size, height: size }}
+      {...props}
+    >
+      {src ? (
+        <Image src={src} alt={alt} width={size} height={size} className="h-full w-full object-cover" />
+      ) : (
+        <UserIcon className="h-2/3 w-2/3 text-muted-foreground" />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add generic Avatar component for user/track images
- replace gradient placeholders with Avatar
- switch lucide-react icons to dynamic imports

## Testing
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/eslint-plugin')*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb97a0bbf08333934d773c56c2e8ad