### PR TITLE
feat(ui): add spacing scale and responsive charts

### DIFF
--- a/services/ui/app/globals.css
+++ b/services/ui/app/globals.css
@@ -34,6 +34,13 @@
   --light-accent: 196 100% 62%;
   --light-accent-foreground: 222 14% 12%;
   --light-ring: 196 100% 62%;
+
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
 }
 
 .light {

--- a/services/ui/app/moods/page.tsx
+++ b/services/ui/app/moods/page.tsx
@@ -10,7 +10,9 @@ import Skeleton from '../../components/Skeleton';
 const MoodsStreamgraph = dynamic(
   () => import('../../components/charts/MoodsStreamgraph'),
   {
-    loading: () => <Skeleton className="h-[340px]" />,
+    loading: () => (
+      <Skeleton className="aspect-[4/3] h-[clamp(240px,40vh,340px)]" />
+    ),
     ssr: false,
   },
 );
@@ -56,10 +58,15 @@ export default function Moods() {
   const loading = trajLoading || radarLoading;
 
   const content = useMemo(() => {
-    if (loading) return <Skeleton className="h-[340px]" />;
+    if (loading)
+      return <Skeleton className="aspect-[4/3] h-[clamp(240px,40vh,340px)]" />;
     if (!series.length) return <div className="text-sm text-muted-foreground">No data yet.</div>;
     return (
-      <Suspense fallback={<Skeleton className="h-[340px]" />}>
+      <Suspense
+        fallback={
+          <Skeleton className="aspect-[4/3] h-[clamp(240px,40vh,340px)]" />
+        }
+      >
         <MoodsStreamgraph data={series} axes={axes} />
       </Suspense>
     );

--- a/services/ui/app/page.tsx
+++ b/services/ui/app/page.tsx
@@ -8,7 +8,7 @@ import Avatar from '../components/ui/Avatar';
 
 export default function Home() {
   return (
-    <section className="space-y-6">
+    <section className="@container space-y-6">
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-semibold">Overview</h1>
@@ -22,7 +22,7 @@ export default function Home() {
         </Link>
       </div>
 
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="grid gap-4 @[640px]:grid-cols-2 @[1024px]:grid-cols-4">
         {[
           <MetricCard
             key="m1"
@@ -55,7 +55,7 @@ export default function Home() {
           value="12w"
         />
       </div>
-      <div className="grid gap-6 lg:grid-cols-2">
+      <div className="grid gap-6 @[768px]:grid-cols-2">
         <motion.div
           initial={{ opacity: 0, y: 8 }}
           whileInView={{ opacity: 1, y: 0 }}

--- a/services/ui/app/trajectory/page.tsx
+++ b/services/ui/app/trajectory/page.tsx
@@ -7,7 +7,9 @@ import Skeleton from '../../components/Skeleton';
 const TrajectoryClient = dynamic(
   () => import('../../components/charts/TrajectoryClient'),
   {
-    loading: () => <Skeleton className="h-[380px]" />,
+    loading: () => (
+      <Skeleton className="aspect-[4/3] h-[clamp(240px,40vh,380px)]" />
+    ),
     ssr: false,
   },
 );
@@ -30,7 +32,11 @@ export default async function Trajectory() {
         />
       </div>
       <ChartContainer title="Trajectory" subtitle="Recent weekly bubbles and positions">
-        <Suspense fallback={<Skeleton className="h-[380px]" />}>
+        <Suspense
+          fallback={
+            <Skeleton className="aspect-[4/3] h-[clamp(240px,40vh,380px)]" />
+          }
+        >
           <TrajectoryClient />
         </Suspense>
       </ChartContainer>

--- a/services/ui/components/ChartContainer.tsx
+++ b/services/ui/components/ChartContainer.tsx
@@ -10,7 +10,7 @@ type Props = {
 
 export default function ChartContainer({ title, subtitle, actions, children }: Props) {
   return (
-    <Card asChild variant="glass" className="p-md">
+    <Card asChild variant="glass" className="p-4">
       <section>
         <div className="mb-3 flex items-center justify-between gap-4">
           <div>
@@ -19,7 +19,7 @@ export default function ChartContainer({ title, subtitle, actions, children }: P
           </div>
           {actions && <div className="flex items-center gap-2">{actions}</div>}
         </div>
-        <div className="min-h-[160px]">{children}</div>
+        <div className="min-h-[clamp(120px,25vh,160px)]">{children}</div>
       </section>
     </Card>
   );

--- a/services/ui/components/MetricCard.tsx
+++ b/services/ui/components/MetricCard.tsx
@@ -15,7 +15,7 @@ export default function MetricCard({ title, value, delta }: Props) {
       : undefined;
   const deltaClass = delta && delta.value >= 0 ? 'text-emerald-400' : 'text-rose-400';
   return (
-    <Card asChild variant="glass" className="p-md shadow-soft">
+    <Card asChild variant="glass" className="p-4 shadow-soft">
       <motion.div
         initial={{ opacity: 0, y: 8 }}
         animate={{ opacity: 1, y: 0 }}

--- a/services/ui/components/charts/MoodsStreamgraph.tsx
+++ b/services/ui/components/charts/MoodsStreamgraph.tsx
@@ -65,7 +65,10 @@ export default function MoodsStreamgraph({ data, axes }: { data: Series[]; axes:
   };
 
   return (
-    <div ref={ref} className="relative w-full h-[320px]">
+    <div
+      ref={ref}
+      className="relative w-full aspect-[4/3] h-[clamp(240px,40vh,320px)]"
+    >
       <motion.div
         initial={{ opacity: 0, y: 8 }}
         animate={{ opacity: 1, y: 0 }}

--- a/services/ui/components/charts/TrajectoryBubble.tsx
+++ b/services/ui/components/charts/TrajectoryBubble.tsx
@@ -40,7 +40,10 @@ export default function TrajectoryBubble({ data }: { data: TrajectoryData }) {
   const [highlight, setHighlight] = useState<number | null>(null);
 
   return (
-    <div ref={ref} className="relative w-full h-[380px]">
+    <div
+      ref={ref}
+      className="relative w-full aspect-[4/3] h-[clamp(240px,40vh,380px)]"
+    >
       <motion.div
         initial={{ opacity: 0, y: 8 }}
         animate={{ opacity: 1, y: 0 }}

--- a/services/ui/components/charts/TrajectoryClient.tsx
+++ b/services/ui/components/charts/TrajectoryClient.tsx
@@ -5,18 +5,25 @@ import Skeleton from '../Skeleton';
 import { useTrajectory } from '../../lib/query';
 
 const TrajectoryBubble = dynamic(() => import('./TrajectoryBubble'), {
-  loading: () => <Skeleton className="h-[380px]" />,
+  loading: () => (
+    <Skeleton className="aspect-[4/3] h-[clamp(240px,40vh,380px)]" />
+  ),
   ssr: false,
 });
 
 export default function TrajectoryClient() {
   const { data, isLoading, isError } = useTrajectory();
 
-  if (isLoading) return <Skeleton className="h-[380px]" />;
+  if (isLoading)
+    return <Skeleton className="aspect-[4/3] h-[clamp(240px,40vh,380px)]" />;
   if (isError || !data)
     return <div className="text-sm text-rose-400">Failed to load trajectory</div>;
   return (
-    <Suspense fallback={<Skeleton className="h-[380px]" />}>
+    <Suspense
+      fallback={
+        <Skeleton className="aspect-[4/3] h-[clamp(240px,40vh,380px)]" />
+      }
+    >
       <TrajectoryBubble data={data} />
     </Suspense>
   );

--- a/services/ui/components/ui/button.tsx
+++ b/services/ui/components/ui/button.tsx
@@ -13,9 +13,9 @@ const buttonVariants = cva(
         ghost: 'hover:bg-accent hover:text-accent-foreground',
       },
       size: {
-        sm: 'h-8 px-sm',
-        md: 'h-10 px-md',
-        lg: 'h-12 px-lg',
+        sm: 'h-8 px-2',
+        md: 'h-10 px-4',
+        lg: 'h-12 px-6',
       },
     },
     defaultVariants: {

--- a/services/ui/components/ui/dialog.tsx
+++ b/services/ui/components/ui/dialog.tsx
@@ -14,7 +14,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border border-border bg-background p-lg shadow-lg',
+        'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border border-border bg-background p-6 shadow-lg',
         className,
       )}
       {...props}

--- a/services/ui/components/ui/input.tsx
+++ b/services/ui/components/ui/input.tsx
@@ -7,7 +7,7 @@ const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLI
       <input
         type={type}
         className={cn(
-          'flex h-10 w-full rounded-md border border-input bg-background px-md py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+          'flex h-10 w-full rounded-md border border-input bg-background px-4 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
           className,
         )}
         ref={ref}

--- a/services/ui/package-lock.json
+++ b/services/ui/package-lock.json
@@ -33,6 +33,7 @@
         "react-use-measure": "^2.1.7"
       },
       "devDependencies": {
+        "@tailwindcss/container-queries": "^0.1.1",
         "@testing-library/jest-dom": "6.4.2",
         "@testing-library/react": "14.2.1",
         "@testing-library/user-event": "14.4.3",
@@ -3022,6 +3023,16 @@
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/container-queries": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/container-queries/-/container-queries-0.1.1.tgz",
+      "integrity": "sha512-p18dswChx6WnTSaJCSGx6lTmrGzNNvm2FtXmiO6AuA1V4U5REyoqwmT6kgAsIMdjo07QdAfYXHJ4hnMtfHzWgA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "tailwindcss": ">=3.2.0"
       }
     },
     "node_modules/@tanstack/query-core": {

--- a/services/ui/package.json
+++ b/services/ui/package.json
@@ -49,6 +49,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "postcss": "8.4.41",
     "tailwindcss": "3.4.10",
+    "@tailwindcss/container-queries": "^0.1.1",
     "typescript": "5.5.4"
   }
 }

--- a/services/ui/tailwind.config.ts
+++ b/services/ui/tailwind.config.ts
@@ -1,11 +1,14 @@
 import type { Config } from 'tailwindcss';
+import containerQueries from '@tailwindcss/container-queries';
 
 export const tokens = {
   spacing: {
-    xs: '0.25rem',
-    sm: '0.5rem',
-    md: '1rem',
-    lg: '1.5rem',
+    1: 'var(--space-1)',
+    2: 'var(--space-2)',
+    3: 'var(--space-3)',
+    4: 'var(--space-4)',
+    5: 'var(--space-5)',
+    6: 'var(--space-6)',
   },
   colors: {
     background: 'hsl(var(--background))',
@@ -85,7 +88,7 @@ const config: Config = {
       },
     },
   },
-  plugins: [],
+  plugins: [containerQueries],
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- add CSS custom properties for spacing and expose as Tailwind scale
- use clamp() heights with aspect ratios for charts and skeletons
- enable container queries and adapt home page grids for tablets

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/eslint-plugin')*


------
https://chatgpt.com/codex/tasks/task_e_68bb987bf92c8333b46fcbea65663802