### PR TITLE
feat(ui): add route change progress bar

### DIFF
--- a/services/ui/components/AppShell.tsx
+++ b/services/ui/components/AppShell.tsx
@@ -10,6 +10,7 @@ import HeaderActions from './HeaderActions';
 import MobileNav from './MobileNav';
 import { NavContext } from './NavContext';
 import Avatar from './ui/Avatar';
+import RouteProgress from './RouteProgress';
 
 export default function AppShell({ children }: { children: React.ReactNode }) {
   const [collapsed, setCollapsed] = useState(false);
@@ -33,6 +34,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
           </aside>
           <div className="flex min-h-dvh flex-1 flex-col">
             <header className="sticky top-0 z-10 glass flex items-center justify-between px-4 py-3">
+              <RouteProgress />
               <div className="flex items-center gap-2">
                 <Avatar size={32} className="hidden md:block" />
                 <span className="text-sm text-muted-foreground">Your taste dashboard</span>

--- a/services/ui/components/RouteProgress.tsx
+++ b/services/ui/components/RouteProgress.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { useEffect } from 'react';
+import Router from 'next/router';
+import NProgress from '../lib/nprogress';
+
+export default function RouteProgress() {
+  useEffect(() => {
+    const start = () => NProgress.start();
+    const done = () => NProgress.done();
+
+    Router.events.on('routeChangeStart', start);
+    Router.events.on('routeChangeComplete', done);
+    Router.events.on('routeChangeError', done);
+
+    return () => {
+      Router.events.off('routeChangeStart', start);
+      Router.events.off('routeChangeComplete', done);
+      Router.events.off('routeChangeError', done);
+    };
+  }, []);
+
+  return null;
+}

--- a/services/ui/lib/nprogress.ts
+++ b/services/ui/lib/nprogress.ts
@@ -1,0 +1,10 @@
+import NProgress from 'nprogress';
+import 'nprogress/nprogress.css';
+
+NProgress.configure({
+  showSpinner: false,
+  trickleSpeed: 200,
+  minimum: 0.1,
+});
+
+export default NProgress;

--- a/services/ui/package-lock.json
+++ b/services/ui/package-lock.json
@@ -28,6 +28,7 @@
         "lucide-react": "0.441.0",
         "next": "14.2.5",
         "next-themes": "^0.2.1",
+        "nprogress": "^0.2.0",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "react-use-measure": "^2.1.7"
@@ -9392,6 +9393,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/nprogress": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
+      "integrity": "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==",
+      "license": "MIT"
     },
     "node_modules/nwsapi": {
       "version": "2.2.21",

--- a/services/ui/package.json
+++ b/services/ui/package.json
@@ -30,11 +30,13 @@
     "lucide-react": "0.441.0",
     "next": "14.2.5",
     "next-themes": "^0.2.1",
+    "nprogress": "^0.2.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-use-measure": "^2.1.7"
   },
   "devDependencies": {
+    "@tailwindcss/container-queries": "^0.1.1",
     "@testing-library/jest-dom": "6.4.2",
     "@testing-library/react": "14.2.1",
     "@testing-library/user-event": "14.4.3",
@@ -49,7 +51,6 @@
     "jest-environment-jsdom": "^29.7.0",
     "postcss": "8.4.41",
     "tailwindcss": "3.4.10",
-    "@tailwindcss/container-queries": "^0.1.1",
     "typescript": "5.5.4"
   }
 }


### PR DESCRIPTION
## Summary
- install nprogress
- add RouteProgress component that hooks router events to NProgress
- mount route progress in AppShell header

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/eslint-plugin')*


------
https://chatgpt.com/codex/tasks/task_e_68bb9a224570833391a4e0ee946d64a2