### PR TITLE
Switch API to async SQLAlchemy and HTTP client

### DIFF
--- a/services/api/app/db.py
+++ b/services/api/app/db.py
@@ -1,51 +1,51 @@
 from __future__ import annotations
 
-from contextlib import contextmanager
+from contextlib import asynccontextmanager
 
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from services.common.models import Base
 
 from .config import get_settings
 
 _engine = None
-_SessionLocal = None
+_SessionLocal: async_sessionmaker[AsyncSession] | None = None
 _current_url = None
 engine = None
 
 
-def _get_sessionmaker() -> sessionmaker:
+def _get_sessionmaker() -> async_sessionmaker[AsyncSession]:
     global _engine, _SessionLocal, _current_url
     settings = get_settings()
     if _SessionLocal is None or _current_url != settings.db_url:
-        _engine = create_engine(settings.db_url, pool_pre_ping=True)
-        _SessionLocal = sessionmaker(bind=_engine, autoflush=False, autocommit=False)
+        _engine = create_async_engine(settings.db_url, pool_pre_ping=True)
+        _SessionLocal = async_sessionmaker(bind=_engine, autoflush=False, autocommit=False)
         _current_url = settings.db_url
         globals()["engine"] = _engine
     return _SessionLocal
 
 
-def SessionLocal():
+def SessionLocal() -> AsyncSession:
     return _get_sessionmaker()()
 
 
-@contextmanager
-def get_db():
+@asynccontextmanager
+async def get_db() -> AsyncSession:
     db = SessionLocal()
     try:
         yield db
     finally:
-        db.close()
+        await db.close()
 
 
-def maybe_create_all():
+async def maybe_create_all() -> None:
     """Create tables automatically when using SQLite or when AUTO_MIGRATE is enabled."""
     try:
         _get_sessionmaker()
         url = _current_url or ""
         if get_settings().auto_migrate or url.startswith("sqlite"):
-            Base.metadata.create_all(bind=_engine)
+            async with _engine.begin() as conn:
+                await conn.run_sync(Base.metadata.create_all)
     except Exception:
         # Silent fail to avoid blocking API start if DB isn't reachable yet (e.g., compose race)
         pass

--- a/services/api/app/routes/auth.py
+++ b/services/api/app/routes/auth.py
@@ -5,7 +5,7 @@ from hashlib import sha256
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from services.common.models import UserAccount, UserSettings
 
@@ -21,8 +21,8 @@ class Credentials(BaseModel):
 
 
 @router.post("/auth/register")
-def register(creds: Credentials, db: Session = Depends(get_db)):
-    if db.get(UserAccount, creds.username):
+async def register(creds: Credentials, db: AsyncSession = Depends(get_db)):
+    if await db.get(UserAccount, creds.username):
         raise HTTPException(status_code=400, detail="User already exists")
     user = UserAccount(
         user_id=creds.username,
@@ -30,27 +30,27 @@ def register(creds: Credentials, db: Session = Depends(get_db)):
         created_at=datetime.utcnow(),
     )
     db.add(user)
-    db.commit()
+    await db.commit()
     return {"user_id": user.user_id}
 
 
 @router.post("/auth/login")
-def login(creds: Credentials, db: Session = Depends(get_db)):
-    user = db.get(UserAccount, creds.username)
+async def login(creds: Credentials, db: AsyncSession = Depends(get_db)):
+    user = await db.get(UserAccount, creds.username)
     if not user or user.password_hash != sha256(creds.password.encode()).hexdigest():
         raise HTTPException(status_code=401, detail="Invalid credentials")
     return {"user_id": user.user_id}
 
 
 @router.get("/auth/me")
-def me(
+async def me(
     user_id: str = Depends(get_current_user),
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_db),
 ):
-    user = db.get(UserAccount, user_id)
+    user = await db.get(UserAccount, user_id)
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
-    settings = db.get(UserSettings, user_id)
+    settings = await db.get(UserSettings, user_id)
     return {
         "user_id": user.user_id,
         "lastfmUser": settings.lastfm_user if settings else None,

--- a/services/api/app/routes/dashboard.py
+++ b/services/api/app/routes/dashboard.py
@@ -4,7 +4,7 @@ from datetime import UTC, date, datetime, timedelta
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import and_, func, select
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from services.common.models import Artist, Listen, MoodAggWeek, MoodScore, Track
 
@@ -16,9 +16,9 @@ router = APIRouter()
 
 
 @router.get("/dashboard/trajectory")
-def dashboard_trajectory(
+async def dashboard_trajectory(
     window: str = Query("12w"),
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_db),
     user_id: str = Depends(get_current_user),
 ):
     # Project weekly means to 2D using (x=valence, y=energy) for simplicity
@@ -35,12 +35,14 @@ def dashboard_trajectory(
 
     # collect recent weeks
     weeks = (
-        db.execute(
-            select(MoodAggWeek.week)
-            .where(MoodAggWeek.user_id == user_id)
-            .distinct()
-            .order_by(MoodAggWeek.week.desc())
-            .limit(n_weeks)
+        (
+            await db.execute(
+                select(MoodAggWeek.week)
+                .where(MoodAggWeek.user_id == user_id)
+                .distinct()
+                .order_by(MoodAggWeek.week.desc())
+                .limit(n_weeks)
+            )
         )
         .scalars()
         .all()
@@ -51,9 +53,11 @@ def dashboard_trajectory(
 
     points = []
     for wk in weeks:
-        axis_rows = db.execute(
-            select(MoodAggWeek.axis, MoodAggWeek.mean).where(
-                and_(MoodAggWeek.week == wk, MoodAggWeek.user_id == user_id)
+        axis_rows = (
+            await db.execute(
+                select(MoodAggWeek.axis, MoodAggWeek.mean).where(
+                    and_(MoodAggWeek.week == wk, MoodAggWeek.user_id == user_id)
+                )
             )
         ).all()
         d = {ax: val for ax, val in axis_rows}
@@ -69,9 +73,9 @@ def dashboard_trajectory(
 
 
 @router.get("/dashboard/radar")
-def dashboard_radar(
+async def dashboard_radar(
     week: str = Query(...),
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_db),
     user_id: str = Depends(get_current_user),
 ):
     # parse week as YYYY-MM-DD (Monday) or ISO week-like YYYY-WW (fallback)
@@ -87,24 +91,28 @@ def dashboard_radar(
     if wk_date is None:
         raise HTTPException(status_code=400, detail="Invalid week format")
 
-    rows = db.execute(
-        select(MoodAggWeek.axis, MoodAggWeek.mean).where(
-            and_(MoodAggWeek.week == wk_date, MoodAggWeek.user_id == user_id)
+    rows = (
+        await db.execute(
+            select(MoodAggWeek.axis, MoodAggWeek.mean).where(
+                and_(MoodAggWeek.week == wk_date, MoodAggWeek.user_id == user_id)
+            )
         )
     ).all()
     axes = {ax: val for ax, val in rows}
 
     # baseline = mean of previous 24 weeks
-    baseline_rows = db.execute(
-        select(MoodAggWeek.axis, func.avg(MoodAggWeek.mean))
-        .where(
-            and_(
-                MoodAggWeek.week < wk_date,
-                MoodAggWeek.week >= wk_date - timedelta(weeks=24),
-                MoodAggWeek.user_id == user_id,
+    baseline_rows = (
+        await db.execute(
+            select(MoodAggWeek.axis, func.avg(MoodAggWeek.mean))
+            .where(
+                and_(
+                    MoodAggWeek.week < wk_date,
+                    MoodAggWeek.week >= wk_date - timedelta(weeks=24),
+                    MoodAggWeek.user_id == user_id,
+                )
             )
+            .group_by(MoodAggWeek.axis)
         )
-        .group_by(MoodAggWeek.axis)
     ).all()
     baseline = {ax: float(avg or 0.0) for ax, avg in baseline_rows}
 
@@ -117,9 +125,9 @@ def dashboard_radar(
 
 
 @router.get("/dashboard/outliers")
-def dashboard_outliers(
+async def dashboard_outliers(
     limit: int = Query(10, ge=1, le=100),
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_db),
     user_id: str = Depends(get_current_user),
 ):
     """Return tracks farthest from the recent mood centroid."""
@@ -127,38 +135,44 @@ def dashboard_outliers(
     since = datetime.now(UTC) - timedelta(days=90)
 
     # Compute centroid across recent listens
-    cent_rows = db.execute(
-        select(MoodScore.axis, func.avg(MoodScore.value))
-        .join(Listen, Listen.track_id == MoodScore.track_id)
-        .where(
-            and_(
-                Listen.user_id == user_id,
-                Listen.played_at >= since,
-                MoodScore.method == DEFAULT_METHOD,
+    cent_rows = (
+        await db.execute(
+            select(MoodScore.axis, func.avg(MoodScore.value))
+            .join(Listen, Listen.track_id == MoodScore.track_id)
+            .where(
+                and_(
+                    Listen.user_id == user_id,
+                    Listen.played_at >= since,
+                    MoodScore.method == DEFAULT_METHOD,
+                )
             )
+            .group_by(MoodScore.axis)
         )
-        .group_by(MoodScore.axis)
     ).all()
     centroid = {ax: float(val or 0.0) for ax, val in cent_rows}
     for ax in AXES:
         centroid.setdefault(ax, 0.0)
 
     # Gather candidate tracks listened to in the window
-    rows = db.execute(
-        select(Track.track_id, Track.title, Artist.name)
-        .join(Listen, Listen.track_id == Track.track_id)
-        .join(Artist, Track.artist_id == Artist.artist_id, isouter=True)
-        .where(and_(Listen.user_id == user_id, Listen.played_at >= since))
-        .group_by(Track.track_id, Track.title, Artist.name)
+    rows = (
+        await db.execute(
+            select(Track.track_id, Track.title, Artist.name)
+            .join(Listen, Listen.track_id == Track.track_id)
+            .join(Artist, Track.artist_id == Artist.artist_id, isouter=True)
+            .where(and_(Listen.user_id == user_id, Listen.played_at >= since))
+            .group_by(Track.track_id, Track.title, Artist.name)
+        )
     ).all()
 
     outliers = []
     for tid, title, artist_name in rows:
-        axis_rows = db.execute(
-            select(MoodScore.axis, MoodScore.value).where(
-                and_(
-                    MoodScore.track_id == tid,
-                    MoodScore.method == DEFAULT_METHOD,
+        axis_rows = (
+            await db.execute(
+                select(MoodScore.axis, MoodScore.value).where(
+                    and_(
+                        MoodScore.track_id == tid,
+                        MoodScore.method == DEFAULT_METHOD,
+                    )
                 )
             )
         ).all()

--- a/services/api/app/utils.py
+++ b/services/api/app/utils.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from sqlalchemy import select
-from sqlalchemy.orm import Session
+from sqlalchemy.ext.asyncio import AsyncSession
 
 
 def mb_sanitize(s: str | None) -> str | None:
@@ -15,9 +15,11 @@ def mb_sanitize(s: str | None) -> str | None:
     return s.strip().replace("\u0000", "")
 
 
-def get_or_create(db: Session, model: type, defaults: dict[str, Any] | None = None, **kwargs: Any):
+async def get_or_create(
+    db: AsyncSession, model: type, defaults: dict[str, Any] | None = None, **kwargs: Any
+):
     """Simple get-or-create helper using the given SQLAlchemy model and filters."""
-    inst = db.execute(select(model).filter_by(**kwargs)).scalar_one_or_none()
+    inst = (await db.execute(select(model).filter_by(**kwargs))).scalar_one_or_none()
     if inst:
         return inst
     params: dict[str, Any] = {**kwargs}
@@ -25,5 +27,5 @@ def get_or_create(db: Session, model: type, defaults: dict[str, Any] | None = No
         params.update(defaults)
     inst = model(**params)
     db.add(inst)
-    db.flush()
+    await db.flush()
     return inst


### PR DESCRIPTION
## Summary
- migrate DB setup to `create_async_engine` and `async_sessionmaker`
- expose async `get_db` and `get_http_client` dependencies
- convert API routes and helpers to `async def` and use `httpx.AsyncClient`
- enqueue analysis jobs via `BackgroundTasks`

## Testing
- `pre-commit run --files services/api/app/db.py services/api/app/main.py services/api/app/routes/auth.py services/api/app/routes/dashboard.py services/api/app/routes/listens.py services/api/app/routes/musicbrainz.py services/api/app/scoring.py services/api/app/utils.py`
- `pytest` *(fails: The asyncio extension requires an async driver)*


------
https://chatgpt.com/codex/tasks/task_e_68bb9ba6bd548333b96df8ab25c10367