### PR TITLE
Refactor listen ingestion with service and repositories

### DIFF
--- a/services/api/app/repositories/artist_repository.py
+++ b/services/api/app/repositories/artist_repository.py
@@ -1,0 +1,15 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from services.common.models import Artist
+from ..utils import get_or_create
+
+
+class ArtistRepository:
+    """Data access layer for :class:`Artist` objects."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def get_or_create(self, name: str, mbid: str | None = None) -> Artist:
+        """Return existing artist or create a new one."""
+        return await get_or_create(self.db, Artist, name=name, mbid=mbid)

--- a/services/api/app/repositories/listen_repository.py
+++ b/services/api/app/repositories/listen_repository.py
@@ -1,0 +1,40 @@
+from datetime import datetime
+
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from services.common.models import Listen
+
+
+class ListenRepository:
+    """Data access layer for :class:`Listen` objects."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def exists(self, user_id: str, track_id: int, played_at: datetime) -> bool:
+        """Check if a listen already exists for the given identifiers."""
+        res = await self.db.execute(
+            select(Listen).where(
+                and_(
+                    Listen.user_id == user_id,
+                    Listen.track_id == track_id,
+                    Listen.played_at == played_at,
+                )
+            )
+        )
+        return res.scalar_one_or_none() is not None
+
+    async def add(self, user_id: str, track_id: int, played_at: datetime, source: str) -> None:
+        """Add a new listen to the session."""
+        self.db.add(
+            Listen(
+                user_id=user_id,
+                track_id=track_id,
+                played_at=played_at,
+                source=source,
+            )
+        )
+
+    async def commit(self) -> None:
+        await self.db.commit()

--- a/services/api/app/repositories/release_repository.py
+++ b/services/api/app/repositories/release_repository.py
@@ -1,0 +1,29 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from services.common.models import Release
+from ..utils import get_or_create
+
+
+class ReleaseRepository:
+    """Data access layer for :class:`Release` objects."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def get_or_create(
+        self,
+        title: str,
+        artist_id: int,
+        mbid: str | None = None,
+        date=None,
+        label=None,
+    ) -> Release:
+        return await get_or_create(
+            self.db,
+            Release,
+            title=title,
+            artist_id=artist_id,
+            mbid=mbid,
+            date=date,
+            label=label,
+        )

--- a/services/api/app/repositories/track_repository.py
+++ b/services/api/app/repositories/track_repository.py
@@ -1,0 +1,31 @@
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from services.common.models import Track
+from ..utils import get_or_create
+
+
+class TrackRepository:
+    """Data access layer for :class:`Track` objects."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def get_or_create(
+        self,
+        mbid: str | None,
+        title: str,
+        artist_id: int,
+        release_id: int | None = None,
+        duration: int | None = None,
+        path_local: str | None = None,
+    ) -> Track:
+        return await get_or_create(
+            self.db,
+            Track,
+            mbid=mbid,
+            title=title,
+            artist_id=artist_id,
+            release_id=release_id,
+            duration=duration,
+            path_local=path_local,
+        )

--- a/services/api/app/routes/listens.py
+++ b/services/api/app/routes/listens.py
@@ -2,20 +2,15 @@
 
 import json
 import os
-from datetime import UTC, date, datetime
+from datetime import date, datetime
 from pathlib import Path
 
 import httpx
 from fastapi import APIRouter, Body, Depends, HTTPException, Query
 from pydantic import BaseModel
-from sqlalchemy import and_, select
-from sqlalchemy.ext.asyncio import AsyncSession
 
-from services.common.models import Artist, Listen, Release, Track
-
-from ..db import get_db
 from ..main import get_current_user, get_http_client
-from ..utils import get_or_create, mb_sanitize
+from ..services.listen_service import ListenService, get_listen_service
 
 router = APIRouter()
 
@@ -40,84 +35,12 @@ def _env(name: str, default: str | None = None) -> str | None:
     return os.getenv(name, default)
 
 
-# use shared utils: mb_sanitize, get_or_create
-
-
-async def _lb_fetch_listens(
-    client: httpx.AsyncClient,
-    user: str,
-    since: date | None,
-    token: str | None = None,
-    limit: int = 500,
-) -> list[dict]:
-    base = "https://api.listenbrainz.org/1/user"
-    params: dict = {"count": min(limit, 1000)}
-    if since:
-        params["min_ts"] = int(datetime.combine(since, datetime.min.time(), tzinfo=UTC).timestamp())
-    url = f"{base}/{user}/listens"
-    r = await client.get(url, params=params, timeout=30)
-    r.raise_for_status()
-    data = r.json()
-    return data.get("listens", [])
-
-
-async def _ingest_lb_rows(db: AsyncSession, listens: list[dict], user_id: str | None = None) -> int:
-    created = 0
-    for item in listens:
-        tm = item.get("track_metadata", {})
-        artist_name = mb_sanitize(tm.get("artist_name") or tm.get("artist_name_mb")) or "Unknown"
-        track_title = mb_sanitize(tm.get("track_name")) or "Unknown"
-        release_title = mb_sanitize(tm.get("release_name"))
-        recording_mbid = (tm.get("mbid_mapping") or {}).get("recording_mbid")
-        played_at_ts = item.get("listened_at")
-        if not played_at_ts:
-            continue
-        played_at = datetime.utcfromtimestamp(played_at_ts)
-        uid = (user_id or item.get("user_name") or "lb").lower()
-
-        artist = await get_or_create(db, Artist, name=artist_name)
-        rel = None
-        if release_title:
-            rel = await get_or_create(db, Release, title=release_title, artist_id=artist.artist_id)
-        track = await get_or_create(
-            db,
-            Track,
-            mbid=recording_mbid,
-            title=track_title,
-            artist_id=artist.artist_id,
-            release_id=rel.release_id if rel else None,
-        )
-        exists = (
-            await db.execute(
-                select(Listen).where(
-                    and_(
-                        Listen.user_id == uid,
-                        Listen.track_id == track.track_id,
-                        Listen.played_at == played_at,
-                    )
-                )
-            )
-        ).scalar_one_or_none()
-        if not exists:
-            db.add(
-                Listen(
-                    user_id=uid,
-                    track_id=track.track_id,
-                    played_at=played_at,
-                    source="listenbrainz",
-                )
-            )
-            created += 1
-    await db.commit()
-    return created
-
-
 @router.post("/ingest/listens")
 async def ingest_listens(
     since: date | None = Query(None),
     listens: list[ListenIn] | None = Body(None, description="List of listens to ingest"),
     source: str = Query("auto", description="auto|listenbrainz|body|sample"),
-    db: AsyncSession = Depends(get_db),
+    listen_service: ListenService = Depends(get_listen_service),
     client: httpx.AsyncClient = Depends(get_http_client),
     user_id: str = Depends(get_current_user),
 ):
@@ -141,14 +64,14 @@ async def ingest_listens(
             for ls in listens
             if not since or ls.played_at.date() >= since
         ]
-        created = await _ingest_lb_rows(db, rows, user_id)
+        created = await listen_service.ingest_lb_rows(rows, user_id)
         return {"detail": "ok", "ingested": created}
 
     if source in ("auto", "listenbrainz"):
         token = _env("LISTENBRAINZ_TOKEN")
         try:
-            rows = await _lb_fetch_listens(client, user_id, since, token)
-            created = await _ingest_lb_rows(db, rows, user_id)
+            rows = await listen_service.lb_fetch_listens(client, user_id, since, token)
+            created = await listen_service.ingest_lb_rows(rows, user_id)
             return {
                 "detail": "ok",
                 "ingested": created,
@@ -180,5 +103,5 @@ async def ingest_listens(
                 "user_name": x["user_id"],
             }
         )
-    created = await _ingest_lb_rows(db, rows, user_id)
+    created = await listen_service.ingest_lb_rows(rows, user_id)
     return {"detail": "ok", "ingested": created, "source": "sample"}

--- a/services/api/app/services/listen_service.py
+++ b/services/api/app/services/listen_service.py
@@ -1,0 +1,96 @@
+from datetime import UTC, date, datetime
+
+import httpx
+from fastapi import Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..db import get_db
+from ..repositories.artist_repository import ArtistRepository
+from ..repositories.listen_repository import ListenRepository
+from ..repositories.release_repository import ReleaseRepository
+from ..repositories.track_repository import TrackRepository
+from ..utils import mb_sanitize
+
+
+class ListenService:
+    """Service layer handling listen ingestion and external fetching."""
+
+    def __init__(
+        self,
+        artist_repo: ArtistRepository,
+        release_repo: ReleaseRepository,
+        track_repo: TrackRepository,
+        listen_repo: ListenRepository,
+    ):
+        self.artists = artist_repo
+        self.releases = release_repo
+        self.tracks = track_repo
+        self.listens = listen_repo
+
+    async def lb_fetch_listens(
+        self,
+        client: httpx.AsyncClient,
+        user: str,
+        since: date | None,
+        token: str | None = None,
+        limit: int = 500,
+    ) -> list[dict]:
+        """Fetch listens from the ListenBrainz API."""
+        base = "https://api.listenbrainz.org/1/user"
+        params: dict = {"count": min(limit, 1000)}
+        if since:
+            params["min_ts"] = int(
+                datetime.combine(since, datetime.min.time(), tzinfo=UTC).timestamp()
+            )
+        url = f"{base}/{user}/listens"
+        headers = {"Authorization": f"Token {token}"} if token else None
+        r = await client.get(url, params=params, timeout=30, headers=headers)
+        r.raise_for_status()
+        data = r.json()
+        return data.get("listens", [])
+
+    async def ingest_lb_rows(
+        self, listens: list[dict], user_id: str | None = None
+    ) -> int:
+        """Ingest ListenBrainz-style listen rows into the database."""
+        created = 0
+        for item in listens:
+            tm = item.get("track_metadata", {})
+            artist_name = (
+                mb_sanitize(tm.get("artist_name") or tm.get("artist_name_mb")) or "Unknown"
+            )
+            track_title = mb_sanitize(tm.get("track_name")) or "Unknown"
+            release_title = mb_sanitize(tm.get("release_name"))
+            recording_mbid = (tm.get("mbid_mapping") or {}).get("recording_mbid")
+            played_at_ts = item.get("listened_at")
+            if not played_at_ts:
+                continue
+            played_at = datetime.utcfromtimestamp(played_at_ts)
+            uid = (user_id or item.get("user_name") or "lb").lower()
+
+            artist = await self.artists.get_or_create(name=artist_name)
+            rel = None
+            if release_title:
+                rel = await self.releases.get_or_create(
+                    title=release_title, artist_id=artist.artist_id
+                )
+            track = await self.tracks.get_or_create(
+                mbid=recording_mbid,
+                title=track_title,
+                artist_id=artist.artist_id,
+                release_id=rel.release_id if rel else None,
+            )
+            if not await self.listens.exists(uid, track.track_id, played_at):
+                await self.listens.add(uid, track.track_id, played_at, "listenbrainz")
+                created += 1
+        await self.listens.commit()
+        return created
+
+
+def get_listen_service(db: AsyncSession = Depends(get_db)) -> ListenService:
+    """FastAPI dependency that provides a :class:`ListenService` instance."""
+    artist_repo = ArtistRepository(db)
+    release_repo = ReleaseRepository(db)
+    track_repo = TrackRepository(db)
+    listen_repo = ListenRepository(db)
+    return ListenService(artist_repo, release_repo, track_repo, listen_repo)

--- a/services/api/tests/test_listen_service.py
+++ b/services/api/tests/test_listen_service.py
@@ -1,0 +1,72 @@
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture()
+async def session(tmp_path, monkeypatch):
+    db_url = f"sqlite+aiosqlite:///{tmp_path}/test.db"
+    monkeypatch.setenv("DATABASE_URL", db_url)
+    root = Path(__file__).resolve().parents[3]
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+    from services.api.app.db import SessionLocal, maybe_create_all
+
+    await maybe_create_all()
+    async with SessionLocal() as sess:
+        yield sess
+
+
+@pytest.mark.asyncio
+async def test_artist_repository_get_or_create(session):
+    from services.api.app.repositories.artist_repository import ArtistRepository
+
+    repo = ArtistRepository(session)
+    a1 = await repo.get_or_create("Test Artist")
+    a2 = await repo.get_or_create("Test Artist")
+    assert a1.artist_id == a2.artist_id
+
+
+@pytest.mark.asyncio
+async def test_listen_service_ingest(session):
+    from services.api.app.repositories.artist_repository import ArtistRepository
+    from services.api.app.repositories.listen_repository import ListenRepository
+    from services.api.app.repositories.release_repository import ReleaseRepository
+    from services.api.app.repositories.track_repository import TrackRepository
+    from services.api.app.services.listen_service import ListenService
+    from sqlalchemy import select
+    from services.common.models import Listen
+
+    service = ListenService(
+        ArtistRepository(session),
+        ReleaseRepository(session),
+        TrackRepository(session),
+        ListenRepository(session),
+    )
+
+    ts = int(datetime.utcnow().timestamp())
+    rows = [
+        {
+            "track_metadata": {
+                "artist_name": "Artist",
+                "track_name": "Song",
+                "release_name": "Album",
+                "mbid_mapping": {"recording_mbid": "mbid1"},
+            },
+            "listened_at": ts,
+            "user_name": "tester",
+        }
+    ]
+
+    created = await service.ingest_lb_rows(rows, "tester")
+    assert created == 1
+
+    # ingest same rows again should not create duplicates
+    created = await service.ingest_lb_rows(rows, "tester")
+    assert created == 0
+
+    res = await session.execute(select(Listen))
+    assert len(res.scalars().all()) == 1


### PR DESCRIPTION
## Summary
- Extract ListenBrainz ingestion logic into a ListenService
- Introduce repository classes encapsulating database operations
- Update listen routes to inject service dependencies
- Add unit tests for repositories and listen service

## Testing
- `pytest tests/test_listen_service.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb9d2501b48333924a3677c3e3bf12