### PR TITLE
feat: load listenbrainz creds from settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ POSTGRES_PASSWORD=vibe
 POSTGRES_PORT=5432
 
 # ListenBrainz / MusicBrainz
-LISTENBRAINZ_USER=your_user
-LISTENBRAINZ_TOKEN=lb_xxx
+LISTENBRAINZ_USER=your_user          # ListenBrainz username for ingestion
+LISTENBRAINZ_TOKEN=lb_xxx            # ListenBrainz API token
 MUSICBRAINZ_RATE_LIMIT=1.0   # req/sec
 
 # Last.fm

--- a/services/api/app/config.py
+++ b/services/api/app/config.py
@@ -18,6 +18,8 @@ class Settings(BaseSettings):
 
     # Use the Compose service name for Redis by default
     redis_url: str = Field(default="redis://cache:6379/0", env="REDIS_URL")
+    listenbrainz_user: str | None = Field(default=None, env="LISTENBRAINZ_USER")
+    listenbrainz_token: str | None = Field(default=None, env="LISTENBRAINZ_TOKEN")
     lastfm_api_key: str | None = Field(default=None, env="LASTFM_API_KEY")
     lastfm_api_secret: str | None = Field(default=None, env="LASTFM_API_SECRET")
 


### PR DESCRIPTION
## Summary
- add ListenBrainz user/token to Settings
- use Settings dependency in ingest route instead of `os.getenv`
- document ListenBrainz environment variables

## Testing
- `ruff check services/api/app/config.py services/api/app/routes/listens.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fakeredis'; invalid async driver 'pysqlite')*

------
https://chatgpt.com/codex/tasks/task_e_68bb9e3ac6a48333a665864fcb9e02ac