### PR TITLE
refactor: add API schemas and response models

### DIFF
--- a/services/api/app/routes/auth.py
+++ b/services/api/app/routes/auth.py
@@ -4,23 +4,18 @@ from datetime import datetime
 from hashlib import sha256
 
 from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from services.common.models import UserAccount, UserSettings
 
 from ..db import get_db
 from ..main import get_current_user
+from ..schemas.auth import Credentials, MeOut, UserOut
 
 router = APIRouter()
 
 
-class Credentials(BaseModel):
-    username: str
-    password: str
-
-
-@router.post("/auth/register")
+@router.post("/auth/register", response_model=UserOut)
 async def register(creds: Credentials, db: AsyncSession = Depends(get_db)):
     if await db.get(UserAccount, creds.username):
         raise HTTPException(status_code=400, detail="User already exists")
@@ -31,18 +26,18 @@ async def register(creds: Credentials, db: AsyncSession = Depends(get_db)):
     )
     db.add(user)
     await db.commit()
-    return {"user_id": user.user_id}
+    return UserOut.model_validate(user)
 
 
-@router.post("/auth/login")
+@router.post("/auth/login", response_model=UserOut)
 async def login(creds: Credentials, db: AsyncSession = Depends(get_db)):
     user = await db.get(UserAccount, creds.username)
     if not user or user.password_hash != sha256(creds.password.encode()).hexdigest():
         raise HTTPException(status_code=401, detail="Invalid credentials")
-    return {"user_id": user.user_id}
+    return UserOut.model_validate(user)
 
 
-@router.get("/auth/me")
+@router.get("/auth/me", response_model=MeOut)
 async def me(
     user_id: str = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
@@ -51,8 +46,8 @@ async def me(
     if not user:
         raise HTTPException(status_code=404, detail="User not found")
     settings = await db.get(UserSettings, user_id)
-    return {
-        "user_id": user.user_id,
-        "lastfmUser": settings.lastfm_user if settings else None,
-        "lastfmConnected": bool(settings and settings.lastfm_session_key),
-    }
+    return MeOut(
+        user_id=user.user_id,
+        lastfmUser=settings.lastfm_user if settings else None,
+        lastfmConnected=bool(settings and settings.lastfm_session_key),
+    )

--- a/services/api/app/routes/musicbrainz.py
+++ b/services/api/app/routes/musicbrainz.py
@@ -12,6 +12,7 @@ from services.common.models import Artist, Release, Track
 
 from ..db import get_db
 from ..main import get_http_client
+from ..schemas.musicbrainz import MusicbrainzIngestResponse
 from ..utils import get_or_create, mb_sanitize
 
 router = APIRouter()
@@ -38,7 +39,7 @@ async def _mb_fetch_release(client: httpx.AsyncClient, mbid: str) -> dict:
     return r.json()
 
 
-@router.post("/ingest/musicbrainz")
+@router.post("/ingest/musicbrainz", response_model=MusicbrainzIngestResponse)
 async def ingest_musicbrainz(
     release_mbid: str = Query(..., description="MusicBrainz release MBID"),
     db: AsyncSession = Depends(get_db),
@@ -121,9 +122,9 @@ async def ingest_musicbrainz(
                     existing.duration = duration
 
     await db.commit()
-    return {
-        "detail": "ok",
-        "artist_id": artist.artist_id if artist else None,
-        "release_id": release.release_id,
-        "tracks": created_tracks,
-    }
+    return MusicbrainzIngestResponse(
+        detail="ok",
+        artist_id=artist.artist_id if artist else None,
+        release_id=release.release_id,
+        tracks=created_tracks,
+    )

--- a/services/api/app/schemas/auth.py
+++ b/services/api/app/schemas/auth.py
@@ -1,0 +1,17 @@
+from pydantic import BaseModel, ConfigDict
+
+
+class Credentials(BaseModel):
+    username: str
+    password: str
+
+
+class UserOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    user_id: str
+
+
+class MeOut(BaseModel):
+    user_id: str
+    lastfmUser: str | None = None
+    lastfmConnected: bool = False

--- a/services/api/app/schemas/labels.py
+++ b/services/api/app/schemas/labels.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel, ConfigDict
+
+
+class LabelResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    detail: str
+    id: int
+    user_id: str
+    track_id: int
+    axis: str
+    value: float

--- a/services/api/app/schemas/listens.py
+++ b/services/api/app/schemas/listens.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class TrackIn(BaseModel):
+    title: str
+    artist_name: str
+    release_title: str | None = None
+    mbid: str | None = None
+    duration: int | None = None
+    path_local: str | None = None
+
+
+class ListenIn(BaseModel):
+    user_id: str
+    played_at: datetime
+    source: str | None = "listenbrainz"
+    track: TrackIn
+
+
+class IngestResponse(BaseModel):
+    detail: str
+    ingested: int
+    source: str | None = None

--- a/services/api/app/schemas/musicbrainz.py
+++ b/services/api/app/schemas/musicbrainz.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class MusicbrainzIngestResponse(BaseModel):
+    detail: str
+    artist_id: int | None = None
+    release_id: int
+    tracks: int

--- a/services/api/app/schemas/settings.py
+++ b/services/api/app/schemas/settings.py
@@ -1,0 +1,24 @@
+from pydantic import BaseModel, ConfigDict
+
+
+class SettingsIn(BaseModel):
+    listenBrainzUser: str | None = None
+    listenBrainzToken: str | None = None
+    useGpu: bool = False
+    useStems: bool = False
+    useExcerpts: bool = False
+
+
+class SettingsOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    listenBrainzUser: str | None = None
+    listenBrainzToken: str | None = None
+    lastfmUser: str | None = None
+    lastfmConnected: bool = False
+    useGpu: bool = False
+    useStems: bool = False
+    useExcerpts: bool = False
+
+
+class SettingsUpdateResponse(BaseModel):
+    ok: bool

--- a/services/api/app/schemas/tracks.py
+++ b/services/api/app/schemas/tracks.py
@@ -1,0 +1,20 @@
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class TrackPathIn(BaseModel):
+    path_local: str
+
+
+class TrackPathResponse(BaseModel):
+    detail: str
+    track_id: int
+    path_local: str
+
+
+class AnalyzeTrackResponse(BaseModel):
+    detail: str
+    track_id: int
+    status: Literal["scheduled", "done"]
+    features_id: int | None = None

--- a/services/api/tests/test_analyze_track.py
+++ b/services/api/tests/test_analyze_track.py
@@ -14,6 +14,7 @@ from rq import Queue
 
 from services.api.app import main as app_main
 from services.api.app.db import SessionLocal, maybe_create_all
+from services.api.app.schemas.tracks import AnalyzeTrackResponse
 from services.common.models import Track
 
 # Ensure tables exist
@@ -31,7 +32,8 @@ def test_analyze_track_schedules_job():
     with TestClient(app_main.app) as client:
         resp = client.post(f"/analyze/track/{tid}")
         assert resp.status_code == 200
-        assert resp.json()["status"] == "scheduled"
+        data = AnalyzeTrackResponse.model_validate(resp.json())
+        assert data.status == "scheduled"
     q = Queue("analysis", connection=connection)
     jobs = q.jobs
     assert jobs and jobs[0].args[0] == tid

--- a/services/api/tests/test_labels.py
+++ b/services/api/tests/test_labels.py
@@ -12,6 +12,7 @@ os.environ["DATABASE_URL"] = "sqlite:///./test.db"
 
 from services.api.app.db import SessionLocal, engine, get_db  # noqa: E402
 from services.api.app.main import app  # noqa: E402  (import after setting env)
+from services.api.app.schemas.labels import LabelResponse
 from services.common.models import Base, Track, UserLabel  # noqa: E402
 
 Base.metadata.create_all(bind=engine)
@@ -55,9 +56,9 @@ def test_submit_label_stores_label():
         headers={"X-User-Id": "u1"},
     )
     assert resp.status_code == 200
-    data = resp.json()
-    assert data["detail"] == "accepted"
-    assert data["axis"] == "energy"
+    data = LabelResponse.model_validate(resp.json())
+    assert data.detail == "accepted"
+    assert data.axis == "energy"
 
     with SessionLocal() as db:
         lbl = db.execute(select(UserLabel)).scalar_one()

--- a/services/api/tests/test_musicbrainz_ingest.py
+++ b/services/api/tests/test_musicbrainz_ingest.py
@@ -4,6 +4,8 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
+from services.api.app.schemas.musicbrainz import MusicbrainzIngestResponse
+
 sample_release = {
     "id": "release-mbid",
     "title": "Sample Release",
@@ -71,7 +73,8 @@ def test_ingest_musicbrainz_dedup(mb_client):
     client, SessionLocal = mb_client
     resp = client.post("/ingest/musicbrainz", params={"release_mbid": "release-mbid"})
     assert resp.status_code == 200
-    assert resp.json()["tracks"] >= 2
+    data = MusicbrainzIngestResponse.model_validate(resp.json())
+    assert data.tracks >= 2
 
     session = SessionLocal()
     from services.common.models import Artist, Release, Track


### PR DESCRIPTION
## Summary
- introduce dedicated Pydantic schema package for API requests/responses
- return typed models from routes using response_model annotations
- adjust tests to validate against schema classes

## Testing
- `pre-commit run --files services/api/app/routes/auth.py services/api/app/routes/listens.py services/api/app/routes/musicbrainz.py services/api/app/main.py services/api/app/schemas/auth.py services/api/app/schemas/listens.py services/api/app/schemas/settings.py services/api/app/schemas/tracks.py services/api/app/schemas/labels.py services/api/app/schemas/musicbrainz.py services/api/app/schemas/__init__.py services/api/tests/test_analyze_track.py services/api/tests/test_labels.py services/api/tests/test_musicbrainz_ingest.py`
- `pytest services/api/tests` *(fails: The asyncio extension requires an async driver ...)*

------
https://chatgpt.com/codex/tasks/task_e_68bb9f05ccc88333b1fbf523494dff95