### PR TITLE
feat: add async Last.fm and ListenBrainz clients

### DIFF
--- a/services/api/app/clients/lastfm.py
+++ b/services/api/app/clients/lastfm.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import hashlib
+from collections.abc import AsyncGenerator
+from datetime import datetime, timedelta
+from typing import Any
+
+import httpx
+from fastapi import Depends
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
+
+from services.common.models import LastfmTags
+
+from ..config import Settings, get_settings
+
+
+def _retryable(exc: Exception) -> bool:
+    if isinstance(exc, httpx.HTTPStatusError):
+        status = exc.response.status_code
+        return status >= 500 or status == 429
+    return isinstance(exc, httpx.RequestError)
+
+
+_retry = retry(
+    reraise=True,
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=4),
+    retry=retry_if_exception(_retryable),
+)
+
+
+class LastfmClient:
+    """Client for interacting with the Last.fm API."""
+
+    api_root = "https://ws.audioscrobbler.com/2.0/"
+
+    def __init__(
+        self, client: httpx.AsyncClient, api_key: str | None, api_secret: str | None
+    ) -> None:
+        self._client = client
+        self.api_key = api_key
+        self.api_secret = api_secret
+
+    def auth_url(self, callback: str) -> str:
+        if not self.api_key:
+            raise RuntimeError("LASTFM_API_KEY not configured")
+        return f"https://www.last.fm/api/auth/?api_key={self.api_key}&cb={callback}"
+
+    def _sign(self, params: dict[str, str]) -> str:
+        if not self.api_secret:
+            raise RuntimeError("LASTFM_API_SECRET not configured")
+        items = "".join(f"{k}{v}" for k, v in sorted(params.items()))
+        m = hashlib.md5()
+        m.update((items + self.api_secret).encode("utf-8"))
+        return m.hexdigest()
+
+    @_retry
+    async def _get(self, params: dict[str, Any]) -> httpx.Response:
+        resp = await self._client.get(self.api_root, params=params, timeout=30)
+        resp.raise_for_status()
+        return resp
+
+    async def get_session(self, token: str) -> tuple[str, str]:
+        """Exchange an auth token for a session key and username."""
+        if not self.api_key:
+            raise RuntimeError("LASTFM_API_KEY not configured")
+        params = {"method": "auth.getSession", "api_key": self.api_key, "token": token}
+        params["api_sig"] = self._sign(params)
+        params["format"] = "json"
+        r = await self._get(params)
+        data = r.json().get("session") or {}
+        key = data.get("key")
+        name = data.get("name")
+        if not key or not name:
+            raise RuntimeError("Invalid session response")
+        return key, name
+
+    async def get_track_tags(
+        self,
+        db: AsyncSession,
+        track_id: int,
+        artist: str,
+        track: str,
+        max_age: int = 86400,
+    ) -> dict[str, int]:
+        """Fetch top tags for a track with DB caching."""
+        if not self.api_key:
+            raise RuntimeError("LASTFM_API_KEY not configured")
+
+        existing = (
+            await db.execute(select(LastfmTags).where(LastfmTags.track_id == track_id))
+        ).scalar_one_or_none()
+        if (
+            existing
+            and existing.updated_at
+            and existing.updated_at > datetime.utcnow() - timedelta(seconds=max_age)
+        ):
+            return existing.tags or {}
+
+        params = {
+            "method": "track.gettoptags",
+            "artist": artist,
+            "track": track,
+            "api_key": self.api_key,
+            "format": "json",
+        }
+        r = await self._get(params)
+        data = r.json()
+        tags = data.get("toptags", {}).get("tag", [])
+        out: dict[str, int] = {}
+        for t in tags:
+            name = (t.get("name") or "").strip()
+            try:
+                cnt = int(t.get("count") or 0)
+            except Exception:
+                cnt = 0
+            if name:
+                out[name] = cnt
+
+        if existing:
+            existing.tags = out
+            existing.updated_at = datetime.utcnow()
+        else:
+            db.add(
+                LastfmTags(
+                    track_id=track_id,
+                    source="track",
+                    tags=out,
+                    updated_at=datetime.utcnow(),
+                )
+            )
+        await db.commit()
+        return out
+
+
+async def get_lastfm_client(
+    settings: Settings = Depends(get_settings),
+) -> AsyncGenerator[LastfmClient, None]:
+    async with httpx.AsyncClient() as client:
+        yield LastfmClient(client, settings.lastfm_api_key, settings.lastfm_api_secret)

--- a/services/api/app/clients/listenbrainz.py
+++ b/services/api/app/clients/listenbrainz.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from datetime import UTC, date, datetime
+from typing import Any
+
+import httpx
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
+
+
+def _retryable(exc: Exception) -> bool:
+    if isinstance(exc, httpx.HTTPStatusError):
+        status = exc.response.status_code
+        return status >= 500 or status == 429
+    return isinstance(exc, httpx.RequestError)
+
+
+_retry = retry(
+    reraise=True,
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=4),
+    retry=retry_if_exception(_retryable),
+)
+
+
+class ListenBrainzClient:
+    """Client for the ListenBrainz API."""
+
+    base_url = "https://api.listenbrainz.org/1"
+
+    def __init__(self, client: httpx.AsyncClient) -> None:
+        self._client = client
+
+    @_retry
+    async def _get(self, url: str, **kwargs: Any) -> httpx.Response:
+        resp = await self._client.get(url, timeout=30, **kwargs)
+        resp.raise_for_status()
+        return resp
+
+    async def fetch_listens(
+        self,
+        user: str,
+        since: date | None,
+        token: str | None = None,
+        limit: int = 500,
+    ) -> list[dict[str, Any]]:
+        """Fetch listens for ``user`` from ListenBrainz."""
+        params: dict[str, Any] = {"count": min(limit, 1000)}
+        if since:
+            params["min_ts"] = int(
+                datetime.combine(since, datetime.min.time(), tzinfo=UTC).timestamp()
+            )
+        headers = {"Authorization": f"Token {token}"} if token else None
+        url = f"{self.base_url}/user/{user}/listens"
+        r = await self._get(url, params=params, headers=headers)
+        data = r.json()
+        return data.get("listens", [])
+
+
+async def get_listenbrainz_client() -> AsyncGenerator[ListenBrainzClient, None]:
+    async with httpx.AsyncClient() as client:
+        yield ListenBrainzClient(client)

--- a/services/api/pyproject.toml
+++ b/services/api/pyproject.toml
@@ -15,6 +15,8 @@ dependencies = [
     "SQLAlchemy==2.0.32",
     "alembic==1.13.2",
     "requests==2.32.3",
+    "httpx==0.27.0",
+    "tenacity==8.2.3",
     "redis==5.0.7",
     "rq==1.16.2",
 ]

--- a/services/api/requirements.txt
+++ b/services/api/requirements.txt
@@ -7,3 +7,5 @@ psycopg[binary]==3.2.1
 SQLAlchemy==2.0.32
 alembic==1.13.2
 requests==2.32.3
+httpx==0.27.0
+tenacity==8.2.3


### PR DESCRIPTION
## Summary
- add async API clients for Last.fm and ListenBrainz with retry/backoff
- inject clients via FastAPI dependencies and move caching to Last.fm client
- use new clients in listen ingestion and auth flows

## Testing
- `pre-commit run --files services/api/app/clients/__init__.py services/api/app/clients/listenbrainz.py services/api/app/clients/lastfm.py services/api/app/routes/listens.py services/api/app/services/listen_service.py services/api/app/main.py services/api/pyproject.toml services/api/requirements.txt`
- `pytest services/api/tests` *(fails: asyncio extension requires an async driver)*

------
https://chatgpt.com/codex/tasks/task_e_68bba06bc658833397a259d93caa9e13