### PR TITLE
Switch API tests to async httpx client

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,7 +16,7 @@ aiosqlite==0.19.0
 
 # HTTP & async clients
 requests==2.32.3
-httpx[http2]==0.27.0
+httpx[async]==0.27.0
 tenacity==8.2.3
 
 # Security & auth

--- a/services/api/pyproject.toml
+++ b/services/api/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "SQLAlchemy==2.0.32",
     "alembic==1.13.2",
     "requests==2.32.3",
-    "httpx==0.27.0",
+    "httpx[async]==0.27.0",
     "tenacity==8.2.3",
     "passlib[bcrypt]==1.7.4",
     "redis==5.0.7",
@@ -26,6 +26,7 @@ dependencies = [
     "opentelemetry-instrumentation-fastapi==0.57b0",
     "opentelemetry-instrumentation-httpx==0.57b0",
     "opentelemetry-instrumentation-sqlalchemy==0.57b0",
+    "pytest-asyncio==0.23.7",
 ]
 
 [tool.setuptools]

--- a/services/api/requirements.txt
+++ b/services/api/requirements.txt
@@ -7,7 +7,7 @@ psycopg[binary]==3.2.1
 SQLAlchemy==2.0.32
 alembic==1.13.2
 requests==2.32.3
-httpx==0.27.0
+httpx[async]==0.27.0
 tenacity==8.2.3
 passlib[bcrypt]==1.7.4
 structlog==24.1.0
@@ -16,4 +16,7 @@ opentelemetry-sdk==1.36.0
 opentelemetry-instrumentation-fastapi==0.57b0
 opentelemetry-instrumentation-httpx==0.57b0
 opentelemetry-instrumentation-sqlalchemy==0.57b0
+
+# Testing
+pytest-asyncio==0.23.7
 

--- a/services/api/tests/test_analyze_track.py
+++ b/services/api/tests/test_analyze_track.py
@@ -1,3 +1,4 @@
+import pytest
 from rq import Queue
 
 from sidetrack.api.db import SessionLocal
@@ -5,13 +6,14 @@ from sidetrack.api.schemas.tracks import AnalyzeTrackResponse
 from sidetrack.common.models import Track
 
 
-def test_analyze_track_schedules_job(client, redis_conn):
-    with SessionLocal() as db:
+@pytest.mark.asyncio
+async def test_analyze_track_schedules_job(async_client, redis_conn):
+    async with SessionLocal() as db:
         tr = Track(title="test", path_local="song.mp3")
         db.add(tr)
-        db.commit()
+        await db.commit()
         tid = tr.track_id
-    resp = client.post(f"/analyze/track/{tid}")
+    resp = await async_client.post(f"/analyze/track/{tid}")
     assert resp.status_code == 200
     data = AnalyzeTrackResponse.model_validate(resp.json())
     assert data.status == "scheduled"
@@ -20,16 +22,18 @@ def test_analyze_track_schedules_job(client, redis_conn):
     assert jobs and jobs[0].args[0] == tid
 
 
-def test_analyze_track_not_found(client):
-    resp = client.post("/analyze/track/9999")
+@pytest.mark.asyncio
+async def test_analyze_track_not_found(async_client):
+    resp = await async_client.post("/analyze/track/9999")
     assert resp.status_code == 404
 
 
-def test_analyze_track_missing_path(client):
-    with SessionLocal() as db:
+@pytest.mark.asyncio
+async def test_analyze_track_missing_path(async_client):
+    async with SessionLocal() as db:
         tr = Track(title="nop")
         db.add(tr)
-        db.commit()
+        await db.commit()
         tid = tr.track_id
-    resp = client.post(f"/analyze/track/{tid}")
+    resp = await async_client.post(f"/analyze/track/{tid}")
     assert resp.status_code == 400

--- a/services/api/tests/test_auth_tokens.py
+++ b/services/api/tests/test_auth_tokens.py
@@ -1,9 +1,19 @@
-def test_token_flow(client):
-    r = client.post("/api/v1/auth/register", json={"username": "alice", "password": "wonder"})
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_token_flow(async_client):
+    r = await async_client.post(
+        "/api/v1/auth/register", json={"username": "alice", "password": "wonder"}
+    )
     assert r.status_code == 200
-    r = client.post("/api/v1/auth/token", data={"username": "alice", "password": "wonder"})
+    r = await async_client.post(
+        "/api/v1/auth/token", data={"username": "alice", "password": "wonder"}
+    )
     assert r.status_code == 200
     token = r.json()["access_token"]
-    m = client.get("/api/v1/auth/me", headers={"Authorization": f"Bearer {token}"})
+    m = await async_client.get(
+        "/api/v1/auth/me", headers={"Authorization": f"Bearer {token}"}
+    )
     assert m.status_code == 200
     assert m.json()["user_id"] == "alice"

--- a/services/api/tests/test_scoring.py
+++ b/services/api/tests/test_scoring.py
@@ -7,20 +7,25 @@ from sidetrack.api.main import score_track
 from sidetrack.common.models import Embedding, Feature, MoodScore, Track
 
 
-def test_score_track_zero_shot(session):
+@pytest.mark.asyncio
+async def test_score_track_zero_shot(async_session):
     tr = Track(title="Song")
-    session.add(tr)
-    session.flush()
-    session.add(Embedding(track_id=tr.track_id, model="test", dim=3, vector=[0.1, 0.2, 0.3]))
-    session.commit()
+    async_session.add(tr)
+    await async_session.flush()
+    async_session.add(
+        Embedding(track_id=tr.track_id, model="test", dim=3, vector=[0.1, 0.2, 0.3])
+    )
+    await async_session.commit()
 
-    res = score_track(tr.track_id, db=session)
+    res = await score_track(tr.track_id, db=async_session)
     assert res["detail"] == "scored"
     assert set(res["scores"]) == set(AXES)
 
     rows = (
-        session.execute(select(MoodScore).where(MoodScore.track_id == tr.track_id)).scalars().all()
-    )
+        await async_session.execute(
+            select(MoodScore).where(MoodScore.track_id == tr.track_id)
+        )
+    ).scalars().all()
     assert len(rows) == len(AXES)
     for row in rows:
         assert 0.0 <= row.value <= 1.0
@@ -30,11 +35,12 @@ def test_score_track_zero_shot(session):
         assert 0.0 <= val["confidence"] <= 1.0
 
 
-def test_score_track_logreg(session):
+@pytest.mark.asyncio
+async def test_score_track_logreg(async_session):
     tr = Track(title="Song2")
-    session.add(tr)
-    session.flush()
-    session.add(
+    async_session.add(tr)
+    await async_session.flush()
+    async_session.add(
         Feature(
             track_id=tr.track_id,
             bpm=120.0,
@@ -42,39 +48,39 @@ def test_score_track_logreg(session):
             percussive_harmonic_ratio=0.4,
         )
     )
-    session.commit()
+    await async_session.commit()
 
-    res = score_track(tr.track_id, method="logreg", version="v1", db=session)
+    res = await score_track(tr.track_id, method="logreg", version="v1", db=async_session)
     assert res["detail"] == "scored"
     assert res["method"] == "logreg_v1"
     assert set(res["scores"]) == set(AXES)
     rows = (
-        session.execute(
+        await async_session.execute(
             select(MoodScore).where(
                 MoodScore.track_id == tr.track_id, MoodScore.method == "logreg_v1"
             )
         )
-        .scalars()
-        .all()
-    )
+    ).scalars().all()
     assert len(rows) == len(AXES)
     for val in res["scores"].values():
         assert 0.0 <= val["value"] <= 1.0
         assert 0.0 <= val["confidence"] <= 1.0
 
 
-def test_score_track_missing_data(session):
+@pytest.mark.asyncio
+async def test_score_track_missing_data(async_session):
     tr = Track(title="NoData")
-    session.add(tr)
-    session.commit()
+    async_session.add(tr)
+    await async_session.commit()
 
     with pytest.raises(HTTPException):
-        score_track(tr.track_id, db=session)
+        await score_track(tr.track_id, db=async_session)
 
 
-def test_score_track_bad_method(session):
+@pytest.mark.asyncio
+async def test_score_track_bad_method(async_session):
     tr = Track(title="Bad")
-    session.add(tr)
-    session.commit()
+    async_session.add(tr)
+    await async_session.commit()
     with pytest.raises(HTTPException):
-        score_track(tr.track_id, method="nope", db=session)
+        await score_track(tr.track_id, method="nope", db=async_session)

--- a/services/api/tests/test_track_features.py
+++ b/services/api/tests/test_track_features.py
@@ -1,29 +1,33 @@
+import pytest
+
 from sidetrack.api.db import SessionLocal
 from sidetrack.common.models import Embedding, Feature, Track
 
 
-def _create_track_with_features() -> int:
-    with SessionLocal() as db:
+async def _create_track_with_features() -> int:
+    async with SessionLocal() as db:
         tr = Track(title="t")
         db.add(tr)
-        db.flush()
+        await db.flush()
         db.add(
             Feature(track_id=tr.track_id, bpm=120.0, pumpiness=0.5, percussive_harmonic_ratio=0.3)
         )
         db.add(Embedding(track_id=tr.track_id, model="m", dim=3, vector=[0.1, 0.2, 0.3]))
-        db.commit()
+        await db.commit()
         return tr.track_id
 
 
-def test_get_track_features_returns_rows(client):
-    tid = _create_track_with_features()
-    resp = client.get(f"/tracks/{tid}/features")
+@pytest.mark.asyncio
+async def test_get_track_features_returns_rows(async_client):
+    tid = await _create_track_with_features()
+    resp = await async_client.get(f"/tracks/{tid}/features")
     assert resp.status_code == 200
     data = resp.json()
     assert data["feature"]["bpm"] == 120.0
     assert data["embedding"]["model"] == "m"
 
 
-def test_get_track_features_not_found(client):
-    resp = client.get("/tracks/9999/features")
+@pytest.mark.asyncio
+async def test_get_track_features_not_found(async_client):
+    resp = await async_client.get("/tracks/9999/features")
     assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- add httpx async extra and pytest-asyncio to dependencies
- provide async_client fixture using FastAPI lifespan
- rewrite API tests to use AsyncClient and asyncio

## Testing
- `pytest -q` *(fails: MissingGreenlet and HTTP 500 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb24d71b8833393bc5d601ecea3cb