### PR TITLE
Add test factories for core models

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -53,6 +53,7 @@ pytest-cov==5.0.0
 pytest-mock==3.12.0
 pytest-env==1.0.1
 factory-boy==3.3.0
+pydantic-factories==1.17.0
 coverage==7.6.1
 
 # Development tools

--- a/services/api/tests/test_labels.py
+++ b/services/api/tests/test_labels.py
@@ -3,16 +3,18 @@ from sqlalchemy import select
 
 from sidetrack.api.db import SessionLocal
 from sidetrack.api.schemas.labels import LabelResponse
-from sidetrack.common.models import Track, UserLabel
+from sidetrack.common.models import UserLabel
+from tests.factories import TrackFactory
 
 
 async def _create_track() -> int:
     async with SessionLocal() as db:
-        tr = Track(title="test")
+        tr = TrackFactory(title="test")
         db.add(tr)
+        await db.flush()
+        tid = tr.track_id
         await db.commit()
-        await db.refresh(tr)
-        return tr.track_id
+        return tid
 
 
 @pytest.mark.asyncio

--- a/services/api/tests/test_track_features.py
+++ b/services/api/tests/test_track_features.py
@@ -1,20 +1,33 @@
 import pytest
 
 from sidetrack.api.db import SessionLocal
-from sidetrack.common.models import Embedding, Feature, Track
+from tests.factories import EmbeddingFactory, FeatureFactory, TrackFactory
 
 
 async def _create_track_with_features() -> int:
     async with SessionLocal() as db:
-        tr = Track(title="t")
+        tr = TrackFactory()
         db.add(tr)
         await db.flush()
+        tid = tr.track_id
         db.add(
-            Feature(track_id=tr.track_id, bpm=120.0, pumpiness=0.5, percussive_harmonic_ratio=0.3)
+            FeatureFactory(
+                track_id=tid,
+                bpm=120.0,
+                pumpiness=0.5,
+                percussive_harmonic_ratio=0.3,
+            )
         )
-        db.add(Embedding(track_id=tr.track_id, model="m", dim=3, vector=[0.1, 0.2, 0.3]))
+        db.add(
+            EmbeddingFactory(
+                track_id=tid,
+                model="m",
+                dim=3,
+                vector=[0.1, 0.2, 0.3],
+            )
+        )
         await db.commit()
-        return tr.track_id
+        return tid
 
 
 @pytest.mark.asyncio

--- a/services/extractor/tests/test_features.py
+++ b/services/extractor/tests/test_features.py
@@ -5,7 +5,8 @@ import soundfile as sf
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
-from sidetrack.common.models import Base, Embedding, Feature, Track
+from sidetrack.common.models import Base, Embedding, Feature
+from tests.factories import TrackFactory
 from sidetrack.extractor.run import analyze_one, estimate_features
 
 SR = 44100
@@ -35,7 +36,7 @@ def test_analyze_one_with_embeddings(tmp_path, monkeypatch):
     engine = create_engine("sqlite://")
     Base.metadata.create_all(engine)
     with Session(engine) as db:
-        tr = Track(track_id=1, title="t", path_local=str(wav), duration=2)
+        tr = TrackFactory(track_id=1, title="t", path_local=str(wav), duration=2)
         db.add(tr)
         db.commit()
         monkeypatch.setenv("EMBEDDING_MODEL", "mfcc")

--- a/tests/factories/README.md
+++ b/tests/factories/README.md
@@ -1,0 +1,29 @@
+# Test Factories
+
+Factories for generating core models in tests.
+
+## Usage
+
+```python
+from tests.factories import TrackFactory, FeatureFactory
+
+tr = TrackFactory()
+session.add(tr)
+session.flush()
+feat = FeatureFactory(track_id=tr.track_id)
+session.add(feat)
+session.commit()
+```
+
+### Available factories
+
+- `TrackFactory`
+- `FeatureFactory`
+- `EmbeddingFactory`
+- `UserFactory`
+
+### Traits
+
+- `FeatureFactory.zero` – zeroed-out feature values.
+- `EmbeddingFactory.unit` – unit vector embedding.
+- `UserFactory.admin` – admin role user.

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+"""Factories for core SQLAlchemy models used in tests."""
+
+import factory
+
+from sidetrack.common.models import Embedding, Feature, Track, UserAccount
+
+
+class TrackFactory(factory.Factory):
+    """Factory for :class:`~sidetrack.common.models.Track`."""
+
+    class Meta:
+        model = Track
+
+    title = factory.Sequence(lambda n: f"Track {n}")
+    path_local = None
+    artist_id = None
+    release_id = None
+    duration = None
+    fingerprint = None
+
+
+
+class FeatureFactory(factory.Factory):
+    """Factory for :class:`~sidetrack.common.models.Feature`."""
+
+    class Meta:
+        model = Feature
+    bpm = 120.0
+    pumpiness = 0.5
+    percussive_harmonic_ratio = 0.3
+
+    class Params:
+        zero = factory.Trait(bpm=0.0, pumpiness=0.0, percussive_harmonic_ratio=0.0)
+
+
+class EmbeddingFactory(factory.Factory):
+    """Factory for :class:`~sidetrack.common.models.Embedding`."""
+
+    class Meta:
+        model = Embedding
+    model = "test"
+    dim = 3
+    vector = [0.1, 0.2, 0.3]
+
+    class Params:
+        unit = factory.Trait(vector=[1.0, 0.0, 0.0])
+
+
+class UserFactory(factory.Factory):
+    """Factory for :class:`~sidetrack.common.models.UserAccount`."""
+
+    class Meta:
+        model = UserAccount
+
+    user_id = factory.Sequence(lambda n: f"user{n}")
+    password_hash = "pw"
+    token_hash = None
+    role = "user"
+
+    class Params:
+        admin = factory.Trait(role="admin")
+
+
+__all__ = [
+    "TrackFactory",
+    "FeatureFactory",
+    "EmbeddingFactory",
+    "UserFactory",
+]


### PR DESCRIPTION
## Summary
- add pydantic-factories to dev requirements
- create factory-boy factories for Track, Feature, Embedding, and User
- refactor tests to use factories and document usage

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q` *(fails: test_auth_tokens.py::test_token_flow, test_musicbrainz_ingest.py::test_ingest_musicbrainz_dedup)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb5293f9c8333ab824d7e6f77d4d5