### PR TITLE
Add pytest configuration and CI coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - run: pip install nox coverage-badge
+      - run: nox -s lint unit integration
+      - run: coverage xml
+      - run: coverage-badge -o coverage.svg -f
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: |
+            coverage.xml
+            coverage.svg
+      - uses: codecov/codecov-action@v4
+        with:
+          files: coverage.xml

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,27 @@
+import nox
+
+PYTHON_VERSIONS = ["3.10", "3.11"]
+LOCATIONS = ["services", "sidetrack", "tests", "noxfile.py"]
+
+nox.options.sessions = ["lint", "unit", "integration"]
+nox.options.reuse_existing_virtualenvs = True
+
+
+@nox.session(python=PYTHON_VERSIONS)
+def unit(session: nox.Session) -> None:
+    session.install("-r", "requirements-dev.txt")
+    session.install("-e", ".")
+    session.run("pytest", "-m", "unit")
+
+
+@nox.session(python=PYTHON_VERSIONS)
+def integration(session: nox.Session) -> None:
+    session.install("-r", "requirements-dev.txt")
+    session.install("-e", ".")
+    session.run("pytest", "-m", "integration")
+
+
+@nox.session(python=PYTHON_VERSIONS)
+def lint(session: nox.Session) -> None:
+    session.install("pre-commit")
+    session.run("pre-commit", "run", "--all-files")

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,10 @@
+[pytest]
+markers =
+    api: tests for API service
+    extractor: tests for extractor service
+    scheduler: tests for scheduler service
+    ui: tests for UI service
+    worker: tests for worker service
+    integration: integration tests
+    unit: unit tests
+addopts = --cov=services --cov-report=term-missing --cov-report=xml --cov-append


### PR DESCRIPTION
## Summary
- configure pytest with service markers and default coverage options
- add Nox sessions for linting, unit, and integration tests across Python 3.10 and 3.11
- set up GitHub Actions workflow to run Nox and publish coverage badge/report

## Testing
- `pytest -q`
- `pre-commit run --files pytest.ini noxfile.py .github/workflows/ci.yml`


------
https://chatgpt.com/codex/tasks/task_e_68bbb9a1f5e483338b9059afa2385c4e