### PR TITLE
Add Google account login endpoint

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -22,6 +22,7 @@ tenacity==8.2.3
 # Security & auth
 passlib[bcrypt]==1.7.4
 bcrypt==4.0.1
+google-auth==2.40.3
 
 # Audio & numeric processing
 numpy==1.26.4

--- a/services/api/requirements.txt
+++ b/services/api/requirements.txt
@@ -11,6 +11,7 @@ httpx[async]==0.27.0
 tenacity==8.2.3
 passlib[bcrypt]==1.7.4
 structlog==24.1.0
+google-auth==2.40.3
 opentelemetry-api==1.36.0
 opentelemetry-sdk==1.36.0
 opentelemetry-instrumentation-fastapi==0.57b0

--- a/sidetrack/api/api/v1/auth.py
+++ b/sidetrack/api/api/v1/auth.py
@@ -5,13 +5,17 @@ from datetime import datetime
 from hashlib import sha256
 
 from fastapi import APIRouter, Depends, HTTPException
+from fastapi.concurrency import run_in_threadpool
 from fastapi.security import OAuth2PasswordRequestForm
+from google.auth.transport import requests as google_requests
+from google.oauth2 import id_token
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sidetrack.common.models import UserAccount, UserSettings
 
+from ...config import Settings, get_settings
 from ...db import get_db
-from ...schemas.auth import Credentials, MeOut, UserOut
+from ...schemas.auth import Credentials, GoogleToken, MeOut, UserOut
 from ...security import hash_password, require_role, verify_password
 
 router = APIRouter()
@@ -67,3 +71,38 @@ async def me(
         lastfmUser=settings.lastfm_user if settings else None,
         lastfmConnected=bool(settings and settings.lastfm_session_key),
     )
+
+
+@router.post("/auth/google", response_model=UserOut)
+@router.post("/auth/continue/google", response_model=UserOut)
+async def continue_with_google(
+    payload: GoogleToken,
+    db: AsyncSession = Depends(get_db),
+    settings: Settings = Depends(get_settings),
+):
+    try:
+        info = await run_in_threadpool(
+            id_token.verify_oauth2_token,
+            payload.token,
+            google_requests.Request(),
+            settings.google_client_id,
+        )
+    except Exception:  # pragma: no cover - network/library errors
+        raise HTTPException(status_code=401, detail="Invalid token")
+
+    user_id = info.get("sub") or info.get("email")
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid token")
+
+    user = await db.get(UserAccount, user_id)
+    if not user:
+        user = UserAccount(
+            user_id=user_id,
+            password_hash=hash_password(secrets.token_urlsafe(16)),
+            created_at=datetime.utcnow(),
+        )
+        db.add(user)
+        await db.commit()
+        await db.refresh(user)
+
+    return UserOut.model_validate(user)

--- a/sidetrack/api/config.py
+++ b/sidetrack/api/config.py
@@ -22,6 +22,7 @@ class Settings(BaseSettings):
     listenbrainz_token: str | None = Field(default=None, env="LISTENBRAINZ_TOKEN")
     lastfm_api_key: str | None = Field(default=None, env="LASTFM_API_KEY")
     lastfm_api_secret: str | None = Field(default=None, env="LASTFM_API_SECRET")
+    google_client_id: str | None = Field(default=None, env="GOOGLE_CLIENT_ID")
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 

--- a/sidetrack/api/schemas/auth.py
+++ b/sidetrack/api/schemas/auth.py
@@ -6,6 +6,10 @@ class Credentials(BaseModel):
     password: str
 
 
+class GoogleToken(BaseModel):
+    token: str
+
+
 class UserOut(BaseModel):
     model_config = ConfigDict(from_attributes=True)
     user_id: str


### PR DESCRIPTION
## Summary
- allow signing in with a Google ID token
- store new Google users automatically and re-use on subsequent logins
- add google-auth dependency and configuration option for client id

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbbb737ba08333886cd5c1276c9102