### PR TITLE
Add Spotify OAuth integration

### DIFF
--- a/migrations/versions/6b1f90e2b8c7_add_spotify_columns_to_user_settings.py
+++ b/migrations/versions/6b1f90e2b8c7_add_spotify_columns_to_user_settings.py
@@ -1,0 +1,40 @@
+"""add spotify columns to user settings
+
+Revision ID: 6b1f90e2b8c7
+Revises: 2b6f8c1d7e90
+Create Date: 2024-10-07 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "6b1f90e2b8c7"
+down_revision: Union[str, None] = "2b6f8c1d7e90"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("user_settings", sa.Column("spotify_user", sa.String(length=128), nullable=True))
+    op.add_column(
+        "user_settings",
+        sa.Column("spotify_access_token", sa.String(length=512), nullable=True),
+    )
+    op.add_column(
+        "user_settings",
+        sa.Column("spotify_refresh_token", sa.String(length=512), nullable=True),
+    )
+    op.add_column(
+        "user_settings",
+        sa.Column("spotify_token_expires_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("user_settings", "spotify_token_expires_at")
+    op.drop_column("user_settings", "spotify_refresh_token")
+    op.drop_column("user_settings", "spotify_access_token")
+    op.drop_column("user_settings", "spotify_user")

--- a/services/ui/app/api/auth/spotify/callback/route.ts
+++ b/services/ui/app/api/auth/spotify/callback/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
+
+export async function GET(req: NextRequest) {
+  const code = req.nextUrl.searchParams.get('code') || '';
+  const callback = req.nextUrl.searchParams.get('callback') || '';
+  const headers: Record<string, string> = {};
+  const uid = req.headers.get('x-user-id');
+  if (uid) headers['X-User-Id'] = uid;
+  const r = await fetch(
+    `${API_BASE}/auth/spotify/callback?code=${encodeURIComponent(code)}&callback=${encodeURIComponent(callback)}`,
+    { headers }
+  );
+  const data = await r.json().catch(() => ({}));
+  return NextResponse.json(data, { status: r.status });
+}

--- a/services/ui/app/api/auth/spotify/disconnect/route.ts
+++ b/services/ui/app/api/auth/spotify/disconnect/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
+
+export async function DELETE(req: NextRequest) {
+  const headers: Record<string, string> = {};
+  const uid = req.headers.get('x-user-id');
+  if (uid) headers['X-User-Id'] = uid;
+  const r = await fetch(`${API_BASE}/auth/spotify/disconnect`, {
+    method: 'DELETE',
+    headers,
+  });
+  const data = await r.json().catch(() => ({}));
+  return NextResponse.json(data, { status: r.status });
+}

--- a/services/ui/app/api/auth/spotify/login/route.ts
+++ b/services/ui/app/api/auth/spotify/login/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
+
+export async function GET(req: NextRequest) {
+  const callback = req.nextUrl.searchParams.get('callback') || '';
+  const headers: Record<string, string> = {};
+  const uid = req.headers.get('x-user-id');
+  if (uid) headers['X-User-Id'] = uid;
+  const r = await fetch(`${API_BASE}/auth/spotify/login?callback=${encodeURIComponent(callback)}`, {
+    headers,
+  });
+  const data = await r.json().catch(() => ({}));
+  return NextResponse.json(data, { status: r.status });
+}

--- a/services/ui/app/settings/page.tsx
+++ b/services/ui/app/settings/page.tsx
@@ -7,6 +7,8 @@ interface SettingsData {
   listenBrainzToken: string;
   lastfmUser: string;
   lastfmConnected: boolean;
+  spotifyUser: string;
+  spotifyConnected: boolean;
   useGpu: boolean;
   useStems: boolean;
   useExcerpts: boolean;
@@ -17,6 +19,8 @@ export default function Settings() {
   const [lbToken, setLbToken] = useState('');
   const [lfmUser, setLfmUser] = useState('');
   const [lfmConnected, setLfmConnected] = useState(false);
+  const [spUser, setSpUser] = useState('');
+  const [spConnected, setSpConnected] = useState(false);
   const [useGpu, setUseGpu] = useState(false);
   const [useStems, setUseStems] = useState(false);
   const [useExcerpts, setUseExcerpts] = useState(false);
@@ -31,6 +35,8 @@ export default function Settings() {
         setLbToken(data.listenBrainzToken || '');
         setLfmUser(data.lastfmUser || '');
         setLfmConnected(!!data.lastfmConnected);
+        setSpUser(data.spotifyUser || '');
+        setSpConnected(!!data.spotifyConnected);
         setUseGpu(!!data.useGpu);
         setUseStems(!!data.useStems);
         setUseExcerpts(!!data.useExcerpts);
@@ -90,6 +96,21 @@ export default function Settings() {
     setLfmConnected(false);
   }
 
+  async function handleSpotifyConnect() {
+    const callback = encodeURIComponent(`${window.location.origin}/spotify/callback`);
+    const res = await fetch(`/api/auth/spotify/login?callback=${callback}`);
+    const data = await res.json().catch(() => ({}));
+    if (data.url) {
+      window.location.href = data.url;
+    }
+  }
+
+  async function handleSpotifyDisconnect() {
+    await fetch('/api/auth/spotify/disconnect', { method: 'DELETE' });
+    setSpUser('');
+    setSpConnected(false);
+  }
+
   return (
     <section>
       <h2>Settings</h2>
@@ -127,6 +148,21 @@ export default function Settings() {
           ) : (
             <button type="button" onClick={handleConnect}>
               Connect Last.fm
+            </button>
+          )}
+        </fieldset>
+        <fieldset>
+          <legend>Connect Spotify</legend>
+          {spConnected ? (
+            <div>
+              Connected as {spUser}{' '}
+              <button type="button" onClick={handleSpotifyDisconnect}>
+                Disconnect
+              </button>
+            </div>
+          ) : (
+            <button type="button" onClick={handleSpotifyConnect}>
+              Connect Spotify
             </button>
           )}
         </fieldset>

--- a/services/ui/app/spotify/callback/page.tsx
+++ b/services/ui/app/spotify/callback/page.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
+
+export default function SpotifyCallback() {
+  const params = useSearchParams();
+  const router = useRouter();
+
+  useEffect(() => {
+    const code = params.get('code');
+    if (code) {
+      const callback = encodeURIComponent(`${window.location.origin}/spotify/callback`);
+      fetch(`/api/auth/spotify/callback?code=${code}&callback=${callback}`)
+        .finally(() => router.replace('/settings'));
+    } else {
+      router.replace('/settings');
+    }
+  }, [params, router]);
+
+  return <p>Connecting to Spotify...</p>;
+}

--- a/sidetrack/api/clients/spotify.py
+++ b/sidetrack/api/clients/spotify.py
@@ -1,0 +1,73 @@
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import httpx
+from fastapi import Depends
+
+from ..config import Settings, get_settings
+
+
+class SpotifyClient:
+    """Minimal Spotify API client for OAuth and basic requests."""
+
+    auth_root = "https://accounts.spotify.com"
+    api_root = "https://api.spotify.com/v1"
+
+    def __init__(self, client: httpx.AsyncClient, client_id: str | None, client_secret: str | None) -> None:
+        self._client = client
+        self.client_id = client_id
+        self.client_secret = client_secret
+
+    def auth_url(self, callback: str, scope: str = "user-read-email") -> str:
+        if not self.client_id:
+            raise RuntimeError("SPOTIFY_CLIENT_ID not configured")
+        params = {
+            "response_type": "code",
+            "client_id": self.client_id,
+            "scope": scope,
+            "redirect_uri": callback,
+        }
+        return f"{self.auth_root}/authorize?" + httpx.QueryParams(params).render()
+
+    async def exchange_code(self, code: str, callback: str) -> dict[str, Any]:
+        if not self.client_id or not self.client_secret:
+            raise RuntimeError("Spotify credentials not configured")
+        data = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": callback,
+        }
+        auth = httpx.BasicAuth(self.client_id, self.client_secret)
+        resp = await self._client.post(
+            f"{self.auth_root}/api/token", data=data, auth=auth, timeout=30
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def refresh_token(self, refresh_token: str) -> dict[str, Any]:
+        if not self.client_id or not self.client_secret:
+            raise RuntimeError("Spotify credentials not configured")
+        data = {"grant_type": "refresh_token", "refresh_token": refresh_token}
+        auth = httpx.BasicAuth(self.client_id, self.client_secret)
+        resp = await self._client.post(
+            f"{self.auth_root}/api/token", data=data, auth=auth, timeout=30
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def get_current_user(self, access_token: str) -> dict[str, Any]:
+        headers = {"Authorization": f"Bearer {access_token}"}
+        resp = await self._client.get(f"{self.api_root}/me", headers=headers, timeout=30)
+        resp.raise_for_status()
+        return resp.json()
+
+
+async def get_spotify_client(
+    settings: Settings = Depends(get_settings),
+) -> AsyncGenerator[SpotifyClient, None]:
+    async with httpx.AsyncClient() as client:
+        yield SpotifyClient(
+            client,
+            settings.spotify_client_id,
+            settings.spotify_client_secret,
+        )

--- a/sidetrack/api/config.py
+++ b/sidetrack/api/config.py
@@ -22,6 +22,8 @@ class Settings(BaseSettings):
     listenbrainz_token: str | None = Field(default=None, env="LISTENBRAINZ_TOKEN")
     lastfm_api_key: str | None = Field(default=None, env="LASTFM_API_KEY")
     lastfm_api_secret: str | None = Field(default=None, env="LASTFM_API_SECRET")
+    spotify_client_id: str | None = Field(default=None, env="SPOTIFY_CLIENT_ID")
+    spotify_client_secret: str | None = Field(default=None, env="SPOTIFY_CLIENT_SECRET")
     google_client_id: str | None = Field(default=None, env="GOOGLE_CLIENT_ID")
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")

--- a/sidetrack/api/schemas/settings.py
+++ b/sidetrack/api/schemas/settings.py
@@ -15,6 +15,8 @@ class SettingsOut(BaseModel):
     listenBrainzToken: str | None = None
     lastfmUser: str | None = None
     lastfmConnected: bool = False
+    spotifyUser: str | None = None
+    spotifyConnected: bool = False
     useGpu: bool = False
     useStems: bool = False
     useExcerpts: bool = False

--- a/sidetrack/common/models.py
+++ b/sidetrack/common/models.py
@@ -176,6 +176,12 @@ class UserSettings(Base):
     lastfm_session_key: Mapped[str | None] = mapped_column(
         "lastfm_api_key", String(128), nullable=True
     )
+    spotify_user: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    spotify_access_token: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    spotify_refresh_token: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    spotify_token_expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     use_gpu: Mapped[bool] = mapped_column(Boolean, default=False)
     use_stems: Mapped[bool] = mapped_column(Boolean, default=False)
     use_excerpts: Mapped[bool] = mapped_column(Boolean, default=False)


### PR DESCRIPTION
## Summary
- add Spotify API client with OAuth helpers
- store Spotify tokens and user info in settings
- expose Spotify connection management in API and UI

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbbdc88a48833384a58f6ca5bf0fb0