### PR TITLE
Add Spotify listen import and scheduler job

### DIFF
--- a/migrations/versions/6b1f90e2b8c7_add_spotify_columns_to_user_settings.py
+++ b/migrations/versions/6b1f90e2b8c7_add_spotify_columns_to_user_settings.py
@@ -1,0 +1,40 @@
+"""add spotify columns to user settings
+
+Revision ID: 6b1f90e2b8c7
+Revises: 2b6f8c1d7e90
+Create Date: 2024-10-07 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "6b1f90e2b8c7"
+down_revision: Union[str, None] = "2b6f8c1d7e90"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("user_settings", sa.Column("spotify_user", sa.String(length=128), nullable=True))
+    op.add_column(
+        "user_settings",
+        sa.Column("spotify_access_token", sa.String(length=512), nullable=True),
+    )
+    op.add_column(
+        "user_settings",
+        sa.Column("spotify_refresh_token", sa.String(length=512), nullable=True),
+    )
+    op.add_column(
+        "user_settings",
+        sa.Column("spotify_token_expires_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("user_settings", "spotify_token_expires_at")
+    op.drop_column("user_settings", "spotify_refresh_token")
+    op.drop_column("user_settings", "spotify_access_token")
+    op.drop_column("user_settings", "spotify_user")

--- a/services/ui/app/api/auth/spotify/callback/route.ts
+++ b/services/ui/app/api/auth/spotify/callback/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
+
+export async function GET(req: NextRequest) {
+  const code = req.nextUrl.searchParams.get('code') || '';
+  const callback = req.nextUrl.searchParams.get('callback') || '';
+  const headers: Record<string, string> = {};
+  const uid = req.headers.get('x-user-id');
+  if (uid) headers['X-User-Id'] = uid;
+  const r = await fetch(
+    `${API_BASE}/auth/spotify/callback?code=${encodeURIComponent(code)}&callback=${encodeURIComponent(callback)}`,
+    { headers }
+  );
+  const data = await r.json().catch(() => ({}));
+  return NextResponse.json(data, { status: r.status });
+}

--- a/services/ui/app/api/auth/spotify/disconnect/route.ts
+++ b/services/ui/app/api/auth/spotify/disconnect/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
+
+export async function DELETE(req: NextRequest) {
+  const headers: Record<string, string> = {};
+  const uid = req.headers.get('x-user-id');
+  if (uid) headers['X-User-Id'] = uid;
+  const r = await fetch(`${API_BASE}/auth/spotify/disconnect`, {
+    method: 'DELETE',
+    headers,
+  });
+  const data = await r.json().catch(() => ({}));
+  return NextResponse.json(data, { status: r.status });
+}

--- a/services/ui/app/api/auth/spotify/login/route.ts
+++ b/services/ui/app/api/auth/spotify/login/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
+
+export async function GET(req: NextRequest) {
+  const callback = req.nextUrl.searchParams.get('callback') || '';
+  const headers: Record<string, string> = {};
+  const uid = req.headers.get('x-user-id');
+  if (uid) headers['X-User-Id'] = uid;
+  const r = await fetch(`${API_BASE}/auth/spotify/login?callback=${encodeURIComponent(callback)}`, {
+    headers,
+  });
+  const data = await r.json().catch(() => ({}));
+  return NextResponse.json(data, { status: r.status });
+}

--- a/services/ui/app/settings/page.tsx
+++ b/services/ui/app/settings/page.tsx
@@ -7,6 +7,8 @@ interface SettingsData {
   listenBrainzToken: string;
   lastfmUser: string;
   lastfmConnected: boolean;
+  spotifyUser: string;
+  spotifyConnected: boolean;
   useGpu: boolean;
   useStems: boolean;
   useExcerpts: boolean;
@@ -17,6 +19,8 @@ export default function Settings() {
   const [lbToken, setLbToken] = useState('');
   const [lfmUser, setLfmUser] = useState('');
   const [lfmConnected, setLfmConnected] = useState(false);
+  const [spUser, setSpUser] = useState('');
+  const [spConnected, setSpConnected] = useState(false);
   const [useGpu, setUseGpu] = useState(false);
   const [useStems, setUseStems] = useState(false);
   const [useExcerpts, setUseExcerpts] = useState(false);
@@ -31,6 +35,8 @@ export default function Settings() {
         setLbToken(data.listenBrainzToken || '');
         setLfmUser(data.lastfmUser || '');
         setLfmConnected(!!data.lastfmConnected);
+        setSpUser(data.spotifyUser || '');
+        setSpConnected(!!data.spotifyConnected);
         setUseGpu(!!data.useGpu);
         setUseStems(!!data.useStems);
         setUseExcerpts(!!data.useExcerpts);
@@ -90,6 +96,21 @@ export default function Settings() {
     setLfmConnected(false);
   }
 
+  async function handleSpotifyConnect() {
+    const callback = encodeURIComponent(`${window.location.origin}/spotify/callback`);
+    const res = await fetch(`/api/auth/spotify/login?callback=${callback}`);
+    const data = await res.json().catch(() => ({}));
+    if (data.url) {
+      window.location.href = data.url;
+    }
+  }
+
+  async function handleSpotifyDisconnect() {
+    await fetch('/api/auth/spotify/disconnect', { method: 'DELETE' });
+    setSpUser('');
+    setSpConnected(false);
+  }
+
   return (
     <section>
       <h2>Settings</h2>
@@ -127,6 +148,21 @@ export default function Settings() {
           ) : (
             <button type="button" onClick={handleConnect}>
               Connect Last.fm
+            </button>
+          )}
+        </fieldset>
+        <fieldset>
+          <legend>Connect Spotify</legend>
+          {spConnected ? (
+            <div>
+              Connected as {spUser}{' '}
+              <button type="button" onClick={handleSpotifyDisconnect}>
+                Disconnect
+              </button>
+            </div>
+          ) : (
+            <button type="button" onClick={handleSpotifyConnect}>
+              Connect Spotify
             </button>
           )}
         </fieldset>

--- a/services/ui/app/spotify/callback/page.tsx
+++ b/services/ui/app/spotify/callback/page.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
+
+export default function SpotifyCallback() {
+  const params = useSearchParams();
+  const router = useRouter();
+
+  useEffect(() => {
+    const code = params.get('code');
+    if (code) {
+      const callback = encodeURIComponent(`${window.location.origin}/spotify/callback`);
+      fetch(`/api/auth/spotify/callback?code=${code}&callback=${callback}`)
+        .finally(() => router.replace('/settings'));
+    } else {
+      router.replace('/settings');
+    }
+  }, [params, router]);
+
+  return <p>Connecting to Spotify...</p>;
+}

--- a/sidetrack/api/api/v1/__init__.py
+++ b/sidetrack/api/api/v1/__init__.py
@@ -1,9 +1,10 @@
 from fastapi import APIRouter
 
-from . import auth, dashboard, listens, musicbrainz
+from . import auth, dashboard, listens, musicbrainz, spotify
 
 router = APIRouter(prefix="/api/v1")
 router.include_router(auth.router)
 router.include_router(listens.router)
 router.include_router(musicbrainz.router)
 router.include_router(dashboard.router)
+router.include_router(spotify.router)

--- a/sidetrack/api/api/v1/spotify.py
+++ b/sidetrack/api/api/v1/spotify.py
@@ -1,0 +1,24 @@
+from fastapi import APIRouter, Depends
+
+from ...clients.spotify import SpotifyClient, get_spotify_client
+from ...config import Settings, get_settings
+from ...schemas.listens import IngestResponse
+from ...security import get_current_user
+from ...services.spotify_service import SpotifyService, get_spotify_service
+
+router = APIRouter()
+
+
+@router.post("/spotify/listens", response_model=IngestResponse)
+async def import_spotify_listens(
+    spotify_service: SpotifyService = Depends(get_spotify_service),
+    spotify_client: SpotifyClient = Depends(get_spotify_client),
+    settings: Settings = Depends(get_settings),
+    user_id: str = Depends(get_current_user),
+):
+    token = settings.spotify_token
+    if not token:
+        return IngestResponse(detail="missing token", ingested=0, source="spotify")
+    items = await spotify_client.fetch_recently_played(token)
+    created = await spotify_service.ingest_recently_played(items, user_id)
+    return IngestResponse(detail="ok", ingested=created, source="spotify")

--- a/sidetrack/api/clients/spotify.py
+++ b/sidetrack/api/clients/spotify.py
@@ -1,11 +1,12 @@
-from __future__ import annotations
-
 from collections.abc import AsyncGenerator
 from datetime import datetime
 from typing import Any
 
 import httpx
+from fastapi import Depends
 from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
+
+from ..config import Settings, get_settings
 
 
 def _retryable(exc: Exception) -> bool:
@@ -24,12 +25,60 @@ _retry = retry(
 
 
 class SpotifyClient:
-    """Client for the Spotify API."""
+    """Spotify API client for OAuth and basic requests."""
 
-    base_url = "https://api.spotify.com/v1"
+    auth_root = "https://accounts.spotify.com"
+    api_root = "https://api.spotify.com/v1"
 
-    def __init__(self, client: httpx.AsyncClient) -> None:
+    def __init__(
+        self, client: httpx.AsyncClient, client_id: str | None, client_secret: str | None
+    ) -> None:
         self._client = client
+        self.client_id = client_id
+        self.client_secret = client_secret
+
+    def auth_url(self, callback: str, scope: str = "user-read-email") -> str:
+        if not self.client_id:
+            raise RuntimeError("SPOTIFY_CLIENT_ID not configured")
+        params = {
+            "response_type": "code",
+            "client_id": self.client_id,
+            "scope": scope,
+            "redirect_uri": callback,
+        }
+        return f"{self.auth_root}/authorize?" + httpx.QueryParams(params).render()
+
+    async def exchange_code(self, code: str, callback: str) -> dict[str, Any]:
+        if not self.client_id or not self.client_secret:
+            raise RuntimeError("Spotify credentials not configured")
+        data = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": callback,
+        }
+        auth = httpx.BasicAuth(self.client_id, self.client_secret)
+        resp = await self._client.post(
+            f"{self.auth_root}/api/token", data=data, auth=auth, timeout=30
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def refresh_token(self, refresh_token: str) -> dict[str, Any]:
+        if not self.client_id or not self.client_secret:
+            raise RuntimeError("Spotify credentials not configured")
+        data = {"grant_type": "refresh_token", "refresh_token": refresh_token}
+        auth = httpx.BasicAuth(self.client_id, self.client_secret)
+        resp = await self._client.post(
+            f"{self.auth_root}/api/token", data=data, auth=auth, timeout=30
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def get_current_user(self, access_token: str) -> dict[str, Any]:
+        headers = {"Authorization": f"Bearer {access_token}"}
+        resp = await self._client.get(f"{self.api_root}/me", headers=headers, timeout=30)
+        resp.raise_for_status()
+        return resp.json()
 
     @_retry
     async def _get(self, url: str, **kwargs: Any) -> httpx.Response:
@@ -48,11 +97,20 @@ class SpotifyClient:
         params: dict[str, Any] = {"limit": min(limit, 50)}
         if after:
             params["after"] = int(after.timestamp() * 1000)  # milliseconds
-        r = await self._get(f"{self.base_url}/me/player/recently-played", headers=headers, params=params)
-        data = r.json()
+        resp = await self._get(
+            f"{self.api_root}/me/player/recently-played", headers=headers, params=params
+        )
+        data = resp.json()
         return data.get("items", [])
 
 
-async def get_spotify_client() -> AsyncGenerator[SpotifyClient, None]:
+async def get_spotify_client(
+    settings: Settings = Depends(get_settings),
+) -> AsyncGenerator[SpotifyClient, None]:
     async with httpx.AsyncClient() as client:
-        yield SpotifyClient(client)
+        yield SpotifyClient(
+            client,
+            settings.spotify_client_id,
+            settings.spotify_client_secret,
+        )
+

--- a/sidetrack/api/clients/spotify.py
+++ b/sidetrack/api/clients/spotify.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from datetime import datetime
+from typing import Any
+
+import httpx
+from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
+
+
+def _retryable(exc: Exception) -> bool:
+    if isinstance(exc, httpx.HTTPStatusError):
+        status = exc.response.status_code
+        return status >= 500 or status == 429
+    return isinstance(exc, httpx.RequestError)
+
+
+_retry = retry(
+    reraise=True,
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=1, max=4),
+    retry=retry_if_exception(_retryable),
+)
+
+
+class SpotifyClient:
+    """Client for the Spotify API."""
+
+    base_url = "https://api.spotify.com/v1"
+
+    def __init__(self, client: httpx.AsyncClient) -> None:
+        self._client = client
+
+    @_retry
+    async def _get(self, url: str, **kwargs: Any) -> httpx.Response:
+        resp = await self._client.get(url, timeout=30, **kwargs)
+        resp.raise_for_status()
+        return resp
+
+    async def fetch_recently_played(
+        self,
+        token: str,
+        after: datetime | None = None,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        """Fetch the current user's recently played tracks."""
+        headers = {"Authorization": f"Bearer {token}"}
+        params: dict[str, Any] = {"limit": min(limit, 50)}
+        if after:
+            params["after"] = int(after.timestamp() * 1000)  # milliseconds
+        r = await self._get(f"{self.base_url}/me/player/recently-played", headers=headers, params=params)
+        data = r.json()
+        return data.get("items", [])
+
+
+async def get_spotify_client() -> AsyncGenerator[SpotifyClient, None]:
+    async with httpx.AsyncClient() as client:
+        yield SpotifyClient(client)

--- a/sidetrack/api/config.py
+++ b/sidetrack/api/config.py
@@ -23,6 +23,7 @@ class Settings(BaseSettings):
     lastfm_api_key: str | None = Field(default=None, env="LASTFM_API_KEY")
     lastfm_api_secret: str | None = Field(default=None, env="LASTFM_API_SECRET")
     google_client_id: str | None = Field(default=None, env="GOOGLE_CLIENT_ID")
+    spotify_token: str | None = Field(default=None, env="SPOTIFY_TOKEN")
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 

--- a/sidetrack/api/config.py
+++ b/sidetrack/api/config.py
@@ -22,6 +22,8 @@ class Settings(BaseSettings):
     listenbrainz_token: str | None = Field(default=None, env="LISTENBRAINZ_TOKEN")
     lastfm_api_key: str | None = Field(default=None, env="LASTFM_API_KEY")
     lastfm_api_secret: str | None = Field(default=None, env="LASTFM_API_SECRET")
+    spotify_client_id: str | None = Field(default=None, env="SPOTIFY_CLIENT_ID")
+    spotify_client_secret: str | None = Field(default=None, env="SPOTIFY_CLIENT_SECRET")
     google_client_id: str | None = Field(default=None, env="GOOGLE_CLIENT_ID")
     spotify_token: str | None = Field(default=None, env="SPOTIFY_TOKEN")
 

--- a/sidetrack/api/repositories/track_repository.py
+++ b/sidetrack/api/repositories/track_repository.py
@@ -29,3 +29,25 @@ class TrackRepository:
             duration=duration,
             path_local=path_local,
         )
+
+    async def get_or_create_spotify(
+        self,
+        spotify_id: str,
+        title: str,
+        artist_id: int,
+        release_id: int | None = None,
+        duration: int | None = None,
+    ) -> Track:
+        """Get or create a track using the Spotify track ID."""
+        defaults = {
+            "title": title,
+            "artist_id": artist_id,
+            "release_id": release_id,
+            "duration": duration,
+        }
+        return await get_or_create(
+            self.db,
+            Track,
+            defaults=defaults,
+            spotify_id=spotify_id,
+        )

--- a/sidetrack/api/schemas/settings.py
+++ b/sidetrack/api/schemas/settings.py
@@ -15,6 +15,8 @@ class SettingsOut(BaseModel):
     listenBrainzToken: str | None = None
     lastfmUser: str | None = None
     lastfmConnected: bool = False
+    spotifyUser: str | None = None
+    spotifyConnected: bool = False
     useGpu: bool = False
     useStems: bool = False
     useExcerpts: bool = False

--- a/sidetrack/api/services/spotify_service.py
+++ b/sidetrack/api/services/spotify_service.py
@@ -1,0 +1,62 @@
+from datetime import datetime
+
+from fastapi import Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..db import get_db
+from ..repositories.artist_repository import ArtistRepository
+from ..repositories.listen_repository import ListenRepository
+from ..repositories.track_repository import TrackRepository
+
+
+class SpotifyService:
+    """Service for importing Spotify listen history."""
+
+    def __init__(
+        self,
+        artist_repo: ArtistRepository,
+        track_repo: TrackRepository,
+        listen_repo: ListenRepository,
+    ) -> None:
+        self.artists = artist_repo
+        self.tracks = track_repo
+        self.listens = listen_repo
+
+    async def ingest_recently_played(
+        self, items: list[dict], user_id: str
+    ) -> int:
+        """Ingest Spotify recently played items."""
+        created = 0
+        for item in items:
+            track = item.get("track") or {}
+            spotify_id = track.get("id")
+            if not spotify_id:
+                continue
+            artist_name = (
+                (track.get("artists") or [{}])[0].get("name") or "Unknown"
+            )
+            track_title = track.get("name") or "Unknown"
+            duration_ms = track.get("duration_ms")
+            played_at_str = item.get("played_at")
+            if not played_at_str:
+                continue
+            played_at = datetime.fromisoformat(played_at_str.replace("Z", "+00:00"))
+            artist = await self.artists.get_or_create(name=artist_name)
+            db_track = await self.tracks.get_or_create_spotify(
+                spotify_id=spotify_id,
+                title=track_title,
+                artist_id=artist.artist_id,
+                duration=int(duration_ms / 1000) if duration_ms else None,
+            )
+            if not await self.listens.exists(user_id, db_track.track_id, played_at):
+                await self.listens.add(user_id, db_track.track_id, played_at, "spotify")
+                created += 1
+        await self.listens.commit()
+        return created
+
+
+def get_spotify_service(db: AsyncSession = Depends(get_db)) -> SpotifyService:
+    artist_repo = ArtistRepository(db)
+    track_repo = TrackRepository(db)
+    listen_repo = ListenRepository(db)
+    return SpotifyService(artist_repo, track_repo, listen_repo)

--- a/sidetrack/common/models.py
+++ b/sidetrack/common/models.py
@@ -52,6 +52,7 @@ class Track(Base):
 
     track_id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     mbid: Mapped[str | None] = mapped_column(String(36), index=True)
+    spotify_id: Mapped[str | None] = mapped_column(String(64), index=True)
     title: Mapped[str] = mapped_column(String(512), index=True)
     artist_id: Mapped[int | None] = mapped_column(ForeignKey("artist.artist_id"))
     release_id: Mapped[int | None] = mapped_column(ForeignKey("release.release_id"))

--- a/sidetrack/common/models.py
+++ b/sidetrack/common/models.py
@@ -177,6 +177,12 @@ class UserSettings(Base):
     lastfm_session_key: Mapped[str | None] = mapped_column(
         "lastfm_api_key", String(128), nullable=True
     )
+    spotify_user: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    spotify_access_token: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    spotify_refresh_token: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    spotify_token_expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
     use_gpu: Mapped[bool] = mapped_column(Boolean, default=False)
     use_stems: Mapped[bool] = mapped_column(Boolean, default=False)
     use_excerpts: Mapped[bool] = mapped_column(Boolean, default=False)

--- a/sidetrack/scheduler/config.py
+++ b/sidetrack/scheduler/config.py
@@ -14,6 +14,9 @@ class SchedulerSettings(BaseSettings):
     ingest_listens_interval_minutes: float = Field(1.0, env="INGEST_LISTENS_INTERVAL_MINUTES")
     lastfm_sync_interval_minutes: float = Field(30.0, env="LASTFM_SYNC_INTERVAL_MINUTES")
     aggregate_weeks_interval_minutes: float = Field(60 * 24, env="AGGREGATE_WEEKS_INTERVAL_MINUTES")
+    spotify_listens_interval_minutes: float = Field(
+        10.0, env="SPOTIFY_LISTENS_INTERVAL_MINUTES"
+    )
 
 
 @lru_cache

--- a/sidetrack/scheduler/run.py
+++ b/sidetrack/scheduler/run.py
@@ -48,13 +48,27 @@ def aggregate_weeks():
         logger.exception("aggregate weeks error")
 
 
+def fetch_spotify_listens():
+    try:
+        r = requests.post(
+            f"{settings.api_url}/spotify/listens",
+            timeout=10,
+            headers={"X-User-Id": settings.default_user_id},
+        )
+        logger.info("spotify listens: %s", r.status_code)
+    except Exception:
+        logger.exception("spotify listens error")
+
+
 def schedule_jobs():
     ingest_minutes = settings.ingest_listens_interval_minutes
     tags_minutes = settings.lastfm_sync_interval_minutes
     agg_minutes = settings.aggregate_weeks_interval_minutes
+    spotify_minutes = settings.spotify_listens_interval_minutes
     schedule.every(ingest_minutes).minutes.do(ingest_listens)
     schedule.every(tags_minutes).minutes.do(sync_lastfm_tags)
     schedule.every(agg_minutes).minutes.do(aggregate_weeks)
+    schedule.every(spotify_minutes).minutes.do(fetch_spotify_listens)
 
 
 def main():

--- a/tests/test_spotify.py
+++ b/tests/test_spotify.py
@@ -1,0 +1,41 @@
+import pytest
+from sqlalchemy import select
+
+from sidetrack.api.clients import spotify as spotify_module
+from sidetrack.common.models import Listen, Track
+
+
+@pytest.mark.asyncio
+async def test_import_spotify_listens(async_client, async_session, monkeypatch):
+    monkeypatch.setenv("SPOTIFY_TOKEN", "tok")
+
+    sample = [
+        {
+            "track": {
+                "id": "s1",
+                "name": "Song",
+                "artists": [{"name": "Artist"}],
+                "duration_ms": 60000,
+            },
+            "played_at": "2024-01-01T00:00:00Z",
+        }
+    ]
+
+    async def fake_fetch(self, token, after=None, limit=50):
+        assert token == "tok"
+        return sample
+
+    monkeypatch.setattr(
+        spotify_module.SpotifyClient, "fetch_recently_played", fake_fetch
+    )
+
+    resp = await async_client.post(
+        "/api/v1/spotify/listens", headers={"X-User-Id": "user1"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["ingested"] == 1
+
+    listens = (await async_session.execute(select(Listen))).scalars().all()
+    assert len(listens) == 1
+    tracks = (await async_session.execute(select(Track))).scalars().all()
+    assert tracks[0].spotify_id == "s1"


### PR DESCRIPTION
## Summary
- add Spotify client and service to import recently played tracks
- expose `/spotify/listens` API endpoint for triggering Spotify history import
- schedule periodic Spotify listen imports and support track lookup by Spotify IDs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bbbdf4a8448333a36a9c32ce7bd1bd