### PR TITLE
Add Spotify listen import and scheduler integration

### DIFF
--- a/services/api/tests/test_spotify_listens.py
+++ b/services/api/tests/test_spotify_listens.py
@@ -1,0 +1,41 @@
+import pytest
+from sqlalchemy import select
+
+from sidetrack.api.clients.spotify import SpotifyClient
+from sidetrack.common.models import Listen, UserSettings
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_spotify_listens_ingest(async_client, async_session, monkeypatch):
+    # create user settings with access token
+    async_session.add(UserSettings(user_id="u1", spotify_access_token="tok"))
+    await async_session.commit()
+
+    async def fake_fetch(self, token, after=None, limit=50):
+        return [
+            {
+                "track": {
+                    "id": "sp1",
+                    "name": "Song",
+                    "artists": [{"name": "Artist"}],
+                },
+                "played_at": "2024-01-01T00:00:00.000Z",
+            }
+        ]
+
+    monkeypatch.setattr(SpotifyClient, "fetch_recently_played", fake_fetch)
+
+    r = await async_client.post("/api/v1/spotify/listens", headers={"X-User-Id": "u1"})
+    assert r.status_code == 200
+    assert r.json()["ingested"] == 1
+
+    # second call should ingest nothing new
+    r = await async_client.post("/api/v1/spotify/listens", headers={"X-User-Id": "u1"})
+    assert r.status_code == 200
+    assert r.json()["ingested"] == 0
+
+    res = await async_session.execute(select(Listen))
+    assert len(res.scalars().all()) == 1
+

--- a/services/scheduler/test_scheduler.py
+++ b/services/scheduler/test_scheduler.py
@@ -20,6 +20,7 @@ def test_all_jobs_run(monkeypatch):
 
     monkeypatch.setenv("API_URL", "http://api")
     monkeypatch.setenv("INGEST_LISTENS_INTERVAL_MINUTES", "1")
+    monkeypatch.setenv("SPOTIFY_LISTENS_INTERVAL_MINUTES", "1")
     monkeypatch.setenv("LASTFM_SYNC_INTERVAL_MINUTES", "1")
     monkeypatch.setenv("AGGREGATE_WEEKS_INTERVAL_MINUTES", "1")
     monkeypatch.setenv("DEFAULT_USER_ID", "u1")
@@ -34,5 +35,6 @@ def test_all_jobs_run(monkeypatch):
 
     expected_headers = {"X-User-Id": "u1"}
     assert ("http://api/ingest/listens", expected_headers) in calls
+    assert ("http://api/spotify/listens", expected_headers) in calls
     assert ("http://api/tags/lastfm/sync", expected_headers) in calls
     assert ("http://api/aggregate/weeks", expected_headers) in calls

--- a/sidetrack/api/api/v1/__init__.py
+++ b/sidetrack/api/api/v1/__init__.py
@@ -1,9 +1,10 @@
 from fastapi import APIRouter
 
-from . import auth, dashboard, listens, musicbrainz
+from . import auth, dashboard, listens, musicbrainz, spotify
 
 router = APIRouter(prefix="/api/v1")
 router.include_router(auth.router)
 router.include_router(listens.router)
 router.include_router(musicbrainz.router)
 router.include_router(dashboard.router)
+router.include_router(spotify.router)

--- a/sidetrack/api/api/v1/spotify.py
+++ b/sidetrack/api/api/v1/spotify.py
@@ -1,0 +1,64 @@
+"""Spotify integration endpoints."""
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sidetrack.common.models import UserSettings
+
+from ...clients.spotify import SpotifyClient, get_spotify_client
+from ...db import get_db
+from ...repositories.artist_repository import ArtistRepository
+from ...repositories.listen_repository import ListenRepository
+from ...repositories.track_repository import TrackRepository
+from ...security import get_current_user
+
+
+router = APIRouter()
+
+
+@router.post("/spotify/listens")
+async def import_spotify_listens(
+    sp_client: SpotifyClient = Depends(get_spotify_client),
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(get_current_user),
+):
+    """Fetch and ingest the user's recent Spotify listens."""
+
+    row = (
+        await db.execute(select(UserSettings).where(UserSettings.user_id == user_id))
+    ).scalar_one_or_none()
+    if not row or not row.spotify_access_token:
+        raise HTTPException(status_code=400, detail="Spotify not connected")
+
+    items = await sp_client.fetch_recently_played(row.spotify_access_token)
+
+    artist_repo = ArtistRepository(db)
+    track_repo = TrackRepository(db)
+    listen_repo = ListenRepository(db)
+
+    created = 0
+    for item in items:
+        track_data = item.get("track") or {}
+        spotify_id = track_data.get("id")
+        if not spotify_id:
+            continue
+
+        artist_name = (track_data.get("artists") or [{}])[0].get("name") or "Unknown"
+        title = track_data.get("name") or "Unknown"
+        played_at = datetime.fromisoformat(item["played_at"].replace("Z", "+00:00"))
+
+        artist = await artist_repo.get_or_create(artist_name)
+        track = await track_repo.get_or_create_spotify(
+            spotify_id, title, artist.artist_id
+        )
+
+        if not await listen_repo.exists(user_id, track.track_id, played_at):
+            await listen_repo.add(user_id, track.track_id, played_at, "spotify")
+            created += 1
+
+    await listen_repo.commit()
+    return {"detail": "ok", "ingested": created}
+

--- a/sidetrack/api/repositories/track_repository.py
+++ b/sidetrack/api/repositories/track_repository.py
@@ -29,3 +29,24 @@ class TrackRepository:
             duration=duration,
             path_local=path_local,
         )
+
+    async def get_or_create_spotify(
+        self,
+        spotify_id: str,
+        title: str,
+        artist_id: int,
+        release_id: int | None = None,
+        duration: int | None = None,
+    ) -> Track:
+        defaults = {
+            "title": title,
+            "artist_id": artist_id,
+            "release_id": release_id,
+            "duration": duration,
+        }
+        return await get_or_create(
+            self.db,
+            Track,
+            defaults=defaults,
+            spotify_id=spotify_id,
+        )

--- a/sidetrack/common/models.py
+++ b/sidetrack/common/models.py
@@ -52,6 +52,7 @@ class Track(Base):
 
     track_id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     mbid: Mapped[str | None] = mapped_column(String(36), index=True)
+    spotify_id: Mapped[str | None] = mapped_column(String(64), index=True)
     title: Mapped[str] = mapped_column(String(512), index=True)
     artist_id: Mapped[int | None] = mapped_column(ForeignKey("artist.artist_id"))
     release_id: Mapped[int | None] = mapped_column(ForeignKey("release.release_id"))

--- a/sidetrack/scheduler/config.py
+++ b/sidetrack/scheduler/config.py
@@ -12,6 +12,7 @@ class SchedulerSettings(BaseSettings):
     api_url: str = Field("http://api:8000", env="API_URL")
     default_user_id: str | None = Field(default=None, env="DEFAULT_USER_ID")
     ingest_listens_interval_minutes: float = Field(1.0, env="INGEST_LISTENS_INTERVAL_MINUTES")
+    spotify_listens_interval_minutes: float = Field(5.0, env="SPOTIFY_LISTENS_INTERVAL_MINUTES")
     lastfm_sync_interval_minutes: float = Field(30.0, env="LASTFM_SYNC_INTERVAL_MINUTES")
     aggregate_weeks_interval_minutes: float = Field(60 * 24, env="AGGREGATE_WEEKS_INTERVAL_MINUTES")
 

--- a/sidetrack/scheduler/run.py
+++ b/sidetrack/scheduler/run.py
@@ -24,6 +24,18 @@ def ingest_listens():
         logger.exception("ingest listens error")
 
 
+def import_spotify_listens():
+    try:
+        r = requests.post(
+            f"{settings.api_url}/spotify/listens",
+            timeout=10,
+            headers={"X-User-Id": settings.default_user_id},
+        )
+        logger.info("spotify listens: %s", r.status_code)
+    except Exception:
+        logger.exception("spotify listens error")
+
+
 def sync_lastfm_tags():
     try:
         r = requests.post(
@@ -50,9 +62,11 @@ def aggregate_weeks():
 
 def schedule_jobs():
     ingest_minutes = settings.ingest_listens_interval_minutes
+    spotify_minutes = settings.spotify_listens_interval_minutes
     tags_minutes = settings.lastfm_sync_interval_minutes
     agg_minutes = settings.aggregate_weeks_interval_minutes
     schedule.every(ingest_minutes).minutes.do(ingest_listens)
+    schedule.every(spotify_minutes).minutes.do(import_spotify_listens)
     schedule.every(tags_minutes).minutes.do(sync_lastfm_tags)
     schedule.every(agg_minutes).minutes.do(aggregate_weeks)
 

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -19,6 +19,7 @@ class TrackFactory(factory.Factory):
     release_id = None
     duration = None
     fingerprint = None
+    spotify_id = None
 
 
 


### PR DESCRIPTION
## Summary
- add Spotify client support for recently played tracks
- expose `/api/v1/spotify/listens` endpoint to import history
- schedule periodic Spotify listen imports

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbccaf19fc8333ae179ab1a8d71183