### PR TITLE
Add Spotify audio features backfill pipeline

### DIFF
--- a/migrations/versions/1cdd5f4b8e41_add_spotify_id_to_track.py
+++ b/migrations/versions/1cdd5f4b8e41_add_spotify_id_to_track.py
@@ -1,0 +1,27 @@
+"""add spotify_id to track
+
+Revision ID: 1cdd5f4b8e41
+Revises: 6b1f90e2b8c7
+Create Date: 2024-10-08 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "1cdd5f4b8e41"
+down_revision: Union[str, None] = "6b1f90e2b8c7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("track", sa.Column("spotify_id", sa.String(length=64), nullable=True))
+    op.create_index(op.f("ix_track_spotify_id"), "track", ["spotify_id"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_track_spotify_id"), table_name="track")
+    op.drop_column("track", "spotify_id")

--- a/services/api/tests/test_spotify_features.py
+++ b/services/api/tests/test_spotify_features.py
@@ -1,0 +1,63 @@
+import pytest
+from sqlalchemy import select
+
+from sidetrack.api.clients.spotify import SpotifyClient
+from sidetrack.common.models import Feature, UserSettings
+from tests.factories import TrackFactory
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_spotify_feature_backfill(async_client, async_session, monkeypatch):
+    track = TrackFactory(spotify_id="sp123")
+    async_session.add_all([track, UserSettings(user_id="u1", spotify_access_token="tok")])
+    await async_session.flush()
+    tid = track.track_id
+    await async_session.commit()
+
+    async def fake_audio_features(self, token, sid):
+        assert token == "tok"
+        assert sid == "sp123"
+        return {"tempo": 100.0, "key": 5, "mode": 1, "energy": 0.8}
+
+    monkeypatch.setattr(SpotifyClient, "get_audio_features", fake_audio_features)
+
+    r = await async_client.post(f"/api/v1/spotify/features/{tid}", headers={"X-User-Id": "u1"})
+    assert r.status_code == 200
+    assert r.json()["status"] == "created"
+
+    res = await async_session.execute(select(Feature).where(Feature.track_id == tid))
+    feat = res.scalar_one()
+    assert feat.bpm == 100.0
+    assert feat.pumpiness == 0.8
+    assert feat.key == "F major"
+
+    # second call should detect existing feature
+    r = await async_client.post(f"/api/v1/spotify/features/{tid}", headers={"X-User-Id": "u1"})
+    assert r.status_code == 200
+    assert r.json()["status"] == "exists"
+
+
+async def test_spotify_feature_batch(async_client, async_session, monkeypatch):
+    t1 = TrackFactory(spotify_id="a1")
+    t2 = TrackFactory(spotify_id="a2")
+    async_session.add_all([t1, t2, UserSettings(user_id="u1", spotify_access_token="tok")])
+    await async_session.flush()
+    t1_id, t2_id = t1.track_id, t2.track_id
+    await async_session.commit()
+
+    calls: list[str] = []
+
+    async def fake_audio_features(self, token, sid):
+        calls.append(sid)
+        return {"tempo": 90.0, "key": 0, "mode": 1, "energy": 0.5}
+
+    monkeypatch.setattr(SpotifyClient, "get_audio_features", fake_audio_features)
+
+    r = await async_client.post("/api/v1/spotify/features/backfill", headers={"X-User-Id": "u1"})
+    assert r.status_code == 200
+    assert r.json()["backfilled"] == 2
+    assert set(calls) == {"a1", "a2"}
+
+    res = await async_session.execute(select(Feature).where(Feature.track_id.in_([t1_id, t2_id])))
+    assert len(res.scalars().all()) == 2

--- a/sidetrack/api/api/v1/spotify.py
+++ b/sidetrack/api/api/v1/spotify.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from sidetrack.common.models import UserSettings
+from sidetrack.common.models import Feature, Track, UserSettings
 
 from ...clients.spotify import SpotifyClient, get_spotify_client
 from ...db import get_db
@@ -14,6 +14,7 @@ from ...repositories.artist_repository import ArtistRepository
 from ...repositories.listen_repository import ListenRepository
 from ...repositories.track_repository import TrackRepository
 from ...security import get_current_user
+from ....worker.jobs import fetch_spotify_features
 
 
 router = APIRouter()
@@ -61,4 +62,64 @@ async def import_spotify_listens(
 
     await listen_repo.commit()
     return {"detail": "ok", "ingested": created}
+
+
+@router.post("/spotify/features/backfill")
+async def spotify_features_backfill(
+    sp_client: SpotifyClient = Depends(get_spotify_client),
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(get_current_user),
+):
+    """Backfill Spotify features for all tracks missing them."""
+
+    row = (
+        await db.execute(select(UserSettings).where(UserSettings.user_id == user_id))
+    ).scalar_one_or_none()
+    if not row or not row.spotify_access_token:
+        raise HTTPException(status_code=400, detail="Spotify not connected")
+
+    stmt = (
+        select(Track)
+        .outerjoin(Feature, Feature.track_id == Track.track_id)
+        .where(Track.spotify_id.is_not(None))
+        .where(Feature.track_id.is_(None))
+    )
+    tracks = (await db.execute(stmt)).scalars().all()
+    count = 0
+    for track in tracks:
+        try:
+            await fetch_spotify_features(track.track_id, row.spotify_access_token, sp_client)
+            count += 1
+        except Exception:
+            continue
+    return {"detail": "ok", "backfilled": count}
+
+
+@router.post("/spotify/features/{track_id}")
+async def spotify_track_features(
+    track_id: int,
+    sp_client: SpotifyClient = Depends(get_spotify_client),
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(get_current_user),
+):
+    """Backfill or retrieve Spotify audio features for a track."""
+
+    row = (
+        await db.execute(select(UserSettings).where(UserSettings.user_id == user_id))
+    ).scalar_one_or_none()
+    if not row or not row.spotify_access_token:
+        raise HTTPException(status_code=400, detail="Spotify not connected")
+
+    track = await db.get(Track, track_id)
+    if not track or not track.spotify_id:
+        raise HTTPException(status_code=404, detail="Track not found")
+
+    feature = (
+        await db.execute(select(Feature).where(Feature.track_id == track_id))
+    ).scalar_one_or_none()
+    if feature:
+        return {"detail": "ok", "status": "exists", "feature_id": feature.id}
+
+    fid = await fetch_spotify_features(track_id, row.spotify_access_token, sp_client)
+    return {"detail": "ok", "status": "created", "feature_id": fid}
 

--- a/sidetrack/api/clients/spotify.py
+++ b/sidetrack/api/clients/spotify.py
@@ -94,6 +94,18 @@ class SpotifyClient:
         resp.raise_for_status()
         return resp.json().get("items", [])
 
+    async def get_audio_features(self, access_token: str, spotify_id: str) -> dict[str, Any]:
+        """Return Spotify's audio features for a track."""
+
+        headers = {"Authorization": f"Bearer {access_token}"}
+        resp = await self._client.get(
+            f"{self.api_root}/audio-features/{spotify_id}",
+            headers=headers,
+            timeout=30,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
 
 async def get_spotify_client(
     settings: Settings = Depends(get_settings),

--- a/sidetrack/worker/__init__.py
+++ b/sidetrack/worker/__init__.py
@@ -1,4 +1,4 @@
 # Worker package exposing background job functions.
-from .jobs import analyze_track, compute_embeddings
+from .jobs import analyze_track, compute_embeddings, fetch_spotify_features
 
-__all__ = ["analyze_track", "compute_embeddings"]
+__all__ = ["analyze_track", "compute_embeddings", "fetch_spotify_features"]


### PR DESCRIPTION
## Summary
- add migration to store `spotify_id` on tracks
- implement Spotify audio feature fetching and backfill endpoints
- include worker job and tests for feature backfill

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bde1ddc2808333a2ad45340f4235d1