### PR TITLE
Use sidetrack package in API image

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -21,7 +21,7 @@ services:
     env_file: .env
     depends_on: [db]
     ports: ["8000:8000"]
-    command: bash -c "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000"
+    command: bash -c "alembic upgrade head && uvicorn sidetrack.api.main:app --host 0.0.0.0 --port 8000"
 
   extractor:
     build:

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -11,6 +11,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     && rm -rf /var/lib/apt/lists/*
 
+# Copy sidetrack package
+COPY sidetrack/ /srv/api/sidetrack/
+
 # Copy API sources (package, alembic, config)
 COPY services/api/ /srv/api/
 
@@ -22,4 +25,4 @@ COPY services/common /src/services/common
 ENV PYTHONPATH=/src
 
 EXPOSE 8000
-CMD ["uvicorn","app.main:app","--host","0.0.0.0","--port","8000"]
+CMD ["uvicorn", "sidetrack.api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/api/pyproject.toml
+++ b/services/api/pyproject.toml
@@ -30,8 +30,8 @@ dependencies = [
 ]
 
 [tool.setuptools]
-packages = ["app"]
+packages = ["sidetrack"]
 include-package-data = true
 
 [tool.setuptools.package-data]
-"app" = ["model_data/*.json"]
+"sidetrack.api" = ["model_data/*.json"]


### PR DESCRIPTION
## Summary
- package sidetrack instead of app for API service
- copy sidetrack code into API container and run main app via sidetrack.api
- update compose command to launch API from new module path

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `docker compose build api` *(fails: command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bde89c045c83338d2331a81a45344a