### PR TITLE
Configure sidetrack.network domain

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,13 +19,13 @@ LASTFM_API_KEY=lfm_xxx
 LASTFM_API_SECRET=lfm_secret
 
 # Auth.js (NextAuth) – Google OAuth
-NEXTAUTH_URL=https://your.domain
+NEXTAUTH_URL=https://sidetrack.network
 NEXTAUTH_SECRET=supersecretlongrandom
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 
 # UI
-NEXT_PUBLIC_API_BASE=http://localhost:8000
+NEXT_PUBLIC_API_BASE=http://localhost:8000 # production: https://sidetrack.network/api
 
 # Paths
 AUDIO_ROOT=/audio

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ curl -H "X-User-Id: YOUR_USER" -X POST "http://localhost:8000/aggregate/weeks"
 
 # 5) Open the UI
 open http://localhost:3000
+# Production: https://sidetrack.network
 ```
 
 Developer tooling (optional):
@@ -90,7 +91,7 @@ LASTFM_API_KEY=lfm_xxx
 LASTFM_API_SECRET=lfm_secret
 
 # Auth.js (NextAuth) – Google OAuth
-NEXTAUTH_URL=https://your.domain
+NEXTAUTH_URL=https://sidetrack.network
 NEXTAUTH_SECRET=supersecretlongrandom
 GOOGLE_CLIENT_ID=...
 GOOGLE_CLIENT_SECRET=...
@@ -170,12 +171,12 @@ cp .env.example .env
 
 # 2) Set up Google OAuth creds
 #    - Create a Google Cloud OAuth Client (Web)
-#    - Authorized redirect URI: https://your.domain/api/auth/callback/google
+#    - Authorized redirect URI: https://sidetrack.network/api/auth/callback/google
 #    - Put GOOGLE_CLIENT_ID/SECRET into .env and set NEXTAUTH_URL
 
 # 2b) API base for UI fetches (default: http://localhost:8000)
 #     - NEXT_PUBLIC_API_BASE points the Next.js UI at the API
-#     - Override in production, e.g., https://api.your.domain
+#     - Override in production, e.g., https://sidetrack.network/api
 
 # 3) Build and start (single compose)
 docker compose up -d --build

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,9 +1,9 @@
-:80 {
-  redir https://{host}{uri}
+http://sidetrack.network {
+  redir https://sidetrack.network{uri}
 }
 
-:443 {
-  tls you@example.com
+sidetrack.network {
+  tls admin@sidetrack.network
   encode gzip
   handle_path /api/* {
     reverse_proxy api:8000

--- a/services/ui/app/api/auth/lastfm/login/route.ts
+++ b/services/ui/app/api/auth/lastfm/login/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
+const API_BASE =
+  process.env.NEXT_PUBLIC_API_BASE || 'https://sidetrack.network/api';
 
 export async function GET(req: NextRequest) {
   const callback = req.nextUrl.searchParams.get('callback') || '';

--- a/services/ui/app/api/auth/lastfm/session/route.ts
+++ b/services/ui/app/api/auth/lastfm/session/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
+const API_BASE =
+  process.env.NEXT_PUBLIC_API_BASE || 'https://sidetrack.network/api';
 
 export async function GET(req: NextRequest) {
   const token = req.nextUrl.searchParams.get('token') || '';

--- a/services/ui/app/api/auth/login/route.ts
+++ b/services/ui/app/api/auth/login/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
+const API_BASE =
+  process.env.NEXT_PUBLIC_API_BASE || 'https://sidetrack.network/api';
 
 export async function POST(req: NextRequest) {
   const body = await req.json();

--- a/services/ui/app/api/auth/me/route.ts
+++ b/services/ui/app/api/auth/me/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
+const API_BASE =
+  process.env.NEXT_PUBLIC_API_BASE || 'https://sidetrack.network/api';
 
 export async function GET(req: NextRequest) {
   const headers: Record<string, string> = {};

--- a/services/ui/app/api/auth/register/route.ts
+++ b/services/ui/app/api/auth/register/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
+const API_BASE =
+  process.env.NEXT_PUBLIC_API_BASE || 'https://sidetrack.network/api';
 
 export async function POST(req: NextRequest) {
   const body = await req.json();

--- a/services/ui/app/api/auth/spotify/callback/route.ts
+++ b/services/ui/app/api/auth/spotify/callback/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
+const API_BASE =
+  process.env.NEXT_PUBLIC_API_BASE || 'https://sidetrack.network/api';
 
 export async function GET(req: NextRequest) {
   const code = req.nextUrl.searchParams.get('code') || '';

--- a/services/ui/app/api/auth/spotify/disconnect/route.ts
+++ b/services/ui/app/api/auth/spotify/disconnect/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
+const API_BASE =
+  process.env.NEXT_PUBLIC_API_BASE || 'https://sidetrack.network/api';
 
 export async function DELETE(req: NextRequest) {
   const headers: Record<string, string> = {};

--- a/services/ui/app/api/auth/spotify/login/route.ts
+++ b/services/ui/app/api/auth/spotify/login/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
+const API_BASE =
+  process.env.NEXT_PUBLIC_API_BASE || 'https://sidetrack.network/api';
 
 export async function GET(req: NextRequest) {
   const callback = req.nextUrl.searchParams.get('callback') || '';

--- a/services/ui/app/api/settings/route.ts
+++ b/services/ui/app/api/settings/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
+const API_BASE =
+  process.env.NEXT_PUBLIC_API_BASE || 'https://sidetrack.network/api';
 
 export async function GET(req: NextRequest) {
   const headers: Record<string, string> = {};

--- a/services/ui/lib/api.ts
+++ b/services/ui/lib/api.ts
@@ -1,4 +1,5 @@
-export const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8000';
+export const API_BASE =
+  process.env.NEXT_PUBLIC_API_BASE || 'https://sidetrack.network/api';
 
 export function apiFetch(path: string, init?: RequestInit) {
   return fetch(`${API_BASE}${path}`, init);


### PR DESCRIPTION
## Summary
- Configure Caddy to serve sidetrack.network with HTTPS and reverse-proxy paths
- Default UI API base and NextAuth settings to sidetrack.network domain
- Document production domain and API usage in README and environment example

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdea3a1a4c8333b89637f4fb6bf5e6