### PR TITLE
build: install sidetrack package in API image

### DIFF
--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -3,25 +3,22 @@ FROM python:3.11-slim
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 
-# Working directory for API package (contains alembic.ini)
-WORKDIR /srv/api
+# Working directory for sidetrack package
+WORKDIR /app
 
 # System deps
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy API sources (package, alembic, config)
-COPY services/api/ /srv/api/
-# Copy monorepo package src for setuptools (sidetrack)
-COPY sidetrack/ /srv/api/sidetrack/
+# Install API dependencies
+COPY services/api/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
-# Install API Python package
-RUN pip install --no-cache-dir /srv/api
-
-# Make shared modules importable (services/*)
-COPY services /src/services
-ENV PYTHONPATH=/src
+# Copy and install sidetrack package
+COPY sidetrack/ /app/sidetrack/
+COPY pyproject.toml /app/
+RUN pip install --no-cache-dir /app
 
 EXPOSE 8000
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "sidetrack.api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/sidetrack/api/api/v1/musicbrainz.py
+++ b/sidetrack/api/api/v1/musicbrainz.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 import requests
 import structlog
+import time
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -11,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sidetrack.common.models import Artist, Release, Track
 
 from ...db import get_db
-from ...main import HTTP_SESSION, time
+from ...main import HTTP_SESSION
 from ...schemas.musicbrainz import MusicbrainzIngestResponse
 from ...utils import get_or_create, mb_sanitize
 


### PR DESCRIPTION
## Summary
- copy sidetrack package and pyproject into API Docker image and install it
- remove PYTHONPATH hack and set entrypoint to sidetrack.api.main
- import `time` directly in MusicBrainz API to avoid circular import

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bdf1fec1d88333bef78a7af2916047