### PR TITLE
Install sidetrack package in extractor image

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -31,7 +31,7 @@ services:
     volumes:
       - ./data/audio:/audio:ro
     depends_on: [db]
-    command: python -m extractor.run --schedule "@daily"
+    command: python -m sidetrack.extractor.run --schedule "@daily"
 
   scheduler:
     build:

--- a/services/extractor/Dockerfile
+++ b/services/extractor/Dockerfile
@@ -13,10 +13,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY services/extractor/requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
-# Copy monorepo services to ensure imports resolve
-COPY services /src/services
-ENV PYTHONPATH=/src
+# Copy and install sidetrack package
+COPY pyproject.toml sidetrack /app/
+RUN pip install /app
 
-# Run extractor from source
-WORKDIR /src/services/extractor
-CMD ["python","-m","extractor.run","--schedule","@daily"]
+# Run extractor
+CMD ["python", "-m", "sidetrack.extractor.run", "--schedule", "@daily"]


### PR DESCRIPTION
## Summary
- Install `sidetrack` package in extractor image via `pip install /app`
- Streamline extractor Dockerfile and run `sidetrack.extractor.run` by default
- Adjust docker compose to invoke the new entrypoint

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q` *(fails: ImportError: cannot import name 'time' from partially initialized module 'sidetrack.api.main')*

------
https://chatgpt.com/codex/tasks/task_e_68bdf21cc8088333b2910e48561719b1