### PR TITLE
feat: add shared base image for Python services

### DIFF
--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -1,20 +1,14 @@
-FROM python:3.11-slim
+# syntax=docker/dockerfile:1
 
-ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
-
-# Working directory for sidetrack package
-WORKDIR /app
-
-# System deps
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
+# Build stage: install API extras using cached wheels
+FROM sidetrack-base AS builder
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential \
     && rm -rf /var/lib/apt/lists/*
+RUN pip install --no-cache-dir --find-links /wheels 'sidetrack[api]'
 
-# Copy project files and install API extras
-COPY pyproject.toml ./
-COPY sidetrack ./sidetrack
-RUN pip install --no-cache-dir .[api]
+# Runtime stage: copy installed packages into a clean base image
+FROM sidetrack-base AS runtime
+COPY --from=builder /usr/local /usr/local
 
 EXPOSE 8000
 CMD ["uvicorn", "sidetrack.api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/base/Dockerfile
+++ b/services/base/Dockerfile
@@ -1,0 +1,29 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.11-slim AS builder
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+# Install build dependencies and shared system packages
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+# Copy project metadata and sources
+COPY pyproject.toml ./
+COPY sidetrack ./sidetrack
+
+# Build wheels for the core package and dependencies
+RUN pip wheel --no-cache-dir --wheel-dir /wheels .
+
+FROM python:3.11-slim AS base
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+# Provide the cached wheels for downstream images
+COPY --from=builder /wheels /wheels
+
+WORKDIR /app

--- a/services/extractor/Dockerfile
+++ b/services/extractor/Dockerfile
@@ -1,18 +1,15 @@
-FROM python:3.11-slim
+# syntax=docker/dockerfile:1
 
-ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
-
-WORKDIR /app
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ffmpeg \
+# Build stage: install extractor extras using cached wheels
+FROM sidetrack-base AS builder
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential \
     && rm -rf /var/lib/apt/lists/*
+RUN pip install --no-cache-dir --find-links /wheels 'sidetrack[extractor]'
 
-# Copy project files and install extractor extras
-COPY pyproject.toml ./
-COPY sidetrack ./sidetrack
-RUN pip install --no-cache-dir .[extractor]
+# Runtime stage: minimal image with ffmpeg and installed packages
+FROM sidetrack-base AS runtime
+RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /usr/local /usr/local
 
-# Run extractor
 CMD ["python", "-m", "sidetrack.extractor.run", "--schedule", "@daily"]

--- a/services/scheduler/Dockerfile
+++ b/services/scheduler/Dockerfile
@@ -1,10 +1,13 @@
-FROM python:3.11-slim
-WORKDIR /app
+# syntax=docker/dockerfile:1
 
-# Copy project files and install scheduler extras
-COPY pyproject.toml ./
-COPY sidetrack ./sidetrack
-RUN pip install --no-cache-dir .[scheduler]
+# Build stage: install scheduler extras using cached wheels
+FROM sidetrack-base AS builder
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/*
+RUN pip install --no-cache-dir --find-links /wheels 'sidetrack[scheduler]'
 
-# Run scheduler module from sidetrack package
-CMD ["python","-m","sidetrack.scheduler.run"]
+# Runtime stage: copy installed packages into base image
+FROM sidetrack-base AS runtime
+COPY --from=builder /usr/local /usr/local
+
+CMD ["python", "-m", "sidetrack.scheduler.run"]

--- a/services/worker/Dockerfile
+++ b/services/worker/Dockerfile
@@ -1,13 +1,13 @@
-FROM python:3.11-slim
+# syntax=docker/dockerfile:1
 
-# Copy the project sources and install the sidetrack package with
-# worker-specific extras.
-WORKDIR /src
-COPY pyproject.toml ./
-COPY sidetrack ./sidetrack
-RUN pip install --no-cache-dir .[worker]
+# Build stage: install worker extras using cached wheels
+FROM sidetrack-base AS builder
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential \
+    && rm -rf /var/lib/apt/lists/*
+RUN pip install --no-cache-dir --find-links /wheels 'sidetrack[worker]'
 
-# Run the worker from the installed package location.
-WORKDIR /usr/local/lib/python3.11/site-packages/sidetrack
+# Runtime stage: copy installed packages into base image
+FROM sidetrack-base AS runtime
+COPY --from=builder /usr/local /usr/local
+
 CMD ["python", "-m", "sidetrack.worker.run"]
-


### PR DESCRIPTION
## Summary
- provide base Python Docker image with cached dependency wheels
- refactor service Dockerfiles to use the base image with builder/runtime stages

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68be70c6aec483338dca0d98e638d0c9