### PR TITLE
Use asyncio lock for MusicBrainz rate limiting

### DIFF
--- a/services/api/tests/test_musicbrainz_ingest.py
+++ b/services/api/tests/test_musicbrainz_ingest.py
@@ -41,7 +41,6 @@ async def mb_client(async_client, monkeypatch):
         return Resp()
 
     monkeypatch.setattr(main_mod.HTTP_SESSION, "get", fake_get)
-    monkeypatch.setattr(main_mod, "_MB_LAST_CALL", 0.0)
     return async_client
 
 
@@ -78,6 +77,5 @@ async def test_ingest_musicbrainz_not_found(mb_client, monkeypatch):
         return Resp()
 
     monkeypatch.setattr(main_mod.HTTP_SESSION, "get", fake_get)
-    monkeypatch.setattr(main_mod, "_MB_LAST_CALL", 0.0)
     resp = await mb_client.post("/api/v1/ingest/musicbrainz", params={"release_mbid": "missing"})
     assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- Replace custom timestamp rate limiter with an `asyncio.Lock`
- Issue MusicBrainz requests via shared `httpx.AsyncClient`
- Handle `httpx.RequestError` and `HTTPStatusError` separately
- Update tests to reflect new rate limiter

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be76332fbc83338217eaac3d5d9a8b