### PR TITLE
Cache API settings and clear test cache after env updates

### DIFF
--- a/sidetrack/api/config.py
+++ b/sidetrack/api/config.py
@@ -1,3 +1,5 @@
+from functools import lru_cache
+
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -38,5 +40,6 @@ class Settings(BaseSettings):
         )
 
 
+@lru_cache
 def get_settings() -> Settings:
     return Settings()


### PR DESCRIPTION
## Summary
- cache API configuration in `get_settings` using `functools.lru_cache`
- clear settings cache in tests whenever environment variables change

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pre-commit run --files sidetrack/api/config.py services/tests/conftest.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68be7641a1b08333ae87a937e4b7d6d6