### PR TITLE
Refresh redis connection when URL changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,14 @@ session from within async-aware code (e.g. a fixture running under
 Integration tests rely on Docker; they are automatically skipped if a Docker
 daemon is not reachable.
 
+## Redis connections
+
+The API caches a Redis client in `sidetrack.api.main`. `_get_redis_connection`
+now recreates this client whenever the `REDIS_URL` setting changes or the
+existing connection is no longer reachable. When writing tests that interact
+with Redis, use the `redis_conn` fixture to obtain a fresh instance and prevent
+stale connections from leaking between tests.
+
 ## Environment
 
 - Python 3.11

--- a/services/api/tests/test_redis_connection.py
+++ b/services/api/tests/test_redis_connection.py
@@ -1,0 +1,41 @@
+import types
+import pytest
+
+import sidetrack.api.main as main
+from sidetrack.api.config import Settings
+
+pytestmark = pytest.mark.unit
+
+
+class DummyRedis:
+    def __init__(self, url: str) -> None:
+        self.url = url
+
+    def ping(self) -> bool:  # pragma: no cover - simple stub
+        return True
+
+
+def test_connection_refreshed_when_url_changes(monkeypatch):
+    created: list[DummyRedis] = []
+
+    def fake_from_url(url: str) -> DummyRedis:
+        conn = DummyRedis(url)
+        created.append(conn)
+        return conn
+
+    fake_module = types.SimpleNamespace(from_url=fake_from_url, ConnectionError=Exception)
+    monkeypatch.setattr(main, "redis", fake_module)
+
+    # reset globals
+    main._REDIS_CONN = None
+    main._REDIS_URL = None
+
+    s1 = Settings(redis_url="redis://one")
+    c1 = main._get_redis_connection(s1)
+    c2 = main._get_redis_connection(s1)
+    assert c1 is c2
+
+    s2 = Settings(redis_url="redis://two")
+    c3 = main._get_redis_connection(s2)
+    assert c3 is not c1
+    assert c3.url == "redis://two"


### PR DESCRIPTION
## Summary
- refresh cached Redis connection when URL changes or existing connection is dead
- document Redis caching and test guidance in AGENTS.md
- add unit test for Redis connection cache refresh

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf0956370c8333b23a25cf32e7baa4