### PR TITLE
feat: expose recent listens API

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ TZ=America/New_York
 
 - `GET /health` – service liveness
 - `POST /api/v1/ingest/listens?since=YYYY-MM-DD` – sync listens
+- `GET /api/v1/listens/recent?limit=50` – most recent listens
 - `POST /tags/lastfm/sync?since=YYYY-MM-DD` – fetch & cache Last.fm tags
 - `POST /analyze/track/{track_id}` – compute features/embeddings
 - `POST /score/track/{track_id}` – compute mood scores

--- a/services/api/tests/test_recent_listens.py
+++ b/services/api/tests/test_recent_listens.py
@@ -1,0 +1,30 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from sidetrack.common.models import Artist, Listen, Track
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_recent_listens_endpoint(async_client, async_session):
+    artist = Artist(name="Artist")
+    track = Track(title="Song", artist=artist)
+    async_session.add_all([artist, track])
+    await async_session.flush()
+    track_id = track.track_id
+
+    l1 = Listen(user_id="u1", track_id=track_id, played_at=datetime(2024, 1, 1, tzinfo=UTC))
+    l2 = Listen(user_id="u1", track_id=track_id, played_at=datetime(2024, 1, 2, tzinfo=UTC))
+    async_session.add_all([l1, l2])
+    await async_session.commit()
+
+    resp = await async_client.get("/api/v1/listens/recent?limit=1", headers={"X-User-Id": "u1"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["listens"]) == 1
+    item = data["listens"][0]
+    assert item["track_id"] == track_id
+    assert item["title"] == "Song"
+    assert item["artist"] == "Artist"
+    assert item["played_at"].startswith("2024-01-02")

--- a/sidetrack/api/schemas/listens.py
+++ b/sidetrack/api/schemas/listens.py
@@ -23,3 +23,14 @@ class IngestResponse(BaseModel):
     detail: str
     ingested: int
     source: str | None = None
+
+
+class RecentListen(BaseModel):
+    track_id: int
+    title: str
+    artist: str | None
+    played_at: datetime
+
+
+class RecentListensResponse(BaseModel):
+    listens: list[RecentListen]


### PR DESCRIPTION
## Summary
- add `/api/v1/listens/recent` for retrieving a user's most recent listens
- document new endpoint in README
- test coverage for recent listens query

## Testing
- `pre-commit run --files README.md sidetrack/api/api/v1/listens.py sidetrack/api/schemas/listens.py services/api/tests/test_recent_listens.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf0d37aaf4833387fcdc603f1a1606