### PR TITLE
feat(ui): add theme context and toggle

### DIFF
--- a/services/ui/app/globals.css
+++ b/services/ui/app/globals.css
@@ -3,22 +3,6 @@
 @tailwind utilities;
 
 :root {
-  --background: 228 16% 6%; /* #0E0F12 */
-  --foreground: 220 14% 96%; /* off-white */
-  --muted: 228 12% 14%;
-  --muted-foreground: 220 10% 70%;
-  --card: 228 12% 10%;
-  --card-foreground: var(--foreground);
-  --border: 228 12% 18%;
-  --input: 228 12% 18%;
-  --primary: 158 84% 58%; /* #2FE08B */
-  --primary-foreground: 222 14% 12%;
-  --secondary: 196 100% 62%; /* #39D2FF */
-  --secondary-foreground: 222 14% 12%;
-  --accent: 196 100% 62%;
-  --accent-foreground: 222 14% 12%;
-  --ring: 196 100% 62%;
-
   --light-background: 0 0% 100%;
   --light-foreground: 222 14% 12%;
   --light-muted: 210 40% 96%;
@@ -35,15 +19,22 @@
   --light-accent-foreground: 222 14% 12%;
   --light-ring: 196 100% 62%;
 
-  --space-1: 0.25rem;
-  --space-2: 0.5rem;
-  --space-3: 0.75rem;
-  --space-4: 1rem;
-  --space-5: 1.25rem;
-  --space-6: 1.5rem;
-}
+  --dark-background: 228 16% 6%; /* #0E0F12 */
+  --dark-foreground: 220 14% 96%; /* off-white */
+  --dark-muted: 228 12% 14%;
+  --dark-muted-foreground: 220 10% 70%;
+  --dark-card: 228 12% 10%;
+  --dark-card-foreground: var(--dark-foreground);
+  --dark-border: 228 12% 18%;
+  --dark-input: 228 12% 18%;
+  --dark-primary: 158 84% 58%; /* #2FE08B */
+  --dark-primary-foreground: 222 14% 12%;
+  --dark-secondary: 196 100% 62%; /* #39D2FF */
+  --dark-secondary-foreground: 222 14% 12%;
+  --dark-accent: 196 100% 62%;
+  --dark-accent-foreground: 222 14% 12%;
+  --dark-ring: 196 100% 62%;
 
-.light {
   --background: var(--light-background);
   --foreground: var(--light-foreground);
   --muted: var(--light-muted);
@@ -59,6 +50,31 @@
   --accent: var(--light-accent);
   --accent-foreground: var(--light-accent-foreground);
   --ring: var(--light-ring);
+
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.25rem;
+  --space-6: 1.5rem;
+}
+
+.dark {
+  --background: var(--dark-background);
+  --foreground: var(--dark-foreground);
+  --muted: var(--dark-muted);
+  --muted-foreground: var(--dark-muted-foreground);
+  --card: var(--dark-card);
+  --card-foreground: var(--dark-card-foreground);
+  --border: var(--dark-border);
+  --input: var(--dark-input);
+  --primary: var(--dark-primary);
+  --primary-foreground: var(--dark-primary-foreground);
+  --secondary: var(--dark-secondary);
+  --secondary-foreground: var(--dark-secondary-foreground);
+  --accent: var(--dark-accent);
+  --accent-foreground: var(--dark-accent-foreground);
+  --ring: var(--dark-ring);
 }
 
 html,
@@ -76,3 +92,4 @@ body {
   backdrop-filter: saturate(140%) blur(8px);
   border: 1px solid hsl(var(--border));
 }
+

--- a/services/ui/app/layout.tsx
+++ b/services/ui/app/layout.tsx
@@ -8,18 +8,21 @@ import AppShell from '../components/AppShell';
 import PageTransition from '../components/PageTransition';
 import { Inter } from 'next/font/google';
 import Providers from './providers';
+import ThemeProvider from '../components/ThemeProvider';
 
 const inter = Inter({ subsets: ['latin'], variable: '--font-sans' });
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="en" className="dark" suppressHydrationWarning>
       <body className={`${inter.variable} font-sans antialiased`}>
-        <Providers>
-          <PageTransition>
-            <AppShell>{children}</AppShell>
-          </PageTransition>
-        </Providers>
+        <ThemeProvider>
+          <Providers>
+            <PageTransition>
+              <AppShell>{children}</AppShell>
+            </PageTransition>
+          </Providers>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/services/ui/app/providers.tsx
+++ b/services/ui/app/providers.tsx
@@ -2,16 +2,9 @@
 
 import { useState } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ThemeProvider } from 'next-themes';
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(() => new QueryClient());
 
-  return (
-    <QueryClientProvider client={queryClient}>
-      <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
-        {children}
-      </ThemeProvider>
-    </QueryClientProvider>
-  );
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
 }

--- a/services/ui/components/HeaderActions.tsx
+++ b/services/ui/components/HeaderActions.tsx
@@ -1,13 +1,17 @@
 'use client';
 import { useState } from 'react';
 import { motion } from 'framer-motion';
-import { useToast } from './ToastProvider';
 import dynamic from 'next/dynamic';
+import { useToast } from './ToastProvider';
+import { useTheme } from './ThemeContext';
 
 const Sync = dynamic(() => import('lucide-react/lib/esm/icons/sync'));
+const Sun = dynamic(() => import('lucide-react/lib/esm/icons/sun'));
+const Moon = dynamic(() => import('lucide-react/lib/esm/icons/moon'));
 
 export default function HeaderActions() {
   const toast = useToast();
+  const { theme, toggleTheme } = useTheme();
   const [syncing, setSyncing] = useState(false);
 
   const handleSync = async () => {
@@ -24,19 +28,29 @@ export default function HeaderActions() {
   };
 
   return (
-    <button
-      onClick={handleSync}
-      disabled={syncing}
-      className="inline-flex items-center gap-2 rounded-full bg-white/5 px-3 py-1 text-xs text-muted-foreground hover:text-foreground disabled:opacity-50"
-    >
-      <motion.span
-        animate={syncing ? { rotate: 360 } : { rotate: 0 }}
-        transition={{ repeat: syncing ? Infinity : 0, duration: 1, ease: 'linear' }}
-        className="inline-block"
+    <div className="flex items-center gap-2">
+      <button
+        onClick={toggleTheme}
+        className="inline-flex items-center justify-center rounded-full bg-white/5 p-2 text-muted-foreground hover:text-foreground"
       >
-        <Sync size={14} />
-      </motion.span>
-      Sync
-    </button>
+        {theme === 'dark' ? <Sun size={14} /> : <Moon size={14} />}
+        <span className="sr-only">Toggle theme</span>
+      </button>
+      <button
+        onClick={handleSync}
+        disabled={syncing}
+        className="inline-flex items-center gap-2 rounded-full bg-white/5 px-3 py-1 text-xs text-muted-foreground hover:text-foreground disabled:opacity-50"
+      >
+        <motion.span
+          animate={syncing ? { rotate: 360 } : { rotate: 0 }}
+          transition={{ repeat: syncing ? Infinity : 0, duration: 1, ease: 'linear' }}
+          className="inline-block"
+        >
+          <Sync size={14} />
+        </motion.span>
+        Sync
+      </button>
+    </div>
   );
 }
+

--- a/services/ui/components/ThemeContext.tsx
+++ b/services/ui/components/ThemeContext.tsx
@@ -1,0 +1,18 @@
+'use client';
+import { createContext, useContext } from 'react';
+
+export type Theme = 'light' | 'dark';
+export type ThemeContextValue = {
+  theme: Theme;
+  setTheme: (t: Theme) => void;
+  toggleTheme: () => void;
+};
+
+export const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error('ThemeContext missing');
+  return ctx;
+}
+

--- a/services/ui/components/ThemeProvider.tsx
+++ b/services/ui/components/ThemeProvider.tsx
@@ -1,0 +1,29 @@
+'use client';
+import { useCallback, useEffect, useState } from 'react';
+import { Theme, ThemeContext } from './ThemeContext';
+
+const STORAGE_KEY = 'theme';
+
+export default function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>(() => {
+    if (typeof window === 'undefined') return 'dark';
+    return (localStorage.getItem(STORAGE_KEY) as Theme) ?? 'dark';
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    root.classList.toggle('dark', theme === 'dark');
+    localStorage.setItem(STORAGE_KEY, theme);
+  }, [theme]);
+
+  const toggleTheme = useCallback(() => {
+    setTheme((prev) => (prev === 'dark' ? 'light' : 'dark'));
+  }, []);
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add ThemeContext and ThemeProvider with localStorage persistence
- expose theme toggle button in header
- wrap application with ThemeProvider and adjust global tokens for light/dark

## Testing
- `npm test`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'docker')*


------
https://chatgpt.com/codex/tasks/task_e_68bf8f3aee888333882fc15b327e0af6