### PR TITLE
refactor: use UI components for settings and account

### DIFF
--- a/services/ui/app/account/page.tsx
+++ b/services/ui/app/account/page.tsx
@@ -1,11 +1,15 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { Button } from '../../components/ui/button';
+import { Card } from '../../components/ui/card';
+import { useToast } from '../../components/ToastProvider';
 
 export default function AccountPage() {
   const [user, setUser] = useState('');
   const [lfmUser, setLfmUser] = useState('');
   const [lfmConnected, setLfmConnected] = useState(false);
+  const { show } = useToast();
 
   useEffect(() => {
     const uid = localStorage.getItem('user_id') || '';
@@ -31,46 +35,45 @@ export default function AccountPage() {
     const data = await res.json().catch(() => ({}));
     if (data.url) {
       window.location.href = data.url;
+    } else {
+      show({ title: 'Failed to connect to Last.fm', kind: 'error' });
     }
   }
 
   async function handleDisconnect() {
     const uid = localStorage.getItem('user_id') || '';
-    await fetch('/api/auth/lastfm/session', {
+    const res = await fetch('/api/auth/lastfm/session', {
       method: 'DELETE',
       headers: { 'X-User-Id': uid },
     });
+    if (!res.ok) {
+      show({ title: 'Failed to disconnect Last.fm', kind: 'error' });
+      return;
+    }
     setLfmConnected(false);
     setLfmUser('');
+    show({ title: 'Disconnected from Last.fm', kind: 'success' });
   }
 
   return (
     <section className="space-y-6">
       <h2 className="text-2xl font-bold">Account</h2>
       <p>Logged in as {user}</p>
-      <div>
+      <Card className="space-y-4 p-4">
         <h3 className="text-xl font-semibold">Last.fm</h3>
         {lfmConnected ? (
           <div className="flex items-center gap-2">
             <span>Connected as {lfmUser}</span>
-            <button
-              type="button"
-              onClick={handleDisconnect}
-              className="rounded bg-red-500 px-3 py-1 text-white"
-            >
+            <Button type="button" onClick={handleDisconnect}>
               Disconnect
-            </button>
+            </Button>
           </div>
         ) : (
-          <button
-            type="button"
-            onClick={handleConnect}
-            className="rounded bg-emerald-500 px-3 py-1 text-white"
-          >
+          <Button type="button" onClick={handleConnect}>
             Connect Last.fm
-          </button>
+          </Button>
         )}
-      </div>
+      </Card>
     </section>
   );
 }

--- a/services/ui/app/settings/page.test.tsx
+++ b/services/ui/app/settings/page.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Settings from './page';
+import ToastProvider from '../../components/ToastProvider';
 
 describe('Settings page', () => {
   beforeEach(() => {
@@ -12,7 +13,11 @@ describe('Settings page', () => {
   });
 
   it('validates ListenBrainz fields', async () => {
-    render(<Settings />);
+    render(
+      <ToastProvider>
+        <Settings />
+      </ToastProvider>,
+    );
     const userInput = screen.getByPlaceholderText('ListenBrainz username');
     await userEvent.type(userInput, 'tester');
     await userEvent.click(screen.getByRole('button', { name: /save/i }));
@@ -31,7 +36,11 @@ describe('Settings page', () => {
       json: () => Promise.resolve({ ok: true }),
     }); // POST
 
-    render(<Settings />);
+    render(
+      <ToastProvider>
+        <Settings />
+      </ToastProvider>,
+    );
     await userEvent.type(screen.getByPlaceholderText('ListenBrainz username'), 'lbuser');
     await userEvent.type(screen.getByPlaceholderText('Token'), 'lbtoken');
     await userEvent.click(screen.getByLabelText('Use GPU'));


### PR DESCRIPTION
## Summary
- replace raw inputs and buttons on settings and account pages with shared UI components
- add toast-based success and error feedback
- adjust tests for ToastProvider

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q` *(fails: No module named 'docker')*
- `cd services/ui && npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68bf9ec44018833383954092b8068dcf