### PR TITLE
Use npm for UI Docker image

### DIFF
--- a/services/ui/Dockerfile
+++ b/services/ui/Dockerfile
@@ -3,11 +3,11 @@ FROM node:20-slim
 WORKDIR /app
 
 # Install deps
-COPY package.json pnpm-lock.yaml* ./
-RUN corepack enable && pnpm install --frozen-lockfile || pnpm install
+COPY package.json package-lock.json ./
+RUN npm ci
 
 # App code
 COPY . .
 
 EXPOSE 3000
-CMD ["pnpm","dev"]
+CMD ["npm","run","dev"]


### PR DESCRIPTION
## Summary
- use npm instead of pnpm for UI Docker image install and startup

## Testing
- `pip install -r requirements-dev.txt` *(fails: tensor package heavy, install aborted)*
- `pip install -e .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'docker')*
- `docker build -t sidetrack-ui-test services/ui` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_68bfcabab79c8333b5001a3bdbce00fc