### PR TITLE
build: prebuild base image

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ Pull listens from ListenBrainz → resolve MusicBrainz metadata → compute audi
 Single Docker Compose with all services enabled.
 
 - File: `compose.yml`
+- Build the shared base image:
+```
+docker build -f services/base/Dockerfile -t sidetrack-base .
+```
+
 - Start everything:
 
 ```bash
@@ -45,18 +50,21 @@ cd SideTrack
 cp .env.example .env
 # (Optional) set LASTFM_API_KEY, DEFAULT_USER_ID, and NEXT_PUBLIC_API_BASE if needed
 
-# 2) Start the stack (single compose)
+# 2) Build the base image
+docker build -f services/base/Dockerfile -t sidetrack-base .
+
+# 3) Start the stack (single compose)
 docker compose up -d --build
 
-# 3) Apply DB migrations
+# 4) Apply DB migrations
 docker compose exec api alembic upgrade head
 
-# 4) Pull listens and aggregate (replace YOUR_USER)
+# 5) Pull listens and aggregate (replace YOUR_USER)
 curl -H "X-User-Id: YOUR_USER" -X POST "http://localhost:8000/api/v1/ingest/listens?since=2024-01-01"
 curl -H "X-User-Id: YOUR_USER" -X POST "http://localhost:8000/tags/lastfm/sync?since=2024-01-01"
 curl -H "X-User-Id: YOUR_USER" -X POST "http://localhost:8000/aggregate/weeks"
 
-# 5) Open the UI
+# 6) Open the UI
 open http://localhost:3000
 # Production: https://sidetrack.network
 ```
@@ -179,18 +187,21 @@ cp .env.example .env
 #     - NEXT_PUBLIC_API_BASE points the Next.js UI at the API
 #     - Override in production, e.g., https://sidetrack.network/api
 
-# 3) Build and start (single compose)
+# 3) Build the base image
+docker build -f services/base/Dockerfile -t sidetrack-base .
+
+# 4) Start the stack (single compose)
 docker compose up -d --build
 
-# 4) Bootstrap DB (migrations)
+# 5) Bootstrap DB (migrations)
 docker compose exec api alembic upgrade head
 
-# 5) First sync + analysis
+# 6) First sync + analysis
 curl -H "X-User-Id: your-user" -X POST http://localhost:8000/api/v1/ingest/listens?since=2024-01-01
 curl -H "X-User-Id: your-user" -X POST http://localhost:8000/tags/lastfm/sync?since=2024-01-01
 curl -H "X-User-Id: your-user" -X POST http://localhost:8000/aggregate/weeks
 
-# 6) Open UI (default port)
+# 7) Open UI (default port)
 http://localhost:3000
 ```
 

--- a/compose.yml
+++ b/compose.yml
@@ -1,11 +1,8 @@
 version: "3.9"
-services:
-  base:
-    build:
-      context: .
-      dockerfile: services/base/Dockerfile
-    image: sidetrack-base
 
+# Build the shared base image before starting services:
+#   docker build -f services/base/Dockerfile -t sidetrack-base .
+services:
   db:
     image: timescale/timescaledb:latest-pg16
     environment:
@@ -36,8 +33,6 @@ services:
       dockerfile: services/api/Dockerfile
     env_file: .env
     depends_on:
-      base:
-        condition: service_started
       db:
         condition: service_healthy
     ports: ["8000:8000"]
@@ -50,8 +45,6 @@ services:
     volumes:
       - ./data/audio:/audio:ro
     depends_on:
-      base:
-        condition: service_started
       db:
         condition: service_healthy
     command: python -m sidetrack.extractor.run --schedule "@daily"
@@ -62,8 +55,6 @@ services:
       dockerfile: services/scheduler/Dockerfile
     env_file: .env
     depends_on:
-      base:
-        condition: service_started
       api:
         condition: service_started
       extractor:
@@ -76,8 +67,6 @@ services:
       dockerfile: services/worker/Dockerfile
     env_file: .env
     depends_on:
-      base:
-        condition: service_started
       cache:
         condition: service_healthy
       db:


### PR DESCRIPTION
## Summary
- remove base service from docker compose and drop service dependencies
- document new workflow to prebuild sidetrack-base image

## Testing
- `pip install -r requirements-dev.txt` *(fails: ModuleNotFoundError: No module named 'imp')*
- `pip install -e .`
- `pytest -q` *(fails: No module named 'docker')*

------
https://chatgpt.com/codex/tasks/task_e_68bfcae2f6f083339d9b93f3dc7cf881