### PR TITLE
refactor: add base extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,16 +9,20 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 
 [project.optional-dependencies]
-api = [
-    "fastapi==0.111.1",
-    "uvicorn[standard]==0.30.1",
+base = [
     "pydantic==2.8.2",
     "pydantic-settings==2.3.4",
     "python-dotenv==1.0.1",
     "psycopg[binary]==3.2.1",
     "SQLAlchemy==2.0.32",
-    "alembic==1.13.2",
     "requests==2.32.3",
+]
+
+api = [
+    "sidetrack[base]",
+    "fastapi==0.111.1",
+    "uvicorn[standard]==0.30.1",
+    "alembic==1.13.2",
     "httpx[async]==0.27.0",
     "tenacity==8.2.3",
     "passlib[bcrypt]==1.7.4",
@@ -33,25 +37,24 @@ api = [
     "opentelemetry-instrumentation-sqlalchemy==0.57b0",
     "pytest-asyncio==0.23.7",
 ]
+
 extractor = [
+    "sidetrack[base]",
     "typer==0.12.3",
-    "python-dotenv==1.0.1",
-    "SQLAlchemy==2.0.32",
-    "psycopg[binary]==3.2.1",
     "numpy==1.26.4",
     "scipy==1.13.1",
     "librosa==0.10.2.post1",
     "soundfile==0.12.1",
     "openl3==0.4.2",
 ]
+
 scheduler = [
-    "requests==2.32.3",
+    "sidetrack[base]",
     "schedule==1.2.2",
-    "pydantic==2.8.2",
-    "pydantic-settings==2.3.4",
 ]
+
 worker = [
-    "sidetrack[api]",
+    "sidetrack[base]",
     "rq==1.16.2",
     "redis==5.0.7",
     "librosa==0.10.2.post1",


### PR DESCRIPTION
## Summary
- create a base optional dependency group with shared libraries
- update service extras to build on the base group with service-specific packages

## Testing
- `pip install --break-system-packages -r requirements-dev.txt` *(fails: ModuleNotFoundError: No module named 'imp' in openl3)*
- `pip install --break-system-packages -e .`
- `python3 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd948306083339925d791ac5b54c4