### PR TITLE
refactor: reorganize package config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,13 +3,7 @@ name = "sidetrack"
 version = "0.1.0"
 description = "Multi-service SideTrack application"
 requires-python = ">=3.11"
-
-[build-system]
-requires = ["setuptools>=61.0"]
-build-backend = "setuptools.build_meta"
-
-[project.optional-dependencies]
-base = [
+dependencies = [
     "pydantic==2.8.2",
     "pydantic-settings==2.3.4",
     "python-dotenv==1.0.1",
@@ -18,8 +12,13 @@ base = [
     "requests==2.32.3",
 ]
 
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project.optional-dependencies]
+
 api = [
-    "sidetrack[base]",
     "fastapi==0.111.1",
     "uvicorn[standard]==0.30.1",
     "alembic==1.13.2",
@@ -39,7 +38,6 @@ api = [
 ]
 
 extractor = [
-    "sidetrack[base]",
     "typer==0.12.3",
     "numpy==1.26.4",
     "scipy==1.13.1",
@@ -50,12 +48,10 @@ extractor = [
 ]
 
 scheduler = [
-    "sidetrack[base]",
     "schedule==1.2.2",
 ]
 
 worker = [
-    "sidetrack[base]",
     "rq==1.16.2",
     "redis==5.0.7",
     "librosa==0.10.2.post1",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -286,7 +286,7 @@ scipy==1.16.1
     #   scikit-learn
 shellingham==1.5.4
     # via typer
-sidetrack[api,base,scheduler,worker] @ file:///workspace/SideTrack
+sidetrack[api,scheduler,worker] @ file:///workspace/SideTrack
     # via file:///workspace/sidetrack
 sniffio==1.3.1
     # via

--- a/sidetrack/__init__.py
+++ b/sidetrack/__init__.py
@@ -1,0 +1,16 @@
+"""Top level package for the SideTrack project."""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+__all__ = ["__version__", "file"]
+
+try:  # pragma: no cover - fallback when package metadata missing
+    __version__ = version("sidetrack")
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "0.0.0"
+
+# expose resolved path similar to ``__file__`` for simple environment checks
+file = str(Path(__file__).resolve())

--- a/sidetrack/api/api/v1/auth.py
+++ b/sidetrack/api/api/v1/auth.py
@@ -13,7 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from sidetrack.common.models import UserAccount, UserSettings
 
-from sidetrack.common.config import Settings, get_settings
+from ...config import Settings, get_settings
 from ...db import get_db
 from ...schemas.auth import Credentials, GoogleToken, MeOut, UserOut
 from ...security import hash_password, require_role, verify_password

--- a/sidetrack/api/api/v1/listens.py
+++ b/sidetrack/api/api/v1/listens.py
@@ -13,7 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sidetrack.common.models import Artist, Listen, Track
 
 from ...clients.listenbrainz import ListenBrainzClient, get_listenbrainz_client
-from sidetrack.common.config import Settings, get_settings
+from ...config import Settings, get_settings
 from ...db import get_db
 from ...schemas.listens import IngestResponse, ListenIn, RecentListensResponse
 from ...security import get_current_user

--- a/sidetrack/api/clients/lastfm.py
+++ b/sidetrack/api/clients/lastfm.py
@@ -13,7 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
 from sidetrack.common.models import LastfmTags
-from sidetrack.common.config import Settings, get_settings
+from ..config import Settings, get_settings
 
 logger = structlog.get_logger(__name__)
 

--- a/sidetrack/api/clients/spotify.py
+++ b/sidetrack/api/clients/spotify.py
@@ -5,7 +5,7 @@ from typing import Any
 import httpx
 from fastapi import Depends
 
-from sidetrack.common.config import Settings, get_settings
+from ..config import Settings, get_settings
 
 
 class SpotifyClient:

--- a/sidetrack/api/config.py
+++ b/sidetrack/api/config.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+"""Configuration for the API service.
+
+This module wraps :mod:`sidetrack.common.config` so callers can simply import
+``sidetrack.api.config``.  Defining a dedicated module also mirrors the
+structure used by other services such as the worker and scheduler.
+"""
+
+from functools import lru_cache
+
+from sidetrack.common.config import Settings as AppSettings
+
+
+class ApiSettings(AppSettings):
+    """Settings for the API service."""
+
+    # API specific options could be added here in the future
+    pass
+
+
+@lru_cache
+def get_settings() -> ApiSettings:
+    """Return cached ``ApiSettings`` instance."""
+
+    return ApiSettings()
+
+
+# Re-export for backward compatibility with modules still importing these
+# names from ``sidetrack.common.config``.
+Settings = ApiSettings
+

--- a/sidetrack/api/db.py
+++ b/sidetrack/api/db.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from sqlalchemy.orm import Session, sessionmaker
 
 from sidetrack.common.models import Base
-from sidetrack.common.config import get_settings
+from .config import get_settings
 
 logger = structlog.get_logger(__name__)
 

--- a/sidetrack/api/main.py
+++ b/sidetrack/api/main.py
@@ -28,8 +28,8 @@ from sidetrack.common.telemetry import setup_tracing
 from . import scoring
 from .clients.lastfm import LastfmClient, get_lastfm_client
 from .clients.spotify import SpotifyClient, get_spotify_client
-from sidetrack.common.config import Settings
-from sidetrack.common.config import get_settings as get_app_settings
+from .config import Settings
+from .config import get_settings as get_app_settings
 from .constants import AXES, DEFAULT_METHOD
 from .db import get_db, maybe_create_all
 from .schemas.labels import LabelResponse


### PR DESCRIPTION
## Summary
- centralize shared dependencies in pyproject and simplify service extras
- expose package metadata via `sidetrack.__init__`
- add dedicated `sidetrack.api.config` and update API modules to use it

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pre-commit run --files pyproject.toml requirements-dev.txt sidetrack/__init__.py sidetrack/api/config.py sidetrack/api/db.py sidetrack/api/main.py sidetrack/api/api/v1/auth.py sidetrack/api/api/v1/listens.py sidetrack/api/clients/lastfm.py sidetrack/api/clients/spotify.py` *(fails: command not found)*
- `pytest -q` *(fails: IntegrityError in spotify feature tests and OperationalError in dashboard test)*

------
https://chatgpt.com/codex/tasks/task_e_68c08a32fc8083338522a12c59352185