### PR TITLE
feat(ui): add auth context

### DIFF
--- a/services/ui/app/account/page.tsx
+++ b/services/ui/app/account/page.tsx
@@ -4,17 +4,18 @@ import { useEffect, useState } from 'react';
 import { Button } from '../../components/ui/button';
 import { Card } from '../../components/ui/card';
 import { useToast } from '../../components/ToastProvider';
+import { useAuth } from '../../lib/auth';
 
 export default function AccountPage() {
   const [user, setUser] = useState('');
   const [lfmUser, setLfmUser] = useState('');
   const [lfmConnected, setLfmConnected] = useState(false);
   const { show } = useToast();
+  const { userId } = useAuth();
 
   useEffect(() => {
-    const uid = localStorage.getItem('user_id') || '';
-    if (!uid) return;
-    fetch('/api/auth/me', { headers: { 'X-User-Id': uid } })
+    if (!userId) return;
+    fetch('/api/auth/me', { headers: { 'X-User-Id': userId } })
       .then((r) => r.json())
       .then((data) => {
         setUser(data.user_id || '');
@@ -24,13 +25,12 @@ export default function AccountPage() {
       .catch(() => {
         /* ignore */
       });
-  }, []);
+  }, [userId]);
 
   async function handleConnect() {
     const callback = encodeURIComponent(`${window.location.origin}/lastfm/callback`);
-    const uid = localStorage.getItem('user_id') || '';
     const res = await fetch(`/api/auth/lastfm/login?callback=${callback}`, {
-      headers: { 'X-User-Id': uid },
+      headers: { 'X-User-Id': userId },
     });
     const data = await res.json().catch(() => ({}));
     if (data.url) {
@@ -41,10 +41,9 @@ export default function AccountPage() {
   }
 
   async function handleDisconnect() {
-    const uid = localStorage.getItem('user_id') || '';
     const res = await fetch('/api/auth/lastfm/session', {
       method: 'DELETE',
-      headers: { 'X-User-Id': uid },
+      headers: { 'X-User-Id': userId },
     });
     if (!res.ok) {
       show({ title: 'Failed to disconnect Last.fm', kind: 'error' });

--- a/services/ui/app/lastfm/callback/page.tsx
+++ b/services/ui/app/lastfm/callback/page.tsx
@@ -2,19 +2,24 @@
 
 import { useEffect } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
+import { useAuth } from '../../../lib/auth';
 
 export default function LastfmCallback() {
   const params = useSearchParams();
   const router = useRouter();
+  const { userId } = useAuth();
 
   useEffect(() => {
     const token = params.get('token');
-    if (token) {
-      fetch(`/api/auth/lastfm/session?token=${token}`).finally(() => router.replace('/settings'));
-    } else {
+    if (!token) {
       router.replace('/settings');
+      return;
     }
-  }, [params, router]);
+    if (!userId) return;
+    fetch(`/api/auth/lastfm/session?token=${token}`, {
+      headers: { 'X-User-Id': userId },
+    }).finally(() => router.replace('/settings'));
+  }, [params, router, userId]);
 
   return <p>Connecting to Last.fm...</p>;
 }

--- a/services/ui/app/login/page.tsx
+++ b/services/ui/app/login/page.tsx
@@ -16,11 +16,7 @@ export default function LoginPage() {
       body: JSON.stringify({ username, password }),
     });
     if (res.ok) {
-      const data = await res.json();
-      if (data.user_id) {
-        localStorage.setItem('user_id', data.user_id);
-        window.location.href = '/account';
-      }
+      window.location.href = '/account';
     } else {
       setError('Login failed');
     }

--- a/services/ui/app/providers.tsx
+++ b/services/ui/app/providers.tsx
@@ -2,9 +2,14 @@
 
 import { useState } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AuthProvider } from '../lib/auth';
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(() => new QueryClient());
 
-  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  return (
+    <AuthProvider>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </AuthProvider>
+  );
 }

--- a/services/ui/app/settings/page.test.tsx
+++ b/services/ui/app/settings/page.test.tsx
@@ -2,10 +2,12 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Settings from './page';
 import ToastProvider from '../../components/ToastProvider';
+import { AuthProvider } from '../../lib/auth';
 
 describe('Settings page', () => {
   beforeEach(() => {
     global.fetch = jest.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+    document.cookie = 'uid=test';
   });
 
   afterEach(() => {
@@ -15,7 +17,9 @@ describe('Settings page', () => {
   it('validates ListenBrainz fields', async () => {
     render(
       <ToastProvider>
-        <Settings />
+        <AuthProvider>
+          <Settings />
+        </AuthProvider>
       </ToastProvider>,
     );
     const userInput = screen.getByPlaceholderText('ListenBrainz username');
@@ -38,7 +42,9 @@ describe('Settings page', () => {
 
     render(
       <ToastProvider>
-        <Settings />
+        <AuthProvider>
+          <Settings />
+        </AuthProvider>
       </ToastProvider>,
     );
     await userEvent.type(screen.getByPlaceholderText('ListenBrainz username'), 'lbuser');

--- a/services/ui/app/spotify/callback/page.tsx
+++ b/services/ui/app/spotify/callback/page.tsx
@@ -2,22 +2,25 @@
 
 import { useEffect } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
+import { useAuth } from '../../../lib/auth';
 
 export default function SpotifyCallback() {
   const params = useSearchParams();
   const router = useRouter();
+  const { userId } = useAuth();
 
   useEffect(() => {
     const code = params.get('code');
-    if (code) {
-      const callback = encodeURIComponent(`${window.location.origin}/spotify/callback`);
-      fetch(`/api/auth/spotify/callback?code=${code}&callback=${callback}`).finally(() =>
-        router.replace('/settings'),
-      );
-    } else {
+    if (!code) {
       router.replace('/settings');
+      return;
     }
-  }, [params, router]);
+    if (!userId) return;
+    const callback = encodeURIComponent(`${window.location.origin}/spotify/callback`);
+    fetch(`/api/auth/spotify/callback?code=${code}&callback=${callback}`, {
+      headers: { 'X-User-Id': userId },
+    }).finally(() => router.replace('/settings'));
+  }, [params, router, userId]);
 
   return <p>Connecting to Spotify...</p>;
 }

--- a/services/ui/lib/auth.tsx
+++ b/services/ui/lib/auth.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { createContext, useContext, useEffect, useState } from 'react';
+
+interface AuthContextValue {
+  userId: string;
+}
+
+const AuthContext = createContext<AuthContextValue>({ userId: '' });
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [userId, setUserId] = useState('');
+
+  useEffect(() => {
+    const match = document.cookie.match(/(?:^|; )uid=([^;]+)/);
+    if (match) {
+      setUserId(decodeURIComponent(match[1]));
+    }
+  }, []);
+
+  return <AuthContext.Provider value={{ userId }}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  return useContext(AuthContext);
+}


### PR DESCRIPTION
## Summary
- add AuthProvider to expose user id from uid cookie
- read user id from context instead of localStorage
- update fetches to forward X-User-Id header

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0c573c03883339b696bdf5c49e7e2