### PR TITLE
Respect next param for UI login redirects

### DIFF
--- a/services/ui/app/login/page.tsx
+++ b/services/ui/app/login/page.tsx
@@ -1,11 +1,15 @@
 'use client';
 
 import { useState, FormEvent } from 'react';
+import { useSearchParams, useRouter } from 'next/navigation';
 
 export default function LoginPage() {
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
+  const params = useSearchParams();
+  const router = useRouter();
+  const next = params.get('next');
 
   async function handleLogin(e: FormEvent) {
     e.preventDefault();
@@ -16,7 +20,7 @@ export default function LoginPage() {
       body: JSON.stringify({ username, password }),
     });
     if (res.ok) {
-      window.location.href = '/account';
+      router.push(next || '/');
     } else {
       setError('Login failed');
     }

--- a/services/ui/middleware.ts
+++ b/services/ui/middleware.ts
@@ -2,7 +2,7 @@ import { NextResponse, type NextRequest } from 'next/server';
 
 // Protect all routes except public ones
 export function middleware(req: NextRequest) {
-  const { pathname } = req.nextUrl;
+  const { pathname, search } = req.nextUrl;
 
   // Allow public assets and routes
   const publicPaths = [
@@ -23,7 +23,7 @@ export function middleware(req: NextRequest) {
   if (!uid) {
     const url = req.nextUrl.clone();
     url.pathname = '/login';
-    url.searchParams.set('next', pathname);
+    url.searchParams.set('next', pathname + search);
     return NextResponse.redirect(url);
   }
 


### PR DESCRIPTION
## Summary
- Read `next` query parameter on the login page and redirect to it after successful authentication
- Middleware now includes the full original path in the `next` query when redirecting unauthenticated users

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0c7fbde408333ab9f0035912c84c1