### PR TITLE
feat(ui): add authenticated fetch helper

### DIFF
--- a/services/ui/app/account/page.tsx
+++ b/services/ui/app/account/page.tsx
@@ -5,6 +5,7 @@ import { Button } from '../../components/ui/button';
 import { Card } from '../../components/ui/card';
 import { useToast } from '../../components/ToastProvider';
 import { useAuth } from '../../lib/auth';
+import { apiFetch } from '../../lib/api';
 
 export default function AccountPage() {
   const [user, setUser] = useState('');
@@ -15,7 +16,7 @@ export default function AccountPage() {
 
   useEffect(() => {
     if (!userId) return;
-    fetch('/api/auth/me', { headers: { 'X-User-Id': userId } })
+    apiFetch('/api/auth/me')
       .then((r) => r.json())
       .then((data) => {
         setUser(data.user_id || '');
@@ -29,9 +30,7 @@ export default function AccountPage() {
 
   async function handleConnect() {
     const callback = encodeURIComponent(`${window.location.origin}/lastfm/callback`);
-    const res = await fetch(`/api/auth/lastfm/login?callback=${callback}`, {
-      headers: { 'X-User-Id': userId },
-    });
+    const res = await apiFetch(`/api/auth/lastfm/login?callback=${callback}`);
     const data = await res.json().catch(() => ({}));
     if (data.url) {
       window.location.href = data.url;
@@ -41,9 +40,8 @@ export default function AccountPage() {
   }
 
   async function handleDisconnect() {
-    const res = await fetch('/api/auth/lastfm/session', {
+    const res = await apiFetch('/api/auth/lastfm/session', {
       method: 'DELETE',
-      headers: { 'X-User-Id': userId },
     });
     if (!res.ok) {
       show({ title: 'Failed to disconnect Last.fm', kind: 'error' });

--- a/services/ui/app/lastfm/callback/page.tsx
+++ b/services/ui/app/lastfm/callback/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { useAuth } from '../../../lib/auth';
+import { apiFetch } from '../../../lib/api';
 
 export default function LastfmCallback() {
   const params = useSearchParams();
@@ -16,9 +17,7 @@ export default function LastfmCallback() {
       return;
     }
     if (!userId) return;
-    fetch(`/api/auth/lastfm/session?token=${token}`, {
-      headers: { 'X-User-Id': userId },
-    }).finally(() => router.replace('/settings'));
+    apiFetch(`/api/auth/lastfm/session?token=${token}`).finally(() => router.replace('/settings'));
   }, [params, router, userId]);
 
   return <p>Connecting to Last.fm...</p>;

--- a/services/ui/app/login/page.tsx
+++ b/services/ui/app/login/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, FormEvent } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
+import { apiFetch } from '../../lib/api';
 
 export default function LoginPage() {
   const [username, setUsername] = useState('');
@@ -14,7 +15,7 @@ export default function LoginPage() {
   async function handleLogin(e: FormEvent) {
     e.preventDefault();
     setError('');
-    const res = await fetch('/api/auth/login', {
+    const res = await apiFetch('/api/auth/login', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username, password }),
@@ -28,7 +29,7 @@ export default function LoginPage() {
 
   async function handleRegister() {
     setError('');
-    const res = await fetch('/api/auth/register', {
+    const res = await apiFetch('/api/auth/register', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ username, password }),

--- a/services/ui/app/settings/page.tsx
+++ b/services/ui/app/settings/page.tsx
@@ -6,6 +6,7 @@ import { Button } from '../../components/ui/button';
 import { Card } from '../../components/ui/card';
 import { useToast } from '../../components/ToastProvider';
 import { useAuth } from '../../lib/auth';
+import { apiFetch } from '../../lib/api';
 
 interface SettingsData {
   listenBrainzUser: string;
@@ -36,7 +37,7 @@ export default function Settings() {
 
   useEffect(() => {
     if (!userId) return;
-    fetch('/api/settings', { headers: { 'X-User-Id': userId } })
+    apiFetch('/api/settings')
       .then((r) => r.json())
       .then((data: Partial<SettingsData>) => {
         setLbUser(data.listenBrainzUser || '');
@@ -74,9 +75,9 @@ export default function Settings() {
       useStems,
       useExcerpts,
     };
-    const res = await fetch('/api/settings', {
+    const res = await apiFetch('/api/settings', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'X-User-Id': userId },
+      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     });
     if (!res.ok) {
@@ -96,9 +97,7 @@ export default function Settings() {
 
   async function handleConnect() {
     const callback = encodeURIComponent(`${window.location.origin}/lastfm/callback`);
-    const res = await fetch(`/api/auth/lastfm/login?callback=${callback}`, {
-      headers: { 'X-User-Id': userId },
-    });
+    const res = await apiFetch(`/api/auth/lastfm/login?callback=${callback}`);
     const data = await res.json().catch(() => ({}));
     if (data.url) {
       window.location.href = data.url;
@@ -108,9 +107,8 @@ export default function Settings() {
   }
 
   async function handleDisconnect() {
-    const res = await fetch('/api/auth/lastfm/session', {
+    const res = await apiFetch('/api/auth/lastfm/session', {
       method: 'DELETE',
-      headers: { 'X-User-Id': userId },
     });
     if (!res.ok) {
       show({ title: 'Failed to disconnect Last.fm', kind: 'error' });
@@ -123,9 +121,7 @@ export default function Settings() {
 
   async function handleSpotifyConnect() {
     const callback = encodeURIComponent(`${window.location.origin}/spotify/callback`);
-    const res = await fetch(`/api/auth/spotify/login?callback=${callback}`, {
-      headers: { 'X-User-Id': userId },
-    });
+    const res = await apiFetch(`/api/auth/spotify/login?callback=${callback}`);
     const data = await res.json().catch(() => ({}));
     if (data.url) {
       window.location.href = data.url;
@@ -135,9 +131,8 @@ export default function Settings() {
   }
 
   async function handleSpotifyDisconnect() {
-    const res = await fetch('/api/auth/spotify/disconnect', {
+    const res = await apiFetch('/api/auth/spotify/disconnect', {
       method: 'DELETE',
-      headers: { 'X-User-Id': userId },
     });
     if (!res.ok) {
       show({ title: 'Failed to disconnect Spotify', kind: 'error' });

--- a/services/ui/app/spotify/callback/page.tsx
+++ b/services/ui/app/spotify/callback/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { useAuth } from '../../../lib/auth';
+import { apiFetch } from '../../../lib/api';
 
 export default function SpotifyCallback() {
   const params = useSearchParams();
@@ -17,9 +18,9 @@ export default function SpotifyCallback() {
     }
     if (!userId) return;
     const callback = encodeURIComponent(`${window.location.origin}/spotify/callback`);
-    fetch(`/api/auth/spotify/callback?code=${code}&callback=${callback}`, {
-      headers: { 'X-User-Id': userId },
-    }).finally(() => router.replace('/settings'));
+    apiFetch(`/api/auth/spotify/callback?code=${code}&callback=${callback}`).finally(() =>
+      router.replace('/settings'),
+    );
   }, [params, router, userId]);
 
   return <p>Connecting to Spotify...</p>;

--- a/services/ui/lib/api.ts
+++ b/services/ui/lib/api.ts
@@ -1,5 +1,14 @@
+import { getUserId } from './auth';
+
 export const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'https://sidetrack.network/api';
 
-export function apiFetch(path: string, init?: RequestInit) {
-  return fetch(`${API_BASE}${path}`, init);
+export function apiFetch(path: string, init: RequestInit = {}) {
+  const headers = new Headers(init.headers);
+  const uid = getUserId();
+  if (uid) headers.set('X-User-Id', uid);
+  const finalInit = { ...init, headers };
+  if (path.startsWith('/api/')) {
+    return fetch(path, finalInit);
+  }
+  return fetch(`${API_BASE}${path}`, finalInit);
 }

--- a/services/ui/lib/auth.tsx
+++ b/services/ui/lib/auth.tsx
@@ -8,6 +8,11 @@ interface AuthContextValue {
 
 const AuthContext = createContext<AuthContextValue>({ userId: '' });
 
+let currentUserId = '';
+export function getUserId() {
+  return currentUserId;
+}
+
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [userId, setUserId] = useState('');
 
@@ -17,6 +22,10 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       setUserId(decodeURIComponent(match[1]));
     }
   }, []);
+
+  useEffect(() => {
+    currentUserId = userId;
+  }, [userId]);
 
   return <AuthContext.Provider value={{ userId }}>{children}</AuthContext.Provider>;
 }


### PR DESCRIPTION
## Summary
- expose user id from auth context to helpers
- add apiFetch helper to attach `X-User-Id`
- replace direct fetch usage in UI pages with apiFetch

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0c984752c833384c3bccc85e7492a