### PR TITLE
Add client logout handling to AppShell

### DIFF
--- a/services/ui/components/AppShell.tsx
+++ b/services/ui/components/AppShell.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { LogOut } from 'lucide-react';
 import clsx from 'clsx';
 
 import NavRail from '../components/NavRail';
@@ -11,9 +13,19 @@ import MobileNav from './MobileNav';
 import { NavContext } from './NavContext';
 import Avatar from './ui/Avatar';
 import RouteProgress from './RouteProgress';
+import { useAuth } from '../lib/auth';
+import { apiFetch } from '../lib/api';
 
 export default function AppShell({ children }: { children: React.ReactNode }) {
   const [collapsed, setCollapsed] = useState(false);
+  const { setUserId } = useAuth();
+  const router = useRouter();
+
+  async function handleLogout() {
+    await apiFetch('/api/auth/logout', { method: 'POST' });
+    setUserId('');
+    router.push('/login');
+  }
 
   useEffect(() => {
     const stored = localStorage.getItem('nav-collapsed');
@@ -41,6 +53,13 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
               </div>
               <div className="flex items-center gap-3 text-sm text-muted-foreground">
                 <HeaderActions />
+                <button
+                  onClick={handleLogout}
+                  className="inline-flex items-center gap-2 rounded-full bg-white/5 px-3 py-1 text-xs text-muted-foreground hover:text-foreground"
+                >
+                  <LogOut size={14} />
+                  <span className="hidden sm:inline">Logout</span>
+                </button>
                 <span>
                   API: <ApiStatus />
                 </span>

--- a/services/ui/components/HeaderActions.tsx
+++ b/services/ui/components/HeaderActions.tsx
@@ -1,10 +1,9 @@
 'use client';
 import { useState } from 'react';
 import { motion } from 'framer-motion';
-import dynamic from 'next/dynamic';
 import { useToast } from './ToastProvider';
 import { useTheme } from './ThemeContext';
-import { RefreshCw, Sun, Moon, LogOut } from 'lucide-react';
+import { RefreshCw, Sun, Moon } from 'lucide-react';
 
 export default function HeaderActions() {
   const toast = useToast();
@@ -47,25 +46,6 @@ export default function HeaderActions() {
         </motion.span>
         Sync
       </button>
-      <form
-        action="/api/auth/logout"
-        method="post"
-        onSubmit={(e) => {
-          // let the request go, then redirect client-side
-          setTimeout(() => {
-            window.location.href = '/login';
-          }, 50);
-        }}
-      >
-        <button
-          type="submit"
-          className="inline-flex items-center gap-2 rounded-full bg-white/5 px-3 py-1 text-xs text-muted-foreground hover:text-foreground"
-          title="Log out"
-        >
-          <LogOut size={14} />
-          <span className="hidden sm:inline">Logout</span>
-        </button>
-      </form>
     </div>
   );
 }

--- a/services/ui/lib/auth.tsx
+++ b/services/ui/lib/auth.tsx
@@ -4,9 +4,10 @@ import { createContext, useContext, useEffect, useState } from 'react';
 
 interface AuthContextValue {
   userId: string;
+  setUserId: (id: string) => void;
 }
 
-const AuthContext = createContext<AuthContextValue>({ userId: '' });
+const AuthContext = createContext<AuthContextValue>({ userId: '', setUserId: () => {} });
 
 let currentUserId = '';
 export function getUserId() {
@@ -27,7 +28,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     currentUserId = userId;
   }, [userId]);
 
-  return <AuthContext.Provider value={{ userId }}>{children}</AuthContext.Provider>;
+  return <AuthContext.Provider value={{ userId, setUserId }}>{children}</AuthContext.Provider>;
 }
 
 export function useAuth() {


### PR DESCRIPTION
## Summary
- expose `setUserId` in auth context
- move logout button to `AppShell` and clear auth state
- remove old logout action from `HeaderActions`

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0cc7071f88333bf772d3b6485d29a