### PR TITLE
Validate user cookie in Next.js middleware

### DIFF
--- a/services/ui/middleware.test.ts
+++ b/services/ui/middleware.test.ts
@@ -1,0 +1,33 @@
+/** @jest-environment node */
+import { NextRequest } from 'next/server';
+import { middleware } from './middleware';
+
+describe('middleware', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('redirects to login and clears cookie when auth check fails', async () => {
+    (fetch as jest.Mock).mockResolvedValue({ ok: false });
+
+    const req = new NextRequest('https://example.com/dashboard', {
+      headers: { cookie: 'uid=123' },
+    });
+
+    const res = await middleware(req);
+
+    expect(fetch).toHaveBeenCalledWith('https://example.com/api/auth/me', {
+      headers: { cookie: 'uid=123' },
+    });
+    expect(res.status).toBe(307);
+    expect(res.headers.get('location')).toBe(
+      'https://example.com/login?next=%2Fdashboard',
+    );
+    expect(res.headers.get('set-cookie') ?? '').toMatch(/uid=;/);
+  });
+});
+


### PR DESCRIPTION
## Summary
- verify `/api/auth/me` before allowing protected routes
- clear invalid uid cookie and redirect to login
- add Jest test for middleware auth fallback

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0d655d4e88333be5e67b660476fee