### PR TITLE
Refactor scheduler for multi-user and update docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,8 +10,9 @@ POSTGRES_PORT=5432
 # AUTO_MIGRATE=1
 
 # ListenBrainz / MusicBrainz
-LISTENBRAINZ_USER=your_user
-LISTENBRAINZ_TOKEN=lb_xxx
+# Per-user credentials are managed via the API/UI
+# LISTENBRAINZ_USER=
+# LISTENBRAINZ_TOKEN=
 MUSICBRAINZ_RATE_LIMIT=1.0
 
 # Last.fm

--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ docker compose up -d --build
 # 4) Apply DB migrations
 docker compose exec api alembic upgrade head
 
-# 5) Pull listens and aggregate (replace YOUR_USER)
-curl -H "X-User-Id: YOUR_USER" -X POST "http://localhost:8000/api/v1/ingest/listens?since=2024-01-01"
-curl -H "X-User-Id: YOUR_USER" -X POST "http://localhost:8000/tags/lastfm/sync?since=2024-01-01"
-curl -H "X-User-Id: YOUR_USER" -X POST "http://localhost:8000/aggregate/weeks"
+# 5) Pull listens and aggregate for a user
+curl -H "X-User-Id: some_user" -X POST "http://localhost:8000/api/v1/ingest/listens?since=2024-01-01"
+curl -H "X-User-Id: some_user" -X POST "http://localhost:8000/tags/lastfm/sync?since=2024-01-01"
+curl -H "X-User-Id: some_user" -X POST "http://localhost:8000/aggregate/weeks"
 # Sample listens file uses placeholder user IDs (`user1`–`user5`).
 
 # 6) Open the UI
@@ -91,8 +91,9 @@ POSTGRES_PASSWORD=vibe
 POSTGRES_PORT=5432
 
 # ListenBrainz / MusicBrainz
-LISTENBRAINZ_USER=your_user          # ListenBrainz username for ingestion
-LISTENBRAINZ_TOKEN=lb_xxx            # ListenBrainz API token
+# Per-user credentials are managed via the API/UI
+# LISTENBRAINZ_USER=
+# LISTENBRAINZ_TOKEN=
 MUSICBRAINZ_RATE_LIMIT=1.0   # req/sec
 
 # Last.fm
@@ -197,10 +198,10 @@ docker compose up -d --build
 # 5) Bootstrap DB (migrations)
 docker compose exec api alembic upgrade head
 
-# 6) First sync + analysis
-curl -H "X-User-Id: your-user" -X POST http://localhost:8000/api/v1/ingest/listens?since=2024-01-01
-curl -H "X-User-Id: your-user" -X POST http://localhost:8000/tags/lastfm/sync?since=2024-01-01
-curl -H "X-User-Id: your-user" -X POST http://localhost:8000/aggregate/weeks
+# 6) First sync + analysis for a user
+curl -H "X-User-Id: some_user" -X POST http://localhost:8000/api/v1/ingest/listens?since=2024-01-01
+curl -H "X-User-Id: some_user" -X POST http://localhost:8000/tags/lastfm/sync?since=2024-01-01
+curl -H "X-User-Id: some_user" -X POST http://localhost:8000/aggregate/weeks
 
 # 7) Open UI (default port)
 http://localhost:3000

--- a/sidetrack/scheduler/run.py
+++ b/sidetrack/scheduler/run.py
@@ -1,8 +1,14 @@
+"""Lightweight scheduler that triggers API tasks for all users."""
+
 import logging
 import time
 
 import requests
 import schedule
+from sqlalchemy import select
+
+from sidetrack.api.db import SessionLocal
+from sidetrack.common.models import UserAccount
 
 from .config import get_settings
 
@@ -13,79 +19,80 @@ settings = get_settings()
 
 
 def fetch_user_ids() -> list[str]:
+    """Return all registered user ids from the database."""
     try:
-        resp = requests.get(f"{settings.api_url}/auth/users", timeout=10)
-        resp.raise_for_status()
-        data = resp.json()
-        if isinstance(data, dict):
-            return data.get("users", [])
-        return data
-    except Exception:  # pragma: no cover - network errors
+        with SessionLocal(async_session=False) as db:
+            stmt = select(UserAccount.user_id)
+            return list(db.execute(stmt).scalars().all())
+    except Exception:  # pragma: no cover - db errors
         logger.exception("fetch user ids error")
         return []
 
 
-def ingest_listens():
-    for user_id in fetch_user_ids():
-        try:
-            r = requests.post(
-                f"{settings.api_url}/ingest/listens",
-                timeout=10,
-                headers={"X-User-Id": user_id},
-            )
-            logger.info("ingest listens %s: %s", user_id, r.status_code)
-        except Exception:
-            logger.exception("ingest listens error for %s", user_id)
+def ingest_listens(user_id: str) -> None:
+    """Trigger ListenBrainz ingestion for ``user_id``."""
+    try:
+        r = requests.post(
+            f"{settings.api_url}/ingest/listens",
+            timeout=10,
+            headers={"X-User-Id": user_id},
+        )
+        logger.info("ingest listens %s: %s", user_id, r.status_code)
+    except Exception:
+        logger.exception("ingest listens error for %s", user_id)
 
 
-def import_spotify_listens():
-    for user_id in fetch_user_ids():
-        try:
-            r = requests.post(
-                f"{settings.api_url}/spotify/listens",
-                timeout=10,
-                headers={"X-User-Id": user_id},
-            )
-            logger.info("spotify listens %s: %s", user_id, r.status_code)
-        except Exception:
-            logger.exception("spotify listens error for %s", user_id)
+def import_spotify_listens(user_id: str) -> None:
+    """Trigger Spotify listens import for ``user_id``."""
+    try:
+        r = requests.post(
+            f"{settings.api_url}/spotify/listens",
+            timeout=10,
+            headers={"X-User-Id": user_id},
+        )
+        logger.info("spotify listens %s: %s", user_id, r.status_code)
+    except Exception:
+        logger.exception("spotify listens error for %s", user_id)
 
 
-def sync_lastfm_tags():
-    for user_id in fetch_user_ids():
-        try:
-            r = requests.post(
-                f"{settings.api_url}/tags/lastfm/sync",
-                timeout=10,
-                headers={"X-User-Id": user_id},
-            )
-            logger.info("lastfm sync %s: %s", user_id, r.status_code)
-        except Exception:
-            logger.exception("lastfm sync error for %s", user_id)
+def sync_lastfm_tags(user_id: str) -> None:
+    """Trigger Last.fm tag sync for ``user_id``."""
+    try:
+        r = requests.post(
+            f"{settings.api_url}/tags/lastfm/sync",
+            timeout=10,
+            headers={"X-User-Id": user_id},
+        )
+        logger.info("lastfm sync %s: %s", user_id, r.status_code)
+    except Exception:
+        logger.exception("lastfm sync error for %s", user_id)
 
 
-def aggregate_weeks():
-    for user_id in fetch_user_ids():
-        try:
-            r = requests.post(
-                f"{settings.api_url}/aggregate/weeks",
-                timeout=30,
-                headers={"X-User-Id": user_id},
-            )
-            logger.info("aggregate weeks %s: %s", user_id, r.status_code)
-        except Exception:
-            logger.exception("aggregate weeks error for %s", user_id)
+def aggregate_weeks(user_id: str) -> None:
+    """Trigger weekly aggregation for ``user_id``."""
+    try:
+        r = requests.post(
+            f"{settings.api_url}/aggregate/weeks",
+            timeout=30,
+            headers={"X-User-Id": user_id},
+        )
+        logger.info("aggregate weeks %s: %s", user_id, r.status_code)
+    except Exception:
+        logger.exception("aggregate weeks error for %s", user_id)
 
 
-def schedule_jobs():
+def schedule_jobs() -> None:
+    """Schedule periodic tasks for each registered user."""
     ingest_minutes = settings.ingest_listens_interval_minutes
     spotify_minutes = settings.spotify_listens_interval_minutes
     tags_minutes = settings.lastfm_sync_interval_minutes
     agg_minutes = settings.aggregate_weeks_interval_minutes
-    schedule.every(ingest_minutes).minutes.do(ingest_listens)
-    schedule.every(spotify_minutes).minutes.do(import_spotify_listens)
-    schedule.every(tags_minutes).minutes.do(sync_lastfm_tags)
-    schedule.every(agg_minutes).minutes.do(aggregate_weeks)
+
+    for user_id in fetch_user_ids():
+        schedule.every(ingest_minutes).minutes.do(ingest_listens, user_id)
+        schedule.every(spotify_minutes).minutes.do(import_spotify_listens, user_id)
+        schedule.every(tags_minutes).minutes.do(sync_lastfm_tags, user_id)
+        schedule.every(agg_minutes).minutes.do(aggregate_weeks, user_id)
 
 
 def main():


### PR DESCRIPTION
## Summary
- allow scheduler tasks to run per user by passing a `user_id` and querying the `UserAccount` table when scheduling jobs
- document multi-user usage and remove single-user environment vars

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c0e7ba9fd083339d1fec1c8b3cf991