### PR TITLE
fix(ui): forward X-User-Id for Last.fm sync

### DIFF
--- a/services/ui/components/HeaderActions.tsx
+++ b/services/ui/components/HeaderActions.tsx
@@ -4,6 +4,7 @@ import { motion } from 'framer-motion';
 import { useToast } from './ToastProvider';
 import { useTheme } from './ThemeContext';
 import { RefreshCw, Sun, Moon } from 'lucide-react';
+import { apiFetch } from '../lib/api';
 
 export default function HeaderActions() {
   const toast = useToast();
@@ -14,7 +15,7 @@ export default function HeaderActions() {
     setSyncing(true);
     toast.show({ title: 'Sync started', description: 'Fetching listens…', kind: 'info' });
     try {
-      await fetch('/api/lastfm/sync', { method: 'POST' });
+      await apiFetch('/api/lastfm/sync', { method: 'POST' });
       toast.show({ title: 'Sync complete', description: 'Listens updated', kind: 'success' });
     } catch {
       toast.show({ title: 'Sync failed', description: 'Please try again later', kind: 'error' });


### PR DESCRIPTION
## Summary
- use `apiFetch` for Last.fm sync to send the `X-User-Id` header automatically

## Testing
- `pytest -q`
- `cd services/ui && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0ececac588333be8e7737bb78b1b9