### PR TITLE
feat(ui): add skeleton and empty state to outliers page

### DIFF
--- a/services/ui/app/outliers/page.tsx
+++ b/services/ui/app/outliers/page.tsx
@@ -1,26 +1,40 @@
 'use client';
 
+import ChartContainer from '../../components/ChartContainer';
+import EmptyState from '../../components/EmptyState';
+import Skeleton from '../../components/Skeleton';
 import { useOutliers } from '../../lib/query';
 
 export default function Outliers() {
   const { data, isLoading } = useOutliers();
   const tracks = data?.tracks ?? [];
+
+  let content;
+  if (isLoading) {
+    content = <Skeleton className="h-[clamp(120px,25vh,160px)]" />;
+  } else if (!tracks.length) {
+    content = <EmptyState title="No outliers found." />;
+  } else {
+    content = (
+      <ul className="space-y-2 text-sm">
+        {tracks.map((t) => (
+          <li key={t.track_id} className="flex items-center justify-between">
+            <span>
+              {t.title} – {t.artist || 'Unknown'}
+            </span>
+            <span className="text-muted-foreground">{t.distance.toFixed(3)}</span>
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
   return (
-    <section>
-      <h2>Outliers</h2>
-      {isLoading ? (
-        <p>Loading...</p>
-      ) : tracks.length === 0 ? (
-        <p>No outliers found.</p>
-      ) : (
-        <ul>
-          {tracks.map((t) => (
-            <li key={t.track_id}>
-              {t.title} – {t.artist || 'Unknown'} ({t.distance.toFixed(3)})
-            </li>
-          ))}
-        </ul>
-      )}
+    <section className="space-y-4">
+      <h2 className="text-xl font-semibold">Outliers</h2>
+      <ChartContainer title="Outliers" subtitle="Far from your recent centroid">
+        {content}
+      </ChartContainer>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- wrap outliers page content in ChartContainer
- show Skeleton while loading and EmptyState when no tracks
- mute distance values for each track item

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0eceda128833385cbee236dd248a3