### PR TITLE
feat(ui): show empty state for moods and radar

### DIFF
--- a/services/ui/app/moods/page.tsx
+++ b/services/ui/app/moods/page.tsx
@@ -6,6 +6,7 @@ import { useTrajectory } from '../../lib/query';
 import ChartContainer from '../../components/ChartContainer';
 import FilterBar from '../../components/FilterBar';
 import Skeleton from '../../components/Skeleton';
+import EmptyState from '../../components/EmptyState';
 
 const MoodsStreamgraph = dynamic(() => import('../../components/charts/MoodsStreamgraph'), {
   loading: () => <Skeleton className="aspect-[4/3] h-[clamp(240px,40vh,340px)]" />,
@@ -54,7 +55,8 @@ export default function Moods() {
 
   const content = useMemo(() => {
     if (loading) return <Skeleton className="aspect-[4/3] h-[clamp(240px,40vh,340px)]" />;
-    if (!series.length) return <div className="text-sm text-muted-foreground">No data yet.</div>;
+    if (!series.length)
+      return <EmptyState title="No data yet" description="Ingest some listens to begin." />;
     return (
       <Suspense fallback={<Skeleton className="aspect-[4/3] h-[clamp(240px,40vh,340px)]" />}>
         <MoodsStreamgraph data={series} axes={axes} />

--- a/services/ui/app/radar/page.tsx
+++ b/services/ui/app/radar/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from 'react';
 import dynamic from 'next/dynamic';
 import ChartContainer from '../../components/ChartContainer';
 import Skeleton from '../../components/Skeleton';
+import EmptyState from '../../components/EmptyState';
 import { apiFetch } from '../../lib/api';
 
 type RadarData = {
@@ -35,7 +36,7 @@ export default async function Radar() {
     <section className="space-y-4">
       <h2 className="text-xl font-semibold">Weekly Radar</h2>
       {!data.week ? (
-        <p>No data yet. Ingest some listens to begin.</p>
+        <EmptyState title="No data yet" description="Ingest some listens to begin." />
       ) : (
         <ChartContainer title="Radar" subtitle="Current week vs baseline">
           <Suspense fallback={<Skeleton className="aspect-[4/3] h-[clamp(240px,40vh,380px)]" />}>


### PR DESCRIPTION
## Summary
- replace inline empty messages with `EmptyState` component in moods and radar pages

## Testing
- `pre-commit run --files services/ui/app/moods/page.tsx services/ui/app/radar/page.tsx`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0ecf63c108333b5d6666c222cacd9