### PR TITLE
feat(ui): add route-level loading and error states

### DIFF
--- a/services/ui/app/account/error.tsx
+++ b/services/ui/app/account/error.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center gap-4 py-10">
+      <p className="text-sm text-rose-400">Something went wrong.</p>
+      <button onClick={() => reset()} className="rounded bg-emerald-500 px-4 py-2 text-white">
+        Try again
+      </button>
+      <Link href="/" className="text-sm text-emerald-400 hover:underline">
+        Go home
+      </Link>
+    </div>
+  );
+}

--- a/services/ui/app/account/loading.tsx
+++ b/services/ui/app/account/loading.tsx
@@ -1,0 +1,11 @@
+import Skeleton from '../../components/Skeleton';
+
+export default function Loading() {
+  return (
+    <section className="space-y-6">
+      <Skeleton className="h-8 w-32" />
+      <Skeleton className="h-5 w-48" />
+      <Skeleton className="h-32" />
+    </section>
+  );
+}

--- a/services/ui/app/error.tsx
+++ b/services/ui/app/error.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center gap-4 py-10">
+      <p className="text-sm text-rose-400">Something went wrong.</p>
+      <button onClick={() => reset()} className="rounded bg-emerald-500 px-4 py-2 text-white">
+        Try again
+      </button>
+      <Link href="/" className="text-sm text-emerald-400 hover:underline">
+        Go home
+      </Link>
+    </div>
+  );
+}

--- a/services/ui/app/lastfm/callback/error.tsx
+++ b/services/ui/app/lastfm/callback/error.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center gap-4 py-10">
+      <p className="text-sm text-rose-400">Something went wrong.</p>
+      <button onClick={() => reset()} className="rounded bg-emerald-500 px-4 py-2 text-white">
+        Try again
+      </button>
+      <Link href="/" className="text-sm text-emerald-400 hover:underline">
+        Go home
+      </Link>
+    </div>
+  );
+}

--- a/services/ui/app/lastfm/callback/loading.tsx
+++ b/services/ui/app/lastfm/callback/loading.tsx
@@ -1,0 +1,5 @@
+import Skeleton from '../../../components/Skeleton';
+
+export default function Loading() {
+  return <Skeleton className="h-4 w-48" />;
+}

--- a/services/ui/app/loading.tsx
+++ b/services/ui/app/loading.tsx
@@ -1,0 +1,26 @@
+import ChartSkeleton from '../components/ChartSkeleton';
+import Skeleton from '../components/Skeleton';
+
+export default function Loading() {
+  return (
+    <section className="@container space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="space-y-2">
+          <Skeleton className="h-6 w-32" />
+          <Skeleton className="h-4 w-48" />
+        </div>
+        <Skeleton className="h-8 w-24" />
+      </div>
+      <div className="grid gap-4 @[640px]:grid-cols-2 @[1024px]:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-24" />
+        ))}
+      </div>
+      <Skeleton className="h-8 w-32" />
+      <div className="grid gap-6 @[768px]:grid-cols-2">
+        <ChartSkeleton />
+        <ChartSkeleton />
+      </div>
+    </section>
+  );
+}

--- a/services/ui/app/login/error.tsx
+++ b/services/ui/app/login/error.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center gap-4 py-10">
+      <p className="text-sm text-rose-400">Something went wrong.</p>
+      <button onClick={() => reset()} className="rounded bg-emerald-500 px-4 py-2 text-white">
+        Try again
+      </button>
+      <Link href="/" className="text-sm text-emerald-400 hover:underline">
+        Go home
+      </Link>
+    </div>
+  );
+}

--- a/services/ui/app/login/loading.tsx
+++ b/services/ui/app/login/loading.tsx
@@ -1,0 +1,12 @@
+import Skeleton from '../../components/Skeleton';
+
+export default function Loading() {
+  return (
+    <section className="max-w-sm mx-auto mt-20 space-y-4">
+      <Skeleton className="h-6 w-32" />
+      <Skeleton className="h-10 w-full" />
+      <Skeleton className="h-10 w-full" />
+      <Skeleton className="h-8 w-full" />
+    </section>
+  );
+}

--- a/services/ui/app/moods/error.tsx
+++ b/services/ui/app/moods/error.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center gap-4 py-10">
+      <p className="text-sm text-rose-400">Something went wrong.</p>
+      <button onClick={() => reset()} className="rounded bg-emerald-500 px-4 py-2 text-white">
+        Try again
+      </button>
+      <Link href="/" className="text-sm text-emerald-400 hover:underline">
+        Go home
+      </Link>
+    </div>
+  );
+}

--- a/services/ui/app/moods/loading.tsx
+++ b/services/ui/app/moods/loading.tsx
@@ -1,0 +1,20 @@
+import ChartSkeleton from '../../components/ChartSkeleton';
+import ChartContainer from '../../components/ChartContainer';
+import Skeleton from '../../components/Skeleton';
+
+export default function Loading() {
+  return (
+    <section className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="space-y-2">
+          <Skeleton className="h-6 w-32" />
+          <Skeleton className="h-4 w-48" />
+        </div>
+        <Skeleton className="h-8 w-24" />
+      </div>
+      <ChartContainer title="Mood streamgraph" subtitle="Axes stacked by week">
+        <ChartSkeleton className="h-[clamp(240px,40vh,340px)]" />
+      </ChartContainer>
+    </section>
+  );
+}

--- a/services/ui/app/moods/page.tsx
+++ b/services/ui/app/moods/page.tsx
@@ -5,11 +5,11 @@ import { apiFetch } from '../../lib/api';
 import { useTrajectory } from '../../lib/query';
 import ChartContainer from '../../components/ChartContainer';
 import FilterBar from '../../components/FilterBar';
-import Skeleton from '../../components/Skeleton';
+import ChartSkeleton from '../../components/ChartSkeleton';
 import EmptyState from '../../components/EmptyState';
 
 const MoodsStreamgraph = dynamic(() => import('../../components/charts/MoodsStreamgraph'), {
-  loading: () => <Skeleton className="aspect-[4/3] h-[clamp(240px,40vh,340px)]" />,
+  loading: () => <ChartSkeleton className="h-[clamp(240px,40vh,340px)]" />,
   ssr: false,
 });
 
@@ -54,11 +54,11 @@ export default function Moods() {
   const loading = trajLoading || radarLoading;
 
   const content = useMemo(() => {
-    if (loading) return <Skeleton className="aspect-[4/3] h-[clamp(240px,40vh,340px)]" />;
+    if (loading) return <ChartSkeleton className="h-[clamp(240px,40vh,340px)]" />;
     if (!series.length)
       return <EmptyState title="No data yet" description="Ingest some listens to begin." />;
     return (
-      <Suspense fallback={<Skeleton className="aspect-[4/3] h-[clamp(240px,40vh,340px)]" />}>
+      <Suspense fallback={<ChartSkeleton className="h-[clamp(240px,40vh,340px)]" />}> 
         <MoodsStreamgraph data={series} axes={axes} />
       </Suspense>
     );

--- a/services/ui/app/outliers/error.tsx
+++ b/services/ui/app/outliers/error.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center gap-4 py-10">
+      <p className="text-sm text-rose-400">Something went wrong.</p>
+      <button onClick={() => reset()} className="rounded bg-emerald-500 px-4 py-2 text-white">
+        Try again
+      </button>
+      <Link href="/" className="text-sm text-emerald-400 hover:underline">
+        Go home
+      </Link>
+    </div>
+  );
+}

--- a/services/ui/app/outliers/loading.tsx
+++ b/services/ui/app/outliers/loading.tsx
@@ -1,0 +1,13 @@
+import ChartContainer from '../../components/ChartContainer';
+import Skeleton from '../../components/Skeleton';
+
+export default function Loading() {
+  return (
+    <section className="space-y-4">
+      <Skeleton className="h-6 w-32" />
+      <ChartContainer title="Outliers" subtitle="Far from your recent centroid">
+        <Skeleton className="h-[clamp(120px,25vh,160px)]" />
+      </ChartContainer>
+    </section>
+  );
+}

--- a/services/ui/app/radar/error.tsx
+++ b/services/ui/app/radar/error.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center gap-4 py-10">
+      <p className="text-sm text-rose-400">Something went wrong.</p>
+      <button onClick={() => reset()} className="rounded bg-emerald-500 px-4 py-2 text-white">
+        Try again
+      </button>
+      <Link href="/" className="text-sm text-emerald-400 hover:underline">
+        Go home
+      </Link>
+    </div>
+  );
+}

--- a/services/ui/app/radar/loading.tsx
+++ b/services/ui/app/radar/loading.tsx
@@ -1,0 +1,14 @@
+import ChartSkeleton from '../../components/ChartSkeleton';
+import ChartContainer from '../../components/ChartContainer';
+import Skeleton from '../../components/Skeleton';
+
+export default function Loading() {
+  return (
+    <section className="space-y-4">
+      <Skeleton className="h-6 w-40" />
+      <ChartContainer title="Radar" subtitle="Current week vs baseline">
+        <ChartSkeleton />
+      </ChartContainer>
+    </section>
+  );
+}

--- a/services/ui/app/radar/page.tsx
+++ b/services/ui/app/radar/page.tsx
@@ -1,7 +1,7 @@
 import { Suspense } from 'react';
 import dynamic from 'next/dynamic';
 import ChartContainer from '../../components/ChartContainer';
-import Skeleton from '../../components/Skeleton';
+import ChartSkeleton from '../../components/ChartSkeleton';
 import EmptyState from '../../components/EmptyState';
 import { apiFetch } from '../../lib/api';
 
@@ -27,7 +27,7 @@ async function getRadar(): Promise<RadarData> {
 
 const RadarChart = dynamic(() => import('../../components/charts/RadarChart'), {
   ssr: false,
-  loading: () => <Skeleton className="aspect-[4/3] h-[clamp(240px,40vh,380px)]" />,
+  loading: () => <ChartSkeleton />,
 });
 
 export default async function Radar() {
@@ -39,7 +39,7 @@ export default async function Radar() {
         <EmptyState title="No data yet" description="Ingest some listens to begin." />
       ) : (
         <ChartContainer title="Radar" subtitle="Current week vs baseline">
-          <Suspense fallback={<Skeleton className="aspect-[4/3] h-[clamp(240px,40vh,380px)]" />}>
+          <Suspense fallback={<ChartSkeleton />}>
             <RadarChart
               axes={data.axes as Record<string, number>}
               baseline={data.baseline as Record<string, number>}

--- a/services/ui/app/settings/error.tsx
+++ b/services/ui/app/settings/error.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center gap-4 py-10">
+      <p className="text-sm text-rose-400">Something went wrong.</p>
+      <button onClick={() => reset()} className="rounded bg-emerald-500 px-4 py-2 text-white">
+        Try again
+      </button>
+      <Link href="/" className="text-sm text-emerald-400 hover:underline">
+        Go home
+      </Link>
+    </div>
+  );
+}

--- a/services/ui/app/settings/loading.tsx
+++ b/services/ui/app/settings/loading.tsx
@@ -1,0 +1,12 @@
+import Skeleton from '../../components/Skeleton';
+
+export default function Loading() {
+  return (
+    <section className="space-y-6">
+      <Skeleton className="h-8 w-32" />
+      {Array.from({ length: 4 }).map((_, i) => (
+        <Skeleton key={i} className="h-40" />
+      ))}
+    </section>
+  );
+}

--- a/services/ui/app/spotify/callback/error.tsx
+++ b/services/ui/app/spotify/callback/error.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center gap-4 py-10">
+      <p className="text-sm text-rose-400">Something went wrong.</p>
+      <button onClick={() => reset()} className="rounded bg-emerald-500 px-4 py-2 text-white">
+        Try again
+      </button>
+      <Link href="/" className="text-sm text-emerald-400 hover:underline">
+        Go home
+      </Link>
+    </div>
+  );
+}

--- a/services/ui/app/spotify/callback/loading.tsx
+++ b/services/ui/app/spotify/callback/loading.tsx
@@ -1,0 +1,5 @@
+import Skeleton from '../../../components/Skeleton';
+
+export default function Loading() {
+  return <Skeleton className="h-4 w-48" />;
+}

--- a/services/ui/app/trajectory/error.tsx
+++ b/services/ui/app/trajectory/error.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex flex-col items-center gap-4 py-10">
+      <p className="text-sm text-rose-400">Something went wrong.</p>
+      <button onClick={() => reset()} className="rounded bg-emerald-500 px-4 py-2 text-white">
+        Try again
+      </button>
+      <Link href="/" className="text-sm text-emerald-400 hover:underline">
+        Go home
+      </Link>
+    </div>
+  );
+}

--- a/services/ui/app/trajectory/loading.tsx
+++ b/services/ui/app/trajectory/loading.tsx
@@ -1,0 +1,20 @@
+import ChartSkeleton from '../../components/ChartSkeleton';
+import ChartContainer from '../../components/ChartContainer';
+import Skeleton from '../../components/Skeleton';
+
+export default function Loading() {
+  return (
+    <section className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div className="space-y-2">
+          <Skeleton className="h-6 w-32" />
+          <Skeleton className="h-4 w-48" />
+        </div>
+        <Skeleton className="h-8 w-24" />
+      </div>
+      <ChartContainer title="Trajectory" subtitle="Recent weekly bubbles and positions">
+        <ChartSkeleton />
+      </ChartContainer>
+    </section>
+  );
+}

--- a/services/ui/app/trajectory/page.tsx
+++ b/services/ui/app/trajectory/page.tsx
@@ -2,10 +2,10 @@ import { Suspense } from 'react';
 import dynamic from 'next/dynamic';
 import ChartContainer from '../../components/ChartContainer';
 import FilterBar from '../../components/FilterBar';
-import Skeleton from '../../components/Skeleton';
+import ChartSkeleton from '../../components/ChartSkeleton';
 
 const TrajectoryClient = dynamic(() => import('../../components/charts/TrajectoryClient'), {
-  loading: () => <Skeleton className="aspect-[4/3] h-[clamp(240px,40vh,380px)]" />,
+  loading: () => <ChartSkeleton />,
   ssr: false,
 });
 
@@ -27,7 +27,7 @@ export default async function Trajectory() {
         />
       </div>
       <ChartContainer title="Trajectory" subtitle="Recent weekly bubbles and positions">
-        <Suspense fallback={<Skeleton className="aspect-[4/3] h-[clamp(240px,40vh,380px)]" />}>
+        <Suspense fallback={<ChartSkeleton />}>
           <TrajectoryClient />
         </Suspense>
       </ChartContainer>

--- a/services/ui/components/ChartSkeleton.tsx
+++ b/services/ui/components/ChartSkeleton.tsx
@@ -1,0 +1,6 @@
+import Skeleton from './Skeleton';
+import { cn } from '../lib/utils';
+
+export default function ChartSkeleton({ className }: { className?: string }) {
+  return <Skeleton className={cn('aspect-[4/3] h-[clamp(240px,40vh,380px)]', className)} />;
+}

--- a/services/ui/components/charts/TrajectoryClient.tsx
+++ b/services/ui/components/charts/TrajectoryClient.tsx
@@ -1,22 +1,22 @@
 'use client';
 import { Suspense } from 'react';
 import dynamic from 'next/dynamic';
-import Skeleton from '../Skeleton';
+import ChartSkeleton from '../ChartSkeleton';
 import { useTrajectory } from '../../lib/query';
 
 const TrajectoryBubble = dynamic(() => import('./TrajectoryBubble'), {
-  loading: () => <Skeleton className="aspect-[4/3] h-[clamp(240px,40vh,380px)]" />,
+  loading: () => <ChartSkeleton />,
   ssr: false,
 });
 
 export default function TrajectoryClient() {
   const { data, isLoading, isError } = useTrajectory();
 
-  if (isLoading) return <Skeleton className="aspect-[4/3] h-[clamp(240px,40vh,380px)]" />;
+  if (isLoading) return <ChartSkeleton />;
   if (isError || !data)
     return <div className="text-sm text-rose-400">Failed to load trajectory</div>;
   return (
-    <Suspense fallback={<Skeleton className="aspect-[4/3] h-[clamp(240px,40vh,380px)]" />}>
+    <Suspense fallback={<ChartSkeleton />}>
       <TrajectoryBubble data={data} />
     </Suspense>
   );


### PR DESCRIPTION
## Summary
- add shared `ChartSkeleton` component and use in chart pages
- add `loading.tsx` and `error.tsx` for all app routes with retry/navigation

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0ef04c9f88333885016c6c2b251e5