### PR TITLE
Improve mobile spacing and touch targets

### DIFF
--- a/services/ui/app/moods/page.tsx
+++ b/services/ui/app/moods/page.tsx
@@ -65,7 +65,7 @@ export default function Moods() {
   }, [loading, series, axes]);
 
   return (
-    <section className="space-y-4">
+    <section className="@container space-y-6">
       <div className="flex items-center justify-between">
         <div>
           <h2 className="text-xl font-semibold">Moods</h2>

--- a/services/ui/app/outliers/page.tsx
+++ b/services/ui/app/outliers/page.tsx
@@ -30,7 +30,7 @@ export default function Outliers() {
   }
 
   return (
-    <section className="space-y-4">
+    <section className="@container space-y-6">
       <h2 className="text-xl font-semibold">Outliers</h2>
       <ChartContainer title="Outliers" subtitle="Far from your recent centroid">
         {content}

--- a/services/ui/app/page.tsx
+++ b/services/ui/app/page.tsx
@@ -16,7 +16,7 @@ export default function Home() {
         </div>
         <Link
           href="/trajectory"
-          className="rounded-full bg-emerald-500/10 px-4 py-2 text-sm text-emerald-300 hover:bg-emerald-500/20"
+          className="h-11 rounded-full bg-emerald-500/10 px-4 text-sm text-emerald-300 hover:bg-emerald-500/20"
         >
           View trajectory
         </Link>

--- a/services/ui/app/radar/page.tsx
+++ b/services/ui/app/radar/page.tsx
@@ -33,7 +33,7 @@ const RadarChart = dynamic(() => import('../../components/charts/RadarChart'), {
 export default async function Radar() {
   const data = await getRadar();
   return (
-    <section className="space-y-4">
+    <section className="@container space-y-6">
       <h2 className="text-xl font-semibold">Weekly Radar</h2>
       {!data.week ? (
         <EmptyState title="No data yet" description="Ingest some listens to begin." />

--- a/services/ui/app/settings/page.test.tsx
+++ b/services/ui/app/settings/page.test.tsx
@@ -63,6 +63,8 @@ describe('Settings page', () => {
       useStems: true,
       useExcerpts: true,
     });
-    expect(await screen.findByRole('status')).toHaveTextContent(/saved/i);
+    await waitFor(() =>
+      expect(screen.getByRole('status')).toHaveTextContent(/saved/i),
+    );
   });
 });

--- a/services/ui/app/settings/page.tsx
+++ b/services/ui/app/settings/page.tsx
@@ -144,7 +144,7 @@ export default function Settings() {
   }
 
   return (
-    <section className="space-y-6">
+    <section className="@container space-y-6">
       <h2>Settings</h2>
       {errors.length > 0 && <div role="alert">{errors.join(', ')}</div>}
       {message && <div role="status">{message}</div>}

--- a/services/ui/app/trajectory/page.tsx
+++ b/services/ui/app/trajectory/page.tsx
@@ -11,7 +11,7 @@ const TrajectoryClient = dynamic(() => import('../../components/charts/Trajector
 
 export default async function Trajectory() {
   return (
-    <section className="space-y-4">
+    <section className="@container space-y-6">
       <div className="flex items-center justify-between">
         <div>
           <h2 className="text-xl font-semibold">Taste Trajectory</h2>

--- a/services/ui/components/AppShell.tsx
+++ b/services/ui/components/AppShell.tsx
@@ -40,7 +40,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
   return (
     <ToastProvider>
       <NavContext.Provider value={{ collapsed, setCollapsed }}>
-        <div className="min-h-dvh md:flex">
+        <div className="min-h-dvh overflow-x-hidden md:flex">
           <aside className={clsx('hidden md:block transition-all', collapsed ? 'w-16' : 'w-60')}>
             <NavRail />
           </aside>
@@ -55,7 +55,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
                 <HeaderActions />
                 <button
                   onClick={handleLogout}
-                  className="inline-flex items-center gap-2 rounded-full bg-white/5 px-3 py-1 text-xs text-muted-foreground hover:text-foreground"
+                  className="inline-flex h-11 items-center gap-2 rounded-full bg-white/5 px-4 text-sm text-muted-foreground hover:text-foreground"
                 >
                   <LogOut size={14} />
                   <span className="hidden sm:inline">Logout</span>
@@ -65,7 +65,9 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
                 </span>
               </div>
             </header>
-            <main className="container mx-auto w-full max-w-6xl flex-1 px-4 py-6">{children}</main>
+            <main className="container mx-auto w-full max-w-6xl flex-1 overflow-x-hidden px-4 py-6">
+              {children}
+            </main>
           </div>
         </div>
         <MobileNav />

--- a/services/ui/components/FilterBar.tsx
+++ b/services/ui/components/FilterBar.tsx
@@ -12,7 +12,10 @@ type Props = {
 
 export default function FilterBar({ options, value, onChange }: Props) {
   return (
-    <div className="inline-flex items-center gap-1 rounded-full bg-white/5 p-1" role="group">
+    <div
+      className="flex flex-wrap items-center gap-2 overflow-x-auto rounded-full bg-white/5 p-1"
+      role="group"
+    >
       {options.map((opt) => {
         const active = value === opt.value;
         return (
@@ -22,7 +25,7 @@ export default function FilterBar({ options, value, onChange }: Props) {
             aria-pressed={active}
             onClick={() => onChange?.(opt.value)}
             className={clsx(
-              'relative rounded-full px-3 py-1 text-xs',
+              'relative h-11 min-w-[44px] rounded-full px-4 text-sm',
               active ? 'text-emerald-300' : 'text-muted-foreground hover:text-foreground',
             )}
           >

--- a/services/ui/components/MobileNav.tsx
+++ b/services/ui/components/MobileNav.tsx
@@ -7,7 +7,7 @@ import { nav } from './NavRail';
 export default function MobileNav() {
   const pathname = usePathname();
   return (
-    <nav className="fixed bottom-0 left-0 right-0 z-40 flex border-t border-white/10 bg-black/70 p-1 backdrop-blur md:hidden">
+    <nav className="fixed bottom-0 left-0 right-0 z-40 flex border-t border-white/10 bg-black/70 p-2 backdrop-blur md:hidden">
       {nav.map((item) => {
         const Icon = item.icon;
         const active = pathname === item.href;
@@ -16,12 +16,12 @@ export default function MobileNav() {
             key={item.href}
             href={item.href}
             className={clsx(
-              'flex flex-1 flex-col items-center justify-center gap-1 rounded-md p-2 text-xs',
+              'flex flex-1 min-h-[48px] flex-col items-center justify-center gap-1 rounded-md p-3 text-sm',
               active ? 'text-emerald-300' : 'text-muted-foreground hover:text-foreground',
             )}
           >
             <Icon size={18} />
-            <span className="text-[10px]">{item.label}</span>
+            <span className="text-xs">{item.label}</span>
           </Link>
         );
       })}

--- a/services/ui/components/NavRail.tsx
+++ b/services/ui/components/NavRail.tsx
@@ -40,7 +40,7 @@ export default function NavRail() {
         {!collapsed && <strong className="text-lg">SideTrack</strong>}
       </div>
       <Tooltip.Provider>
-        <nav className="flex flex-col gap-1">
+        <nav className="flex flex-col gap-2">
           {nav.map((item) => {
             const Icon = item.icon;
             const active = pathname === item.href;
@@ -50,7 +50,7 @@ export default function NavRail() {
                   <Link
                     href={item.href}
                     className={clsx(
-                      'relative flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition-colors',
+                      'relative flex h-11 items-center gap-3 rounded-lg px-4 text-sm transition-colors',
                       active
                         ? 'text-emerald-300'
                         : 'text-muted-foreground hover:text-foreground hover:bg-white/5',
@@ -91,7 +91,7 @@ export default function NavRail() {
       </Tooltip.Provider>
       <button
         onClick={() => setCollapsed(!collapsed)}
-        className="mt-auto flex items-center gap-2 px-2 py-3 text-xs text-muted-foreground"
+        className="mt-auto flex h-11 items-center gap-2 px-4 text-sm text-muted-foreground"
       >
         {collapsed ? <ChevronRight size={16} /> : <ChevronLeft size={16} />}
         {!collapsed && <span>Collapse</span>}

--- a/services/ui/components/ui/button.tsx
+++ b/services/ui/components/ui/button.tsx
@@ -13,8 +13,8 @@ const buttonVariants = cva(
         ghost: 'hover:bg-accent hover:text-accent-foreground',
       },
       size: {
-        sm: 'h-8 px-2',
-        md: 'h-10 px-4',
+        sm: 'h-11 px-3',
+        md: 'h-11 px-4',
         lg: 'h-12 px-6',
       },
     },


### PR DESCRIPTION
## Summary
- add container-query sections across dashboard views
- enlarge navigation and filter controls for touch accessibility
- prevent horizontal overflow in app shell and nav components

## Testing
- `npm --prefix services/ui test`
- `npx --prefix services/ui playwright test services/ui/responsive.spec.ts --browser=chromium`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0ef060910833398c54f0d929b7a3a