### PR TITLE
feat(ui): add dashboard cards and responsive charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,15 @@ Built with **Next.js 14**, **Tailwind**, **shadcn/ui**, **framer‑motion**, **P
 
 - Smooth transitions (framer‑motion), dark/light theme, keyboard nav, persistent filters.
 
+### Adding charts
+
+Dashboard charts live in `services/ui/components/charts` and are wrapped on pages with
+`ChartCard`. `ChartCard` ensures Plotly charts are responsive and accessible – pass
+`ariaLabel` and data/layout just like you would to `react-plotly.js`.
+
+Use **Plotly** for highly interactive or exploratory visuals (scatter plots, UMAP, etc.).
+Use **Recharts/Visx** for lightweight trend or stream graphs.
+
 ---
 
 ## Local Development

--- a/services/ui/app/page.tsx
+++ b/services/ui/app/page.tsx
@@ -1,11 +1,11 @@
 'use client';
-import MetricCard from '../components/MetricCard';
 import Link from 'next/link';
 import { motion } from 'framer-motion';
-import ChartContainer from '../components/ChartContainer';
 import FilterBar from '../components/FilterBar';
 import Avatar from '../components/ui/Avatar';
 import RecentListensTable from '../components/RecentListensTable';
+import KpiCard from '../components/dashboard/KpiCard';
+import ChartCard from '../components/dashboard/ChartCard';
 
 export default function Home() {
   return (
@@ -23,25 +23,34 @@ export default function Home() {
         </Link>
       </div>
 
-      <div className="grid gap-4 @[640px]:grid-cols-2 @[1024px]:grid-cols-4">
+      <div className="grid gap-4 @[640px]:grid-cols-2 @[1024px]:grid-cols-3">
         {[
-          <MetricCard
-            key="m1"
-            title="Listens (7d)"
-            value={128}
-            delta={{ value: 12, suffix: '%' }}
-          />,
-          <MetricCard key="m2" title="Energy" value={0.67} delta={{ value: -0.03 }} />,
-          <MetricCard key="m3" title="Valence" value={0.51} delta={{ value: 0.02 }} />,
-          <MetricCard key="m4" title="Momentum" value={'+0.08'} />,
+          {
+            title: 'Listens (7d)',
+            value: 128,
+            delta: { value: 12, suffix: '%' },
+            series: [80, 96, 102, 110, 115, 120, 128],
+          },
+          {
+            title: 'Diversity',
+            value: 0.82,
+            delta: { value: -0.02 },
+            series: [0.78, 0.8, 0.81, 0.83, 0.82, 0.82, 0.82],
+          },
+          {
+            title: 'Momentum',
+            value: '+0.08',
+            delta: { value: 0.01 },
+            series: [0.02, 0.04, 0.05, 0.06, 0.07, 0.08, 0.08],
+          },
         ].map((card, i) => (
           <motion.div
-            key={i}
+            key={card.title}
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ delay: 0.05 * i, duration: 0.35, ease: 'easeOut' }}
           >
-            {card}
+            <KpiCard {...card} />
           </motion.div>
         ))}
       </div>
@@ -63,7 +72,7 @@ export default function Home() {
           viewport={{ once: true }}
           transition={{ duration: 0.4 }}
         >
-          <ChartContainer
+          <ChartCard
             title="Recent Weeks"
             subtitle="Quick glance at your trajectory"
             actions={
@@ -71,14 +80,19 @@ export default function Home() {
                 Open
               </Link>
             }
-          >
-            <motion.div
-              className="h-48 rounded-md bg-white/5"
-              initial={{ scale: 0.98, opacity: 0 }}
-              animate={{ scale: 1, opacity: 1 }}
-              transition={{ duration: 0.4 }}
-            />
-          </ChartContainer>
+            plot={{
+              ariaLabel: 'recent weeks trend',
+              data: [
+                {
+                  x: ['W1', 'W2', 'W3', 'W4', 'W5', 'W6', 'W7'],
+                  y: [0.2, 0.35, 0.4, 0.5, 0.45, 0.6, 0.65],
+                  type: 'scatter',
+                  mode: 'lines+markers',
+                  line: { color: '#2FE08B' },
+                },
+              ],
+            }}
+          />
         </motion.div>
         <motion.div
           initial={{ opacity: 0, y: 8 }}
@@ -86,7 +100,7 @@ export default function Home() {
           viewport={{ once: true }}
           transition={{ duration: 0.4, delay: 0.05 }}
         >
-          <ChartContainer
+          <ChartCard
             title="Outliers"
             subtitle="Far from your recent centroid"
             actions={
@@ -114,7 +128,7 @@ export default function Home() {
                 </motion.div>
               ))}
             </div>
-          </ChartContainer>
+          </ChartCard>
         </motion.div>
       </div>
       <motion.div
@@ -123,9 +137,9 @@ export default function Home() {
         viewport={{ once: true }}
         transition={{ duration: 0.4, delay: 0.1 }}
       >
-        <ChartContainer title="Recent Listens">
+        <ChartCard title="Recent Listens">
           <RecentListensTable />
-        </ChartContainer>
+        </ChartCard>
       </motion.div>
     </section>
   );

--- a/services/ui/components/dashboard/ChartCard.tsx
+++ b/services/ui/components/dashboard/ChartCard.tsx
@@ -1,0 +1,63 @@
+'use client';
+import { ReactNode } from 'react';
+import Plot from 'react-plotly.js';
+import type { Data, Layout, Config } from 'plotly.js';
+import { Card } from '../ui/card';
+
+export type PlotProps = {
+  data: Data[];
+  layout?: Partial<Layout>;
+  config?: Partial<Config>;
+  ariaLabel: string;
+};
+
+type Props = {
+  title: string;
+  subtitle?: string;
+  actions?: ReactNode;
+  plot?: PlotProps;
+  children?: ReactNode;
+};
+
+export default function ChartCard({ title, subtitle, actions, plot, children }: Props) {
+  return (
+    <Card asChild variant="glass" className="p-4">
+      <section>
+        <div className="mb-3 flex items-center justify-between gap-4">
+          <div>
+            <h3 className="text-sm font-medium">{title}</h3>
+            {subtitle && <p className="text-xs text-muted-foreground">{subtitle}</p>}
+          </div>
+          {actions && <div className="flex items-center gap-2">{actions}</div>}
+        </div>
+        <div className="min-h-[clamp(160px,40vh,320px)]">
+          {plot ? (
+            <div tabIndex={0} className="h-full w-full">
+              <Plot
+                data={plot.data}
+                layout={{
+                  autosize: true,
+                  paper_bgcolor: 'transparent',
+                  plot_bgcolor: 'transparent',
+                  margin: { t: 20, l: 30, r: 10, b: 30 },
+                  ...plot.layout,
+                }}
+                config={{
+                  displayModeBar: false,
+                  responsive: true,
+                  ...plot.config,
+                }}
+                style={{ width: '100%', height: '100%' }}
+                useResizeHandler
+                aria-label={plot.ariaLabel}
+              />
+            </div>
+          ) : (
+            children
+          )}
+        </div>
+      </section>
+    </Card>
+  );
+}
+

--- a/services/ui/components/dashboard/KpiCard.tsx
+++ b/services/ui/components/dashboard/KpiCard.tsx
@@ -1,0 +1,59 @@
+'use client';
+import { motion } from 'framer-motion';
+import { Card } from '../ui/card';
+import { useMemo } from 'react';
+
+type Props = {
+  title: string;
+  value: string | number;
+  delta?: { value: number; suffix?: string };
+  series?: number[];
+};
+
+export default function KpiCard({ title, value, delta, series }: Props) {
+  const deltaText =
+    delta && typeof delta.value === 'number'
+      ? `${delta.value > 0 ? '+' : ''}${delta.value}${delta.suffix ?? ''}`
+      : undefined;
+  const deltaClass = delta && delta.value >= 0 ? 'text-emerald-400' : 'text-rose-400';
+
+  const path = useMemo(() => {
+    if (!series || series.length === 0) return '';
+    const w = 100;
+    const h = 24;
+    const max = Math.max(...series);
+    const min = Math.min(...series);
+    const range = max - min || 1;
+    const scaleX = w / (series.length - 1);
+    const points = series.map((v, i) => {
+      const x = i * scaleX;
+      const y = h - ((v - min) / range) * h;
+      return `${x},${y}`;
+    });
+    return `M${points.join(' L')}`;
+  }, [series]);
+
+  return (
+    <Card asChild variant="glass" className="p-4 shadow-soft">
+      <motion.div
+        initial={{ opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.35, ease: 'easeOut' }}
+        whileHover={{ scale: 1.02 }}
+        whileTap={{ scale: 0.98 }}
+      >
+        <div className="text-xs uppercase tracking-wide text-muted-foreground">{title}</div>
+        <div className="mt-2 flex items-baseline gap-2">
+          <div className="text-2xl font-semibold">{value}</div>
+          {deltaText && <div className={`text-xs ${deltaClass}`}>{deltaText}</div>}
+        </div>
+        {path && (
+          <svg viewBox="0 0 100 24" className="mt-2 h-6 w-full text-emerald-400">
+            <path d={path} fill="none" stroke="currentColor" strokeWidth={2} />
+          </svg>
+        )}
+      </motion.div>
+    </Card>
+  );
+}
+

--- a/services/ui/package.json
+++ b/services/ui/package.json
@@ -38,7 +38,9 @@
     "react": "18.3.1",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "18.3.1",
-    "react-use-measure": "^2.1.7"
+    "react-use-measure": "^2.1.7",
+    "plotly.js": "^2.31.0",
+    "react-plotly.js": "^2.6.0"
   },
   "devDependencies": {
     "@tailwindcss/container-queries": "^0.1.1",


### PR DESCRIPTION
## Summary
- add reusable KpiCard with mini sparkline
- wrap charts in new ChartCard with responsive Plotly defaults
- document dashboard chart guidelines

## Testing
- `npm test` *(fails: TestingLibraryElementError: Unable to find an element with the placeholder text of: ListenBrainz username)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0f338362c83339c5dea5db9a963e1