### PR TITLE
feat: add insights system

### DIFF
--- a/migrations/versions/7e0e2f720f2b_insight_events.py
+++ b/migrations/versions/7e0e2f720f2b_insight_events.py
@@ -1,0 +1,39 @@
+"""add insight events table
+
+Revision ID: 7e0e2f720f2b
+Revises: 6b1f90e2b8c7
+Create Date: 2025-05-27 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "7e0e2f720f2b"
+down_revision: Union[str, None] = "6b1f90e2b8c7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "insight_events",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("user_id", sa.String(length=128), nullable=False),
+        sa.Column("ts", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("type", sa.String(length=64), nullable=False),
+        sa.Column("summary", sa.Text(), nullable=False),
+        sa.Column("details", sa.JSON(), nullable=True),
+        sa.Column("severity", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.create_index(op.f("ix_insight_events_user_id"), "insight_events", ["user_id"], False)
+    op.create_index(op.f("ix_insight_events_ts"), "insight_events", ["ts"], False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_insight_events_ts"), table_name="insight_events")
+    op.drop_index(op.f("ix_insight_events_user_id"), table_name="insight_events")
+    op.drop_table("insight_events")

--- a/services/ui/app/(dashboard)/insights/error.tsx
+++ b/services/ui/app/(dashboard)/insights/error.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return (
+    <div className="space-y-4 p-4">
+      <p className="text-sm text-rose-400">Failed to load insights: {error.message}</p>
+      <button onClick={reset} className="rounded bg-emerald-500 px-4 py-2 text-sm text-emerald-950">
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/services/ui/app/(dashboard)/insights/loading.tsx
+++ b/services/ui/app/(dashboard)/insights/loading.tsx
@@ -1,0 +1,11 @@
+import Skeleton from '../../../components/Skeleton';
+
+export default function Loading() {
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      {[1, 2, 3].map((i) => (
+        <Skeleton key={i} className="h-24" />
+      ))}
+    </div>
+  );
+}

--- a/services/ui/app/(dashboard)/insights/page.tsx
+++ b/services/ui/app/(dashboard)/insights/page.tsx
@@ -1,0 +1,39 @@
+'use client';
+import { useEffect, useState } from 'react';
+import InsightCard, { Insight } from '../../../components/insights/InsightCard';
+import InsightModal from '../../../components/insights/InsightModal';
+import Skeleton from '../../../components/Skeleton';
+
+export default function InsightsPage() {
+  const [insights, setInsights] = useState<Insight[]>([]);
+  const [active, setActive] = useState<Insight | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('/api/v1/insights?window=12w')
+      .then((r) => r.json())
+      .then((d) => setInsights(d))
+      .catch(() => setInsights([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <section className="space-y-4">
+      <h2 className="text-xl font-semibold">Insights</h2>
+      {loading ? (
+        <div className="grid gap-4 md:grid-cols-2">
+          {[1, 2, 3].map((i) => (
+            <Skeleton key={i} className="h-24" />
+          ))}
+        </div>
+      ) : (
+        <div className="grid gap-4 md:grid-cols-2">
+          {insights.map((ins) => (
+            <InsightCard key={ins.ts + ins.type} insight={ins} onClick={() => setActive(ins)} />
+          ))}
+        </div>
+      )}
+      <InsightModal insight={active} onOpenChange={(open) => !open && setActive(null)} />
+    </section>
+  );
+}

--- a/services/ui/app/page.tsx
+++ b/services/ui/app/page.tsx
@@ -1,146 +1,170 @@
 'use client';
 import Link from 'next/link';
 import { motion } from 'framer-motion';
+import { useEffect, useState } from 'react';
 import FilterBar from '../components/FilterBar';
 import Avatar from '../components/ui/Avatar';
 import RecentListensTable from '../components/RecentListensTable';
 import KpiCard from '../components/dashboard/KpiCard';
 import ChartCard from '../components/dashboard/ChartCard';
+import InsightCard, { Insight } from '../components/insights/InsightCard';
+import InsightModal from '../components/insights/InsightModal';
 
 export default function Home() {
+  const [insights, setInsights] = useState<Insight[]>([]);
+  const [active, setActive] = useState<Insight | null>(null);
+
+  useEffect(() => {
+    fetch('/api/v1/insights?window=12w')
+      .then((r) => r.json())
+      .then((d) => setInsights(d))
+      .catch(() => setInsights([]));
+  }, []);
+
   return (
-    <section className="@container space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-semibold">Overview</h1>
-          <p className="text-sm text-muted-foreground">Your listening vibe at a glance</p>
+    <>
+      <section className="@container space-y-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold">Overview</h1>
+            <p className="text-sm text-muted-foreground">Your listening vibe at a glance</p>
+          </div>
+          <Link
+            href="/trajectory"
+            className="h-11 rounded-full bg-emerald-500/10 px-4 text-sm text-emerald-300 hover:bg-emerald-500/20"
+          >
+            View trajectory
+          </Link>
         </div>
-        <Link
-          href="/trajectory"
-          className="h-11 rounded-full bg-emerald-500/10 px-4 text-sm text-emerald-300 hover:bg-emerald-500/20"
-        >
-          View trajectory
-        </Link>
-      </div>
 
-      <div className="grid gap-4 @[640px]:grid-cols-2 @[1024px]:grid-cols-3">
-        {[
-          {
-            title: 'Listens (7d)',
-            value: 128,
-            delta: { value: 12, suffix: '%' },
-            series: [80, 96, 102, 110, 115, 120, 128],
-          },
-          {
-            title: 'Diversity',
-            value: 0.82,
-            delta: { value: -0.02 },
-            series: [0.78, 0.8, 0.81, 0.83, 0.82, 0.82, 0.82],
-          },
-          {
-            title: 'Momentum',
-            value: '+0.08',
-            delta: { value: 0.01 },
-            series: [0.02, 0.04, 0.05, 0.06, 0.07, 0.08, 0.08],
-          },
-        ].map((card, i) => (
-          <motion.div
-            key={card.title}
-            initial={{ opacity: 0, y: 10 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.05 * i, duration: 0.35, ease: 'easeOut' }}
-          >
-            <KpiCard {...card} />
-          </motion.div>
-        ))}
-      </div>
+        {insights.length > 0 && (
+          <div className="flex gap-4 overflow-x-auto pb-2">
+            {insights.map((ins) => (
+              <InsightCard key={ins.ts + ins.type} insight={ins} onClick={() => setActive(ins)} />
+            ))}
+          </div>
+        )}
 
-      <div className="flex items-center justify-between">
-        <FilterBar
-          options={[
-            { label: '4w', value: '4w' },
-            { label: '12w', value: '12w' },
-            { label: '24w', value: '24w' },
-          ]}
-          value="12w"
-        />
-      </div>
-      <div className="grid gap-6 @[768px]:grid-cols-2">
-        <motion.div
-          initial={{ opacity: 0, y: 8 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          viewport={{ once: true }}
-          transition={{ duration: 0.4 }}
-        >
-          <ChartCard
-            title="Recent Weeks"
-            subtitle="Quick glance at your trajectory"
-            actions={
-              <Link href="/trajectory" className="text-xs text-muted-foreground hover:underline">
-                Open
-              </Link>
-            }
-            plot={{
-              ariaLabel: 'recent weeks trend',
-              data: [
-                {
-                  x: ['W1', 'W2', 'W3', 'W4', 'W5', 'W6', 'W7'],
-                  y: [0.2, 0.35, 0.4, 0.5, 0.45, 0.6, 0.65],
-                  type: 'scatter',
-                  mode: 'lines+markers',
-                  line: { color: '#2FE08B' },
-                },
-              ],
-            }}
+        <div className="grid gap-4 @[640px]:grid-cols-2 @[1024px]:grid-cols-3">
+          {[
+            {
+              title: 'Listens (7d)',
+              value: 128,
+              delta: { value: 12, suffix: '%' },
+              series: [80, 96, 102, 110, 115, 120, 128],
+            },
+            {
+              title: 'Diversity',
+              value: 0.82,
+              delta: { value: -0.02 },
+              series: [0.78, 0.8, 0.81, 0.83, 0.82, 0.82, 0.82],
+            },
+            {
+              title: 'Momentum',
+              value: '+0.08',
+              delta: { value: 0.01 },
+              series: [0.02, 0.04, 0.05, 0.06, 0.07, 0.08, 0.08],
+            },
+          ].map((card, i) => (
+            <motion.div
+              key={card.title}
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ delay: 0.05 * i, duration: 0.35, ease: 'easeOut' }}
+            >
+              <KpiCard {...card} />
+            </motion.div>
+          ))}
+        </div>
+
+        <div className="flex items-center justify-between">
+          <FilterBar
+            options={[
+              { label: '4w', value: '4w' },
+              { label: '12w', value: '12w' },
+              { label: '24w', value: '24w' },
+            ]}
+            value="12w"
           />
-        </motion.div>
+        </div>
+        <div className="grid gap-6 @[768px]:grid-cols-2">
+          <motion.div
+            initial={{ opacity: 0, y: 8 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.4 }}
+          >
+            <ChartCard
+              title="Recent Weeks"
+              subtitle="Quick glance at your trajectory"
+              actions={
+                <Link href="/trajectory" className="text-xs text-muted-foreground hover:underline">
+                  Open
+                </Link>
+              }
+              plot={{
+                ariaLabel: 'recent weeks trend',
+                data: [
+                  {
+                    x: ['W1', 'W2', 'W3', 'W4', 'W5', 'W6', 'W7'],
+                    y: [0.2, 0.35, 0.4, 0.5, 0.45, 0.6, 0.65],
+                    type: 'scatter',
+                    mode: 'lines+markers',
+                    line: { color: '#2FE08B' },
+                  },
+                ],
+              }}
+            />
+          </motion.div>
+          <motion.div
+            initial={{ opacity: 0, y: 8 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.4, delay: 0.05 }}
+          >
+            <ChartCard
+              title="Outliers"
+              subtitle="Far from your recent centroid"
+              actions={
+                <Link href="/outliers" className="text-xs text-muted-foreground hover:underline">
+                  Open
+                </Link>
+              }
+            >
+              <div className="space-y-2">
+                {[1, 2, 3].map((i) => (
+                  <motion.div
+                    key={i}
+                    className="flex items-center gap-3 rounded-md p-2 hover:bg-white/5"
+                    initial={{ opacity: 0, y: 6 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.3, delay: 0.05 * i }}
+                    whileHover={{ scale: 1.01 }}
+                  >
+                    <Avatar size={32} />
+                    <div className="flex-1">
+                      <div className="text-sm">Track {i}</div>
+                      <div className="text-xs text-muted-foreground">Artist</div>
+                    </div>
+                    <div className="text-xs text-muted-foreground">dist 0.{9 - i}</div>
+                  </motion.div>
+                ))}
+              </div>
+            </ChartCard>
+          </motion.div>
+        </div>
         <motion.div
           initial={{ opacity: 0, y: 8 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
-          transition={{ duration: 0.4, delay: 0.05 }}
+          transition={{ duration: 0.4, delay: 0.1 }}
         >
-          <ChartCard
-            title="Outliers"
-            subtitle="Far from your recent centroid"
-            actions={
-              <Link href="/outliers" className="text-xs text-muted-foreground hover:underline">
-                Open
-              </Link>
-            }
-          >
-            <div className="space-y-2">
-              {[1, 2, 3].map((i) => (
-                <motion.div
-                  key={i}
-                  className="flex items-center gap-3 rounded-md p-2 hover:bg-white/5"
-                  initial={{ opacity: 0, y: 6 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 0.3, delay: 0.05 * i }}
-                  whileHover={{ scale: 1.01 }}
-                >
-                  <Avatar size={32} />
-                  <div className="flex-1">
-                    <div className="text-sm">Track {i}</div>
-                    <div className="text-xs text-muted-foreground">Artist</div>
-                  </div>
-                  <div className="text-xs text-muted-foreground">dist 0.{9 - i}</div>
-                </motion.div>
-              ))}
-            </div>
+          <ChartCard title="Recent Listens">
+            <RecentListensTable />
           </ChartCard>
         </motion.div>
-      </div>
-      <motion.div
-        initial={{ opacity: 0, y: 8 }}
-        whileInView={{ opacity: 1, y: 0 }}
-        viewport={{ once: true }}
-        transition={{ duration: 0.4, delay: 0.1 }}
-      >
-        <ChartCard title="Recent Listens">
-          <RecentListensTable />
-        </ChartCard>
-      </motion.div>
-    </section>
+      </section>
+      <InsightModal insight={active} onOpenChange={(open) => !open && setActive(null)} />
+    </>
   );
 }

--- a/services/ui/components/insights/InsightCard.tsx
+++ b/services/ui/components/insights/InsightCard.tsx
@@ -1,0 +1,40 @@
+'use client';
+import { Card } from '../ui/card';
+import { cn } from '../../lib/utils';
+
+export type Insight = {
+  ts: string;
+  type: string;
+  summary: string;
+  details?: Record<string, unknown>;
+  severity: number;
+};
+
+const TYPE_VARIANTS: Record<string, string> = {
+  weekly_listens: 'border-emerald-400',
+  discovery: 'border-blue-400',
+  surge: 'border-rose-400',
+};
+
+type Props = {
+  insight: Insight;
+  onClick?: () => void;
+};
+
+export default function InsightCard({ insight, onClick }: Props) {
+  const variant = TYPE_VARIANTS[insight.type] ?? 'border-white/10';
+  return (
+    <Card
+      asChild
+      variant="glass"
+      className={cn('min-w-[200px] cursor-pointer border p-4', variant)}
+    >
+      <div onClick={onClick} className="space-y-2">
+        <div className="text-sm font-medium">{insight.summary}</div>
+        <div className="text-xs text-muted-foreground">
+          {new Date(insight.ts).toLocaleDateString()}
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/services/ui/components/insights/InsightModal.tsx
+++ b/services/ui/components/insights/InsightModal.tsx
@@ -1,0 +1,42 @@
+'use client';
+import dynamic from 'next/dynamic';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../ui/dialog';
+import type { Data } from 'plotly.js';
+import type { Insight } from './InsightCard';
+
+const Plot = dynamic(() => import('react-plotly.js'), { ssr: false });
+
+type Props = {
+  insight: Insight | null;
+  onOpenChange: (open: boolean) => void;
+};
+
+export default function InsightModal({ insight, onOpenChange }: Props) {
+  return (
+    <Dialog open={!!insight} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        {insight && (
+          <>
+            <DialogHeader>
+              <DialogTitle>{insight.summary}</DialogTitle>
+            </DialogHeader>
+            {Array.isArray((insight.details as { data?: unknown } | undefined)?.data) && (
+              <Plot
+                data={(insight.details as { data?: Data[] } | undefined)?.data ?? []}
+                layout={{
+                  autosize: true,
+                  margin: { t: 20, r: 20, b: 30, l: 30 },
+                  paper_bgcolor: 'transparent',
+                  plot_bgcolor: 'transparent',
+                  height: 200,
+                }}
+                config={{ displayModeBar: false, responsive: true }}
+                style={{ width: '100%', height: '200px' }}
+              />
+            )}
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/sidetrack/api/api/v1/__init__.py
+++ b/sidetrack/api/api/v1/__init__.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter
 
+from ...routers import insights
 from . import auth, dashboard, listens, musicbrainz, spotify
 
 router = APIRouter(prefix="/api/v1")
@@ -8,3 +9,4 @@ router.include_router(listens.router)
 router.include_router(musicbrainz.router)
 router.include_router(dashboard.router)
 router.include_router(spotify.router)
+router.include_router(insights.router)

--- a/sidetrack/api/routers/__init__.py
+++ b/sidetrack/api/routers/__init__.py
@@ -1,0 +1,1 @@
+"""API routers."""

--- a/sidetrack/api/routers/insights.py
+++ b/sidetrack/api/routers/insights.py
@@ -1,0 +1,45 @@
+"""Insight-related API endpoints."""
+
+from datetime import UTC, datetime, timedelta
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sidetrack.services.insights import get_insights
+
+from ..db import get_db
+from ..security import get_current_user
+
+router = APIRouter()
+
+
+@router.get("/insights")
+async def list_insights(
+    window: str = Query("12w"),
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(get_current_user),
+):
+    """Return insight events for the current user within the given window."""
+
+    try:
+        if window.endswith("w"):
+            n_weeks = int(window[:-1])
+        elif window.endswith("m"):
+            n_weeks = int(window[:-1]) * 4
+        else:
+            n_weeks = int(window)
+    except ValueError:
+        n_weeks = 12
+
+    since = datetime.now(UTC) - timedelta(weeks=n_weeks)
+    events = await get_insights(db, user_id, since)
+    return [
+        {
+            "ts": evt.ts.isoformat(),
+            "type": evt.type,
+            "summary": evt.summary,
+            "details": evt.details,
+            "severity": evt.severity,
+        }
+        for evt in events
+    ]

--- a/sidetrack/services/__init__.py
+++ b/sidetrack/services/__init__.py
@@ -1,0 +1,1 @@
+"""Service layer utilities."""

--- a/sidetrack/services/insights.py
+++ b/sidetrack/services/insights.py
@@ -1,0 +1,74 @@
+"""Utilities for generating and retrieving listening insights."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import JSON, DateTime, Integer, String, Text, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Mapped, mapped_column
+
+from sidetrack.common.models import Base, Listen
+
+
+class InsightEvent(Base):
+    __tablename__ = "insight_events"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[str] = mapped_column(String(128), index=True)
+    ts: Mapped[datetime] = mapped_column(DateTime(timezone=True), index=True)
+    type: Mapped[str] = mapped_column(String(64))
+    summary: Mapped[str] = mapped_column(Text)
+    details: Mapped[dict | None] = mapped_column(JSON)
+    severity: Mapped[int] = mapped_column(Integer, default=0)
+
+
+async def compute_weekly_insights(db: AsyncSession, user_id: str) -> Sequence[InsightEvent]:
+    """Compute simple weekly insights for a user and persist them.
+
+    This implementation is intentionally lightweight; it currently records a
+    single insight with the number of listens in the past week. More advanced
+    analytics (changepoints, genre deltas, discovery rate, etc.) can be added
+    later.
+    """
+
+    now = datetime.now(UTC)
+    since = now - timedelta(days=7)
+
+    total = (
+        await db.execute(
+            select(func.count())
+            .select_from(Listen)
+            .where(Listen.user_id == user_id, Listen.played_at >= since)
+        )
+    ).scalar()
+
+    events: list[InsightEvent] = []
+    if total:
+        evt = InsightEvent(
+            user_id=user_id,
+            ts=now,
+            type="weekly_listens",
+            summary=f"{int(total)} listens this week",
+            details={"count": int(total)},
+            severity=0,
+        )
+        db.add(evt)
+        await db.commit()
+        await db.refresh(evt)
+        events.append(evt)
+    return events
+
+
+async def get_insights(db: AsyncSession, user_id: str, since: datetime) -> Sequence[InsightEvent]:
+    """Return insight events for ``user_id`` since ``since``."""
+
+    rows = (
+        await db.execute(
+            select(InsightEvent)
+            .where(InsightEvent.user_id == user_id, InsightEvent.ts >= since)
+            .order_by(InsightEvent.ts.desc())
+        )
+    ).scalars()
+    return list(rows)


### PR DESCRIPTION
## Summary
- add InsightEvent model/service and worker job to compute weekly insights
- expose `/api/v1/insights` endpoint returning user insight events
- build UI cards, modal and insights page with Plotly charts

## Testing
- `pre-commit run --files sidetrack/services/__init__.py sidetrack/services/insights.py sidetrack/api/routers/__init__.py sidetrack/api/routers/insights.py sidetrack/api/api/v1/__init__.py migrations/versions/7e0e2f720f2b_insight_events.py sidetrack/worker/jobs.py services/ui/components/insights/InsightCard.tsx services/ui/components/insights/InsightModal.tsx services/ui/app/(dashboard)/insights/page.tsx services/ui/app/(dashboard)/insights/loading.tsx services/ui/app/(dashboard)/insights/error.tsx services/ui/app/page.tsx` 
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c0f5c81908833391c32ff547652438