### PR TITLE
Add pgvector similarity API and neighbors UI

### DIFF
--- a/migrations/versions/3e1c1f4e3d90_pgvector_enable.py
+++ b/migrations/versions/3e1c1f4e3d90_pgvector_enable.py
@@ -1,0 +1,30 @@
+"""Enable pgvector and store track embeddings."""
+
+from typing import Union
+
+from alembic import op
+import sqlalchemy as sa
+from pgvector.sqlalchemy import Vector
+
+
+# revision identifiers, used by Alembic.
+revision: str = "3e1c1f4e3d90"
+down_revision: Union[str, None] = "1cdd5f4b8e41"
+branch_labels: Union[str, tuple[str, ...], None] = None
+depends_on: Union[str, tuple[str, ...], None] = None
+
+
+def upgrade() -> None:
+    op.execute("CREATE EXTENSION IF NOT EXISTS vector")
+    op.add_column("track", sa.Column("embeddings", Vector(1536)))
+    op.execute(
+        "CREATE INDEX track_embeddings_ivfflat_idx ON track "
+        "USING ivfflat (embeddings vector_l2_ops) WITH (lists = 100)"
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("track_embeddings_ivfflat_idx", table_name="track")
+    op.drop_column("track", "embeddings")
+    op.execute("DROP EXTENSION IF EXISTS vector")
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ api = [
     "opentelemetry-instrumentation-sqlalchemy==0.57b0",
     "pytest-asyncio==0.23.7",
     "fastapi-limiter==0.1.6",
+    "pgvector==0.3.5",
 ]
 
 extractor = [

--- a/services/ui/components/similar/NeighborsDrawer.tsx
+++ b/services/ui/components/similar/NeighborsDrawer.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import { apiFetch } from '../../lib/api';
+import { addToMixtape } from '../../lib/mixtape';
+
+type Props = {
+  trackId: number;
+  open: boolean;
+  onClose: () => void;
+};
+
+type Neighbor = { track_id: number; score: number; title?: string };
+
+export default function NeighborsDrawer({ trackId, open, onClose }: Props) {
+  const [neighbors, setNeighbors] = useState<Neighbor[]>([]);
+
+  useEffect(() => {
+    if (!open) return;
+    (async () => {
+      try {
+        const res = await apiFetch(`/similar/track/${trackId}`);
+        if (res.ok) {
+          setNeighbors((await res.json()) as Neighbor[]);
+        } else {
+          setNeighbors([]);
+        }
+      } catch {
+        setNeighbors([]);
+      }
+    })();
+  }, [trackId, open]);
+
+  const handleDragStart = (e: React.DragEvent, n: Neighbor) => {
+    e.dataTransfer.setData('application/json', JSON.stringify(n));
+  };
+
+  return (
+    <aside
+      className={`fixed right-0 top-0 z-40 h-full w-80 bg-background shadow-lg transition-transform ${
+        open ? 'translate-x-0' : 'translate-x-full'
+      }`}
+    >
+      <div className="flex items-center justify-between p-4">
+        <h2 className="text-lg font-semibold">Sonic Neighbors</h2>
+        <button onClick={onClose} className="text-sm text-muted-foreground">
+          Close
+        </button>
+      </div>
+      <ul className="divide-y divide-border overflow-y-auto">
+        {neighbors.map((n) => (
+          <li
+            key={n.track_id}
+            draggable
+            onDragStart={(e) => handleDragStart(e, n)}
+            onDoubleClick={() => addToMixtape(n)}
+            className="cursor-move p-4 text-sm hover:bg-muted/20"
+          >
+            {n.title ?? `Track ${n.track_id}`}
+          </li>
+        ))}
+      </ul>
+    </aside>
+  );
+}
+

--- a/services/ui/lib/mixtape.ts
+++ b/services/ui/lib/mixtape.ts
@@ -1,0 +1,28 @@
+export type MixtapeTrack = { track_id: number; title?: string };
+
+let queue: MixtapeTrack[] = [];
+
+export function addToMixtape(track: MixtapeTrack) {
+  queue.push(track);
+}
+
+export function getMixtape() {
+  return queue;
+}
+
+export function clearMixtape() {
+  queue = [];
+}
+
+export function handleMixtapeDrop(e: React.DragEvent) {
+  const data = e.dataTransfer.getData('application/json');
+  if (data) {
+    try {
+      const track = JSON.parse(data) as MixtapeTrack;
+      addToMixtape(track);
+    } catch {
+      /* noop */
+    }
+  }
+}
+

--- a/sidetrack/api/api/v1/__init__.py
+++ b/sidetrack/api/api/v1/__init__.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from ...routers import insights, moods
+from ...routers import insights, moods, similar
 from . import auth, dashboard, listens, musicbrainz, spotify
 
 router = APIRouter(prefix="/api/v1")
@@ -11,3 +11,4 @@ router.include_router(dashboard.router)
 router.include_router(spotify.router)
 router.include_router(insights.router)
 router.include_router(moods.router)
+router.include_router(similar.router)

--- a/sidetrack/api/routers/similar.py
+++ b/sidetrack/api/routers/similar.py
@@ -1,0 +1,64 @@
+"""Track similarity endpoints."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sidetrack.common.models import Track
+
+from ..db import get_db
+
+router = APIRouter()
+
+
+@router.get("/similar/track/{track_id}")
+async def get_similar_tracks(
+    track_id: int,
+    k: int = Query(20, ge=1, le=100),
+    diversity_penalty: float = Query(0.3, ge=0.0, le=1.0),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return tracks similar to ``track_id``.
+
+    Results are obtained using pgvector distance and then reranked to reduce
+    consecutive results from the same artist or label.
+    """
+
+    base = await db.get(Track, track_id)
+    if base is None or base.embeddings is None:
+        raise HTTPException(status_code=404, detail="track not found")
+
+    # Fetch a larger candidate set ordered by vector distance
+    stmt = text(
+        "SELECT t.track_id, t.artist_id, r.label, 1 - (t.embeddings <=> :vec) AS score "
+        "FROM track t LEFT JOIN release r ON t.release_id = r.release_id "
+        "WHERE t.track_id != :tid "
+        "ORDER BY t.embeddings <=> :vec "
+        "LIMIT :limit"
+    )
+    rows = (
+        await db.execute(
+            stmt, {"vec": base.embeddings, "tid": track_id, "limit": k * 4}
+        )
+    ).all()
+
+    seen_artists: set[int | None] = set()
+    seen_labels: set[str | None] = set()
+    results: list[dict[str, float | int]] = []
+
+    for tid, artist_id, label, score in rows:
+        penalty = 0.0
+        if artist_id in seen_artists:
+            penalty += diversity_penalty
+        if label in seen_labels:
+            penalty += diversity_penalty
+        seen_artists.add(artist_id)
+        seen_labels.add(label)
+        results.append({"track_id": int(tid), "score": float(score - penalty)})
+        if len(results) >= k:
+            break
+
+    return results
+

--- a/sidetrack/common/models.py
+++ b/sidetrack/common/models.py
@@ -16,6 +16,7 @@ from sqlalchemy import (
     UniqueConstraint,
 )
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+from pgvector.sqlalchemy import Vector
 
 
 class Base(DeclarativeBase):
@@ -59,6 +60,7 @@ class Track(Base):
     duration: Mapped[int | None] = mapped_column(Integer, nullable=True)
     path_local: Mapped[str | None] = mapped_column(Text, nullable=True)
     fingerprint: Mapped[str | None] = mapped_column(String(128), index=True)
+    embeddings: Mapped[list[float] | None] = mapped_column(Vector(1536), nullable=True)
 
     artist: Mapped[Artist | None] = relationship("Artist", back_populates="tracks")
     release: Mapped[Release | None] = relationship("Release", back_populates="tracks")


### PR DESCRIPTION
## Summary
- add pgvector dependency and store track embeddings with IVFFlat index
- expose `/api/v1/similar/track/{track_id}` endpoint with simple reranking
- add Sonic Neighbors drawer and mixtape queue utilities

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0fa0520f0833383951b33386fa42a