### PR TITLE
Add daypart listening heatmap

### DIFF
--- a/services/ui/app/page.tsx
+++ b/services/ui/app/page.tsx
@@ -7,6 +7,7 @@ import Avatar from '../components/ui/Avatar';
 import RecentListensTable from '../components/RecentListensTable';
 import KpiCard from '../components/dashboard/KpiCard';
 import ChartCard from '../components/dashboard/ChartCard';
+import DaypartHeatmap from '../components/dashboard/DaypartHeatmap';
 import InsightCard, { Insight } from '../components/insights/InsightCard';
 import InsightModal from '../components/insights/InsightModal';
 
@@ -151,6 +152,14 @@ export default function Home() {
                 ))}
               </div>
             </ChartCard>
+          </motion.div>
+          <motion.div
+            initial={{ opacity: 0, y: 8 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.4, delay: 0.1 }}
+          >
+            <DaypartHeatmap />
           </motion.div>
         </div>
         <motion.div

--- a/services/ui/components/dashboard/DaypartHeatmap.tsx
+++ b/services/ui/components/dashboard/DaypartHeatmap.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import ChartCard from './ChartCard';
+
+interface Cell {
+  day: number;
+  hour: number;
+  count: number;
+  energy: number | null;
+  valence: number | null;
+  tempo: number | null;
+}
+
+interface Highlight {
+  day: number;
+  hour: number;
+  count: number;
+  z: number;
+}
+
+interface HeatmapResponse {
+  cells: Cell[];
+  highlights: Highlight[];
+}
+
+const dayNames = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+export default function DaypartHeatmap() {
+  const [data, setData] = useState<HeatmapResponse | null>(null);
+
+  useEffect(() => {
+    fetch('/api/v1/daypart/heatmap')
+      .then((r) => r.json())
+      .then((d) => setData(d))
+      .catch(() => setData(null));
+  }, []);
+
+  const counts: number[][] = Array.from({ length: 7 }, () => Array(24).fill(0));
+  if (data) {
+    for (const c of data.cells) {
+      counts[c.day][c.hour] = c.count;
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <ChartCard
+        title="Daypart Heatmap"
+        subtitle="Listens by day and hour"
+        plot={{
+          ariaLabel: 'listening heatmap',
+          data: [
+            {
+              z: counts,
+              x: Array.from({ length: 24 }, (_, i) => i),
+              y: dayNames,
+              type: 'heatmap',
+              colorscale: 'Viridis',
+            },
+          ],
+        }}
+      />
+      {data && (
+        <>
+          <table className="sr-only">
+            <caption>Listening counts and averages by day and hour</caption>
+            <thead>
+              <tr>
+                <th>Day</th>
+                <th>Hour</th>
+                <th>Count</th>
+                <th>Energy</th>
+                <th>Valence</th>
+                <th>Tempo</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.cells.map((c) => (
+                <tr key={`${c.day}-${c.hour}`}>
+                  <td>{dayNames[c.day]}</td>
+                  <td>{c.hour}</td>
+                  <td>{c.count}</td>
+                  <td>{c.energy?.toFixed(2) ?? ''}</td>
+                  <td>{c.valence?.toFixed(2) ?? ''}</td>
+                  <td>{c.tempo?.toFixed(1) ?? ''}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {data.highlights.length > 0 && (
+            <ul className="text-xs">
+              {data.highlights.map((h) => (
+                <li key={`${h.day}-${h.hour}`}>
+                  {dayNames[h.day]} {h.hour}:00 – {h.count} listens
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/sidetrack/api/api/v1/__init__.py
+++ b/sidetrack/api/api/v1/__init__.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from ...routers import insights, moods, similar
+from ...routers import daypart, insights, moods, similar
 from . import auth, dashboard, listens, musicbrainz, spotify
 
 router = APIRouter(prefix="/api/v1")
@@ -12,3 +12,4 @@ router.include_router(spotify.router)
 router.include_router(insights.router)
 router.include_router(moods.router)
 router.include_router(similar.router)
+router.include_router(daypart.router)

--- a/sidetrack/api/routers/daypart.py
+++ b/sidetrack/api/routers/daypart.py
@@ -1,0 +1,124 @@
+"""Day-part statistics endpoints."""
+
+from __future__ import annotations
+
+from statistics import mean, pstdev
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import and_, select
+from sqlalchemy.orm import aliased
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sidetrack.common.models import Listen, MoodScore, Feature
+
+from ..constants import DEFAULT_METHOD
+from ..db import get_db
+from ..security import get_current_user
+
+router = APIRouter()
+
+
+@router.get("/daypart/heatmap")
+async def daypart_heatmap(
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(get_current_user),
+):
+    """Return 24x7 listening stats and highlight high-activity cells."""
+
+    ms_energy = aliased(MoodScore)
+    ms_valence = aliased(MoodScore)
+
+    rows = (
+        await db.execute(
+            select(
+                Listen.played_at,
+                ms_energy.value,
+                ms_valence.value,
+                Feature.bpm,
+            )
+            .join(
+                ms_energy,
+                and_(
+                    ms_energy.track_id == Listen.track_id,
+                    ms_energy.axis == "energy",
+                    ms_energy.method == DEFAULT_METHOD,
+                ),
+                isouter=True,
+            )
+            .join(
+                ms_valence,
+                and_(
+                    ms_valence.track_id == Listen.track_id,
+                    ms_valence.axis == "valence",
+                    ms_valence.method == DEFAULT_METHOD,
+                ),
+                isouter=True,
+            )
+            .join(Feature, Feature.track_id == Listen.track_id, isouter=True)
+            .where(Listen.user_id == user_id)
+        )
+    ).all()
+
+    counts = [[0 for _ in range(24)] for _ in range(7)]
+    sum_energy = [[0.0 for _ in range(24)] for _ in range(7)]
+    sum_valence = [[0.0 for _ in range(24)] for _ in range(7)]
+    sum_tempo = [[0.0 for _ in range(24)] for _ in range(7)]
+    cnt_energy = [[0 for _ in range(24)] for _ in range(7)]
+    cnt_valence = [[0 for _ in range(24)] for _ in range(7)]
+    cnt_tempo = [[0 for _ in range(24)] for _ in range(7)]
+
+    for played_at, energy, valence, tempo in rows:
+        day = played_at.isoweekday() - 1  # Monday=0
+        hour = played_at.hour
+        counts[day][hour] += 1
+        if energy is not None:
+            sum_energy[day][hour] += float(energy)
+            cnt_energy[day][hour] += 1
+        if valence is not None:
+            sum_valence[day][hour] += float(valence)
+            cnt_valence[day][hour] += 1
+        if tempo is not None:
+            sum_tempo[day][hour] += float(tempo)
+            cnt_tempo[day][hour] += 1
+
+    cells = []
+    count_values = []
+    for day in range(7):
+        for hour in range(24):
+            n = counts[day][hour]
+            count_values.append(n)
+            cell = {
+                "day": day,
+                "hour": hour,
+                "count": n,
+                "energy": (sum_energy[day][hour] / cnt_energy[day][hour])
+                if cnt_energy[day][hour]
+                else None,
+                "valence": (sum_valence[day][hour] / cnt_valence[day][hour])
+                if cnt_valence[day][hour]
+                else None,
+                "tempo": (sum_tempo[day][hour] / cnt_tempo[day][hour])
+                if cnt_tempo[day][hour]
+                else None,
+            }
+            cells.append(cell)
+
+    mu = mean(count_values) if count_values else 0.0
+    sigma = pstdev(count_values) if len(count_values) > 1 else 0.0
+
+    highlights = []
+    if sigma > 0:
+        for cell in cells:
+            if cell["count"] > 0:
+                z = (cell["count"] - mu) / sigma
+                if z > 1.0:
+                    highlights.append(
+                        {
+                            "day": cell["day"],
+                            "hour": cell["hour"],
+                            "count": cell["count"],
+                            "z": z,
+                        }
+                    )
+
+    return {"cells": cells, "highlights": highlights}

--- a/tests/api/test_daypart.py
+++ b/tests/api/test_daypart.py
@@ -1,0 +1,41 @@
+from datetime import datetime, UTC, timedelta
+
+import pytest
+
+from sidetrack.api.constants import DEFAULT_METHOD
+from sidetrack.common.models import Feature, Listen, MoodScore, Track
+
+
+@pytest.fixture
+def user_id():
+    return "user1"
+
+
+def test_daypart_heatmap(client, session, user_id):
+    track = Track(title="T1")
+    session.add(track)
+    session.flush()
+
+    session.add_all([
+        MoodScore(track_id=track.track_id, axis="energy", method=DEFAULT_METHOD, value=0.8),
+        MoodScore(track_id=track.track_id, axis="valence", method=DEFAULT_METHOD, value=0.6),
+    ])
+    session.add(Feature(track_id=track.track_id, bpm=120.0))
+
+    base = datetime(2024, 1, 1, 9, 0, tzinfo=UTC)  # Monday
+    for i in range(5):
+        session.add(Listen(user_id=user_id, track_id=track.track_id, played_at=base + timedelta(minutes=i)))
+    session.add(Listen(user_id=user_id, track_id=track.track_id, played_at=base + timedelta(days=1)))
+    session.commit()
+
+    resp = client.get("/api/v1/daypart/heatmap", headers={"X-User-Id": user_id})
+    assert resp.status_code == 200
+    data = resp.json()
+
+    cell = next(c for c in data["cells"] if c["day"] == 0 and c["hour"] == 9)
+    assert cell["count"] == 5
+    assert cell["energy"] == pytest.approx(0.8)
+    assert cell["valence"] == pytest.approx(0.6)
+    assert cell["tempo"] == pytest.approx(120.0)
+
+    assert any(h["day"] == 0 and h["hour"] == 9 for h in data["highlights"])


### PR DESCRIPTION
## Summary
- add `/api/v1/daypart/heatmap` endpoint returning 24x7 listening stats with mean energy/valence/tempo and highlights
- expose new API route and UI component to render daypart heatmap with accessible table and callouts on home page
- cover endpoint with unit test

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0fba6aacc8333a178600f48b8a957