### PR TITLE
Add Spotify and Last.fm service layers for recommendation candidates

### DIFF
--- a/sidetrack/services/candidates.py
+++ b/sidetrack/services/candidates.py
@@ -1,0 +1,119 @@
+"""Candidate track generation from Spotify or Last.fm histories."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .lastfm import LastfmService
+from .spotify import SpotifyService
+
+
+async def _spotify_candidates(sp: SpotifyService) -> list[dict[str, Any]]:
+    """Generate candidate tracks for a Spotify user."""
+
+    top_tracks = await sp.get_top_items("tracks")
+    top_artists = await sp.get_top_items("artists")
+    seed_tracks = [t.get("id") for t in top_tracks if t.get("id")][:5]
+    seed_artists = [a.get("id") for a in top_artists if a.get("id")][:5]
+    seeds = {"tracks": seed_tracks, "artists": seed_artists}
+
+    recs = await sp.get_recommendations(seeds)
+
+    recent_ids = {
+        (item.get("track") or {}).get("id")
+        for item in await sp.get_recently_played()
+        if (item.get("track") or {}).get("id")
+    }
+    saved_ids = {
+        (item.get("track") or {}).get("id")
+        for item in await sp.get_saved_tracks()
+        if (item.get("track") or {}).get("id")
+    }
+    seen = recent_ids | saved_ids
+
+    out: list[dict[str, Any]] = []
+    for track in recs:
+        tid = track.get("id")
+        if not tid or tid in seen:
+            continue
+        out.append(
+            {
+                "spotify_id": tid,
+                "isrc": (track.get("external_ids") or {}).get("isrc"),
+                "artist": ", ".join(a.get("name") for a in track.get("artists", [])),
+                "title": track.get("name"),
+                "seeds": seeds,
+                "source": "spotify",
+                "score_cf": float(track.get("popularity", 0)) / 100.0,
+            }
+        )
+    return out
+
+
+async def _lastfm_candidates(lfm: LastfmService, user: str) -> list[dict[str, Any]]:
+    """Generate candidate tracks for a Last.fm user."""
+
+    out: list[dict[str, Any]] = []
+
+    top_tracks = await lfm.get_top_tracks(user)
+    for tr in top_tracks[:5]:
+        artist_name = (tr.get("artist") or {}).get("name")
+        track_name = tr.get("name")
+        if not artist_name or not track_name:
+            continue
+        sims = await lfm.get_similar_track(artist=artist_name, track=track_name)
+        for s in sims:
+            cand = {
+                "spotify_id": None,
+                "isrc": None,
+                "artist": (s.get("artist") or {}).get("name"),
+                "title": s.get("name"),
+                "seeds": {"artist": artist_name, "track": track_name},
+                "source": "lastfm",
+                "score_cf": float(s.get("match") or 0.0),
+            }
+            if cand["artist"] and cand["title"]:
+                out.append(cand)
+
+    top_artists = await lfm.get_top_artists(user)
+    for art in top_artists[:5]:
+        name = art.get("name")
+        if not name:
+            continue
+        sims = await lfm.get_similar_artist(name=name)
+        for sa in sims:
+            sname = sa.get("name")
+            if not sname:
+                continue
+            tracks = await lfm.get_artist_top_tracks(sname, limit=1)
+            track = tracks[0] if tracks else None
+            title = track.get("name") if isinstance(track, dict) else None
+            if not title:
+                continue
+            out.append(
+                {
+                    "spotify_id": None,
+                    "isrc": None,
+                    "artist": sname,
+                    "title": title,
+                    "seeds": {"artist": name},
+                    "source": "lastfm",
+                    "score_cf": float(sa.get("match") or 0.0),
+                }
+            )
+    return out
+
+
+async def generate_candidates(
+    *,
+    spotify: SpotifyService | None = None,
+    lastfm: LastfmService | None = None,
+    lastfm_user: str | None = None,
+) -> list[dict[str, Any]]:
+    """Return recommendation candidates for the given user."""
+
+    if spotify is not None:
+        return await _spotify_candidates(spotify)
+    if lastfm is not None and lastfm_user:
+        return await _lastfm_candidates(lastfm, lastfm_user)
+    return []

--- a/sidetrack/services/lastfm.py
+++ b/sidetrack/services/lastfm.py
@@ -1,0 +1,95 @@
+"""Helpers for interacting with the Last.fm API."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+
+class LastfmService:
+    """Minimal Last.fm API wrapper used for candidate generation."""
+
+    api_root = "https://ws.audioscrobbler.com/2.0/"
+
+    def __init__(self, client: httpx.AsyncClient, api_key: str | None) -> None:
+        self._client = client
+        self.api_key = api_key
+
+    async def _request(self, params: dict[str, Any]) -> dict[str, Any]:
+        if not self.api_key:
+            raise RuntimeError("LASTFM_API_KEY not configured")
+        params = dict(params)
+        params["api_key"] = self.api_key
+        params["format"] = "json"
+        resp = await self._client.get(self.api_root, params=params, timeout=30)
+        resp.raise_for_status()
+        return resp.json()
+
+    async def get_recent_tracks(self, user: str, limit: int = 50) -> list[dict[str, Any]]:
+        params = {"method": "user.getrecenttracks", "user": user, "limit": limit}
+        data = await self._request(params)
+        return data.get("recenttracks", {}).get("track", [])
+
+    async def get_top_artists(
+        self, user: str, period: str = "7day", limit: int = 50
+    ) -> list[dict[str, Any]]:
+        params = {
+            "method": "user.gettopartists",
+            "user": user,
+            "period": period,
+            "limit": limit,
+        }
+        data = await self._request(params)
+        return data.get("topartists", {}).get("artist", [])
+
+    async def get_top_tracks(
+        self, user: str, period: str = "7day", limit: int = 50
+    ) -> list[dict[str, Any]]:
+        params = {
+            "method": "user.gettoptracks",
+            "user": user,
+            "period": period,
+            "limit": limit,
+        }
+        data = await self._request(params)
+        return data.get("toptracks", {}).get("track", [])
+
+    async def get_similar_artist(
+        self, *, name: str | None = None, mbid: str | None = None, limit: int = 50
+    ) -> list[dict[str, Any]]:
+        params = {"method": "artist.getsimilar", "limit": limit}
+        if mbid:
+            params["mbid"] = mbid
+        elif name:
+            params["artist"] = name
+        else:
+            raise ValueError("name or mbid required")
+        data = await self._request(params)
+        return data.get("similarartists", {}).get("artist", [])
+
+    async def get_similar_track(
+        self,
+        *,
+        artist: str | None = None,
+        track: str | None = None,
+        mbid: str | None = None,
+        limit: int = 50,
+    ) -> list[dict[str, Any]]:
+        params = {"method": "track.getsimilar", "limit": limit}
+        if mbid:
+            params["mbid"] = mbid
+        else:
+            if not artist or not track:
+                raise ValueError("artist and track required when mbid not provided")
+            params["artist"] = artist
+            params["track"] = track
+        data = await self._request(params)
+        return data.get("similartracks", {}).get("track", [])
+
+    async def get_artist_top_tracks(
+        self, artist: str, limit: int = 10
+    ) -> list[dict[str, Any]]:
+        params = {"method": "artist.gettoptracks", "artist": artist, "limit": limit}
+        data = await self._request(params)
+        return data.get("toptracks", {}).get("track", [])

--- a/sidetrack/services/spotify.py
+++ b/sidetrack/services/spotify.py
@@ -1,0 +1,145 @@
+"""Helpers for interacting with the Spotify Web API."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import httpx
+
+
+class SpotifyService:
+    """Lightweight wrapper around the Spotify Web API.
+
+    The service only implements the handful of endpoints needed by the
+    application.  It also includes minimal OAuth helpers for obtaining and
+    refreshing access tokens.  Requests automatically handle Spotify's
+    rate‑limit responses (HTTP 429) by honouring the ``Retry-After`` header.
+    """
+
+    auth_root = "https://accounts.spotify.com"
+    api_root = "https://api.spotify.com/v1"
+
+    def __init__(
+        self,
+        client: httpx.AsyncClient,
+        client_id: str | None = None,
+        client_secret: str | None = None,
+        access_token: str | None = None,
+    ) -> None:
+        self._client = client
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.access_token = access_token
+
+    # ------------------------------------------------------------------
+    # OAuth helpers
+    # ------------------------------------------------------------------
+    async def exchange_code(self, code: str, redirect_uri: str) -> dict[str, Any]:
+        """Exchange an authorisation code for an access token."""
+
+        if not self.client_id or not self.client_secret:
+            raise RuntimeError("Spotify credentials not configured")
+        data = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": redirect_uri,
+        }
+        auth = httpx.BasicAuth(self.client_id, self.client_secret)
+        resp = await self._client.post(
+            f"{self.auth_root}/api/token", data=data, auth=auth, timeout=30
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    async def refresh_token(self, refresh_token: str) -> dict[str, Any]:
+        """Refresh an expired access token."""
+
+        if not self.client_id or not self.client_secret:
+            raise RuntimeError("Spotify credentials not configured")
+        data = {"grant_type": "refresh_token", "refresh_token": refresh_token}
+        auth = httpx.BasicAuth(self.client_id, self.client_secret)
+        resp = await self._client.post(
+            f"{self.auth_root}/api/token", data=data, auth=auth, timeout=30
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    async def _request(self, method: str, url: str, **kwargs: Any) -> dict[str, Any]:
+        """Make an authorised request handling 429s with ``Retry-After``."""
+
+        if not self.access_token:
+            raise RuntimeError("access token not set")
+
+        headers = kwargs.pop("headers", {})
+        headers["Authorization"] = f"Bearer {self.access_token}"
+
+        while True:
+            resp = await self._client.request(
+                method, url, headers=headers, timeout=30, **kwargs
+            )
+            if resp.status_code == 429:
+                retry = int(resp.headers.get("Retry-After", "1"))
+                await asyncio.sleep(retry)
+                continue
+            resp.raise_for_status()
+            return resp.json()
+
+    # ------------------------------------------------------------------
+    # API methods
+    # ------------------------------------------------------------------
+    async def get_top_items(
+        self, type_: str = "tracks", time_range: str = "short_term", limit: int = 20
+    ) -> list[dict[str, Any]]:
+        """Return the user's top tracks or artists."""
+
+        params = {"time_range": time_range, "limit": limit}
+        data = await self._request(
+            "GET", f"{self.api_root}/me/top/{type_}", params=params
+        )
+        return data.get("items", [])
+
+    async def get_recently_played(self, limit: int = 50) -> list[dict[str, Any]]:
+        """Return tracks the user recently listened to."""
+
+        params = {"limit": min(limit, 50)}
+        data = await self._request(
+            "GET", f"{self.api_root}/me/player/recently-played", params=params
+        )
+        return data.get("items", [])
+
+    async def get_saved_tracks(self, limit: int = 50) -> list[dict[str, Any]]:
+        """Return the user's saved tracks, handling pagination."""
+
+        items: list[dict[str, Any]] = []
+        url = f"{self.api_root}/me/tracks"
+        params: dict[str, Any] | None = {"limit": min(limit, 50)}
+        while url:
+            data = await self._request("GET", url, params=params)
+            items.extend(data.get("items", []))
+            url = data.get("next")
+            params = None  # ``next`` already includes query parameters
+        return items
+
+    async def get_recommendations(
+        self,
+        seeds: dict[str, list[str]] | None = None,
+        target_features: dict[str, Any] | None = None,
+        limit: int = 20,
+    ) -> list[dict[str, Any]]:
+        """Return track recommendations from Spotify."""
+
+        params: dict[str, Any] = {"limit": limit}
+        seeds = seeds or {}
+        for key, values in seeds.items():
+            if values:
+                params[f"seed_{key}"] = ",".join(values[:5])
+        if target_features:
+            params.update(target_features)
+        data = await self._request(
+            "GET", f"{self.api_root}/recommendations", params=params
+        )
+        return data.get("tracks", [])


### PR DESCRIPTION
## Summary
- Implement Spotify service with OAuth helpers, rate limit handling, and endpoints for top items, listens, saved tracks, and recommendations
- Add Last.fm service to fetch recent/top tracks, artists, and similar items
- Provide candidate generation logic combining Spotify and Last.fm data

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c104a886248333a8d8d56751dc9770