### PR TITLE
Enrich recs with MusicBrainz metadata via ISRC lookup

### DIFF
--- a/sidetrack/api/api/v1/__init__.py
+++ b/sidetrack/api/api/v1/__init__.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter
 
 from ...routers import cohorts, compare, daypart, insights, moods, similar
-from . import auth, dashboard, listens, musicbrainz, spotify
+from . import auth, dashboard, listens, musicbrainz, spotify, recs
 
 router = APIRouter(prefix="/api/v1")
 router.include_router(auth.router)
@@ -15,3 +15,4 @@ router.include_router(similar.router)
 router.include_router(daypart.router)
 router.include_router(cohorts.router)
 router.include_router(compare.router)
+router.include_router(recs.router)

--- a/sidetrack/api/api/v1/recs.py
+++ b/sidetrack/api/api/v1/recs.py
@@ -1,0 +1,81 @@
+"""Recommendation candidate endpoints."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+import httpx
+
+from sidetrack.common.models import UserSettings
+from sidetrack.services.candidates import generate_candidates
+from sidetrack.services.lastfm import LastfmService
+from sidetrack.services.mb_map import recording_by_isrc
+from sidetrack.services.spotify import SpotifyService
+
+from ...config import get_settings as get_app_settings, Settings
+from ...db import get_db
+from ...main import _get_redis_connection, get_http_client
+from ...security import get_current_user
+
+router = APIRouter()
+
+
+@router.get("/recs")
+async def list_recs(
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(get_current_user),
+    client: httpx.AsyncClient = Depends(get_http_client),
+) -> dict:
+    """Return recommendation candidates enriched with MusicBrainz data."""
+
+    settings: Settings = get_app_settings()
+    row = (
+        await db.execute(select(UserSettings).where(UserSettings.user_id == user_id))
+    ).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(status_code=404, detail="user settings not found")
+
+    spotify_service: SpotifyService | None = None
+    lastfm_service: LastfmService | None = None
+    lastfm_user: str | None = None
+    if row.spotify_access_token:
+        spotify_service = SpotifyService(client, access_token=row.spotify_access_token)
+    elif row.lastfm_user:
+        lastfm_service = LastfmService(client, settings.lastfm_api_key)
+        lastfm_user = row.lastfm_user
+
+    candidates = await generate_candidates(
+        spotify=spotify_service, lastfm=lastfm_service, lastfm_user=lastfm_user
+    )
+
+    redis_conn = _get_redis_connection(settings)
+
+    enriched: list[dict] = []
+    for cand in candidates:
+        item = {
+            "artist": cand.get("artist"),
+            "title": cand.get("title"),
+            "source": cand.get("source"),
+            "score_cf": cand.get("score_cf"),
+        }
+        isrc = cand.get("isrc")
+        if isrc:
+            rec_mbid, art_mbid, year, label, tags = await recording_by_isrc(
+                isrc, client=client, redis_conn=redis_conn
+            )
+            item.update(
+                {
+                    "recording_mbid": rec_mbid,
+                    "artist_mbid": art_mbid,
+                    "release_year": year,
+                    "label": label,
+                    "tags": tags,
+                }
+            )
+        else:
+            item["spotify_id"] = cand.get("spotify_id")
+        enriched.append(item)
+
+    return {"candidates": enriched}

--- a/sidetrack/services/mb_map.py
+++ b/sidetrack/services/mb_map.py
@@ -1,0 +1,116 @@
+"""MusicBrainz mapping helpers."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Tuple
+
+import httpx
+from redis import Redis
+
+_MB_LOCK = asyncio.Lock()
+_CACHE_TTL = 24 * 3600  # one day
+
+
+async def recording_by_isrc(
+    isrc: str,
+    *,
+    client: httpx.AsyncClient | None = None,
+    redis_conn: Redis | None = None,
+) -> Tuple[str | None, str | None, int | None, str | None, list[str]]:
+    """Return MusicBrainz metadata for a recording given its ISRC.
+
+    Parameters
+    ----------
+    isrc:
+        The ISRC to look up.
+    client:
+        Optional ``httpx.AsyncClient`` to use for the request.  A new client
+        will be created if not provided.
+    redis_conn:
+        Optional Redis connection used to cache responses.
+
+    Returns
+    -------
+    tuple
+        ``(recording_mbid, artist_mbid, release_year, label, tags)``
+    """
+
+    cache_key = f"mb:isrc:{isrc}"
+    if redis_conn is not None:
+        cached = await asyncio.to_thread(redis_conn.get, cache_key)
+        if cached:
+            data = json.loads(cached)
+            return (
+                data.get("recording_mbid"),
+                data.get("artist_mbid"),
+                data.get("release_year"),
+                data.get("label"),
+                data.get("tags", []),
+            )
+
+    close_client = False
+    if client is None:
+        client = httpx.AsyncClient()
+        close_client = True
+
+    url = f"https://musicbrainz.org/ws/2/isrc/{isrc}"
+    params = {"inc": "recordings+releases+artist-credits+tags", "fmt": "json"}
+    headers = {"User-Agent": "SideTrack/0.1 (+https://example.com)"}
+
+    async with _MB_LOCK:
+        resp = await client.get(url, params=params, headers=headers, timeout=30)
+        resp.raise_for_status()
+        payload = resp.json()
+        # One request per second per MusicBrainz guidelines
+        await asyncio.sleep(1)
+
+    if close_client:
+        await client.aclose()
+
+    rec = (payload.get("recordings") or [{}])[0]
+    recording_mbid = rec.get("id")
+
+    artist_credit = (rec.get("artist-credit") or [{}])[0].get("artist", {})
+    artist_mbid = artist_credit.get("id")
+
+    # Determine release year and label from earliest release
+    release_year: int | None = None
+    label: str | None = None
+    releases = rec.get("releases") or []
+    if releases:
+        def _release_year(rel: dict[str, Any]) -> int:
+            date = rel.get("date") or "9999"
+            try:
+                return int(str(date)[:4])
+            except Exception:
+                return 9999
+
+        rel = min(releases, key=_release_year)
+        date = rel.get("date")
+        if isinstance(date, str) and len(date) >= 4:
+            try:
+                release_year = int(date[:4])
+            except ValueError:
+                release_year = None
+        label_info = rel.get("label-info") or rel.get("label-info-list") or []
+        if label_info:
+            label = (label_info[0].get("label") or {}).get("name")
+
+    tags = [t.get("name") for t in rec.get("tags", []) if t.get("name")]
+
+    result = {
+        "recording_mbid": recording_mbid,
+        "artist_mbid": artist_mbid,
+        "release_year": release_year,
+        "label": label,
+        "tags": tags,
+    }
+
+    if redis_conn is not None:
+        await asyncio.to_thread(
+            redis_conn.setex, cache_key, _CACHE_TTL, json.dumps(result)
+        )
+
+    return recording_mbid, artist_mbid, release_year, label, tags

--- a/tests/test_mb_map.py
+++ b/tests/test_mb_map.py
@@ -1,0 +1,71 @@
+import asyncio
+import httpx
+import pytest
+
+from sidetrack.services.mb_map import recording_by_isrc
+
+
+@pytest.mark.asyncio
+async def test_recording_by_isrc_multiple_releases(redis_conn, monkeypatch):
+    """Ensure earliest release is chosen when multiple exist."""
+
+    payload = {
+        "isrc": "US1234567890",
+        "recordings": [
+            {
+                "id": "rec-1",
+                "artist-credit": [{"artist": {"id": "art-1"}}],
+                "releases": [
+                    {
+                        "id": "rel-old",
+                        "date": "1999-02-01",
+                        "label-info": [{"label": {"name": "Label A"}}],
+                    },
+                    {
+                        "id": "rel-new",
+                        "date": "2005-01-01",
+                        "label-info": [{"label": {"name": "Label B"}}],
+                    },
+                ],
+                "tags": [{"name": "rock"}, {"name": "indie"}],
+            }
+        ],
+    }
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=payload)
+
+    transport = httpx.MockTransport(handler)
+
+    # avoid slow sleeps during tests
+    async def no_sleep(_):
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", no_sleep)
+
+    async with httpx.AsyncClient(transport=transport) as client:
+        res = await recording_by_isrc(
+            "US1234567890", client=client, redis_conn=redis_conn
+        )
+        assert res == (
+            "rec-1",
+            "art-1",
+            1999,
+            "Label A",
+            ["rock", "indie"],
+        )
+
+        # second call should hit cache and not invoke handler again
+        called = False
+
+        async def fail_handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover
+            nonlocal called
+            called = True
+            return httpx.Response(500)
+
+        client._transport = httpx.MockTransport(fail_handler)
+        res2 = await recording_by_isrc(
+            "US1234567890", client=client, redis_conn=redis_conn
+        )
+        assert res2[0] == "rec-1"
+        assert not called


### PR DESCRIPTION
## Summary
- add MusicBrainz mapping service with Redis caching and polite rate limiting
- expose `/api/v1/recs` endpoint and enrich candidates with MusicBrainz data
- test ISRC lookup handles multiple releases and caches results

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1063348048333852e4443d0500191