### PR TITLE
Add ranking service and endpoint

### DIFF
--- a/sidetrack/api/api/v1/recs.py
+++ b/sidetrack/api/api/v1/recs.py
@@ -2,19 +2,22 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, HTTPException
-from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
+from typing import Any
 
 import httpx
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from sidetrack.common.models import UserSettings
 from sidetrack.services.candidates import generate_candidates
 from sidetrack.services.lastfm import LastfmService
 from sidetrack.services.mb_map import recording_by_isrc
+from sidetrack.services.ranker import profile_from_spotify, rank
 from sidetrack.services.spotify import SpotifyService
 
-from ...config import get_settings as get_app_settings, Settings
+from ...config import Settings
+from ...config import get_settings as get_app_settings
 from ...db import get_db
 from ...main import _get_redis_connection, get_http_client
 from ...security import get_current_user
@@ -79,3 +82,85 @@ async def list_recs(
         enriched.append(item)
 
     return {"candidates": enriched}
+
+
+@router.get("/recs/ranked")
+async def ranked_recs(
+    limit: int = Query(50, ge=1, le=100),
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(get_current_user),
+    client: httpx.AsyncClient = Depends(get_http_client),
+) -> list[dict]:
+    """Return ranked recommendation candidates."""
+
+    settings: Settings = get_app_settings()
+    row = (
+        await db.execute(select(UserSettings).where(UserSettings.user_id == user_id))
+    ).scalar_one_or_none()
+    if row is None:
+        raise HTTPException(status_code=404, detail="user settings not found")
+
+    spotify_service: SpotifyService | None = None
+    lastfm_service: LastfmService | None = None
+    lastfm_user: str | None = None
+    if row.spotify_access_token:
+        spotify_service = SpotifyService(client, access_token=row.spotify_access_token)
+    elif row.lastfm_user:
+        lastfm_service = LastfmService(client, settings.lastfm_api_key)
+        lastfm_user = row.lastfm_user
+
+    candidates = await generate_candidates(
+        spotify=spotify_service, lastfm=lastfm_service, lastfm_user=lastfm_user
+    )
+
+    redis_conn = _get_redis_connection(settings)
+
+    enriched: list[dict] = []
+    spotify_ids: list[str] = []
+    for cand in candidates:
+        item: dict[str, Any] = {
+            "artist": cand.get("artist"),
+            "title": cand.get("title"),
+            "score_cf": cand.get("score_cf"),
+        }
+        isrc = cand.get("isrc")
+        if isrc:
+            rec_mbid, art_mbid, year, label, _tags = await recording_by_isrc(
+                isrc, client=client, redis_conn=redis_conn
+            )
+            item.update(
+                {
+                    "recording_mbid": rec_mbid,
+                    "artist_mbid": art_mbid,
+                    "label": label,
+                }
+            )
+        else:
+            sid = cand.get("spotify_id")
+            if sid:
+                item["spotify_id"] = sid
+                spotify_ids.append(sid)
+        enriched.append(item)
+
+    user_profile: dict[str, float] = {}
+    if spotify_service:
+        user_profile = await profile_from_spotify(spotify_service)
+        if spotify_ids:
+            feats = await spotify_service.get_audio_features(spotify_ids)
+            feat_map = {f.get("id"): f for f in feats}
+            for item in enriched:
+                sid = item.get("spotify_id")
+                if sid and sid in feat_map:
+                    item["audio_features"] = feat_map[sid]
+
+    ranked = rank(enriched, user_profile)
+    out: list[dict] = []
+    for item in ranked[:limit]:
+        out.append(
+            {
+                k: item.get(k)
+                for k in ("title", "artist", "spotify_id", "recording_mbid", "reasons", "final_score")
+                if item.get(k) is not None
+            }
+        )
+    return out

--- a/sidetrack/services/ranker.py
+++ b/sidetrack/services/ranker.py
@@ -1,0 +1,130 @@
+"""Ranking helpers for recommendation candidates."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from .spotify import SpotifyService
+
+
+def artist_or_label(item: dict[str, Any]) -> str | None:
+    """Return a key for diversity: artist or label.
+
+    ``recording_by_isrc`` may attach either MusicBrainz identifiers or a label
+    string to a candidate.  We favour MBIDs where available to keep the key
+    stable.
+    """
+
+    return (
+        item.get("artist_mbid")
+        or item.get("artist")
+        or item.get("label")
+    )
+
+
+async def profile_from_spotify(sp: SpotifyService) -> dict[str, float]:
+    """Return a simple audio feature profile for a Spotify user.
+
+    The profile contains the mean tempo, valence and energy of the user's
+    recently played tracks.  Missing values are ignored.
+    """
+
+    recent = await sp.get_recently_played()
+    ids = [
+        (item.get("track") or {}).get("id")
+        for item in recent
+        if (item.get("track") or {}).get("id")
+    ]
+    features = await sp.get_audio_features(ids) if ids else []
+
+    tempos = [f.get("tempo") for f in features if isinstance(f.get("tempo"), int | float)]
+    valences = [
+        f.get("valence") for f in features if isinstance(f.get("valence"), int | float)
+    ]
+    energies = [
+        f.get("energy") for f in features if isinstance(f.get("energy"), int | float)
+    ]
+
+    def _mean(vals: list[float]) -> float:
+        return float(sum(vals) / len(vals)) if vals else 0.0
+
+    return {
+        "tempo": _mean(tempos),
+        "valence": _mean(valences),
+        "energy": _mean(energies),
+    }
+
+
+def mmr_diversity(
+    items: list[dict[str, Any]],
+    *,
+    key: Callable[[dict[str, Any]], str | None] = artist_or_label,
+    penalty: float = 0.3,
+) -> list[dict[str, Any]]:
+    """Penalise consecutive results sharing the same ``key``.
+
+    The implementation is intentionally lightweight: items are processed in
+    descending ``final_score`` order and a fixed penalty is subtracted when a
+    key has been seen before.  The adjusted list is returned in the new order.
+    """
+
+    seen: dict[str | None, int] = {}
+    ordered = sorted(
+        items, key=lambda x: x.get("final_score", x.get("score_cf", 0.0)), reverse=True
+    )
+    out: list[dict[str, Any]] = []
+    for item in ordered:
+        k = key(item)
+        dup_count = seen.get(k, 0)
+        if dup_count:
+            item["final_score"] = float(
+                item.get("final_score", item.get("score_cf", 0.0)) - penalty * dup_count
+            )
+        else:
+            item["final_score"] = float(item.get("final_score", item.get("score_cf", 0.0)))
+        seen[k] = dup_count + 1
+        out.append(item)
+    return out
+
+
+def rank(candidates: list[dict[str, Any]], user_profile: dict[str, float]) -> list[dict[str, Any]]:
+    """Score and rerank ``candidates`` using ``user_profile``.
+
+    Each candidate is given a ``final_score`` starting from its collaborative
+    filtering score (``score_cf``).  When audio features for the candidate are
+    available, they are compared against the user's profile and can slightly
+    boost the score.  A list of ``reasons`` describing strong matches is also
+    attached to each candidate.  Finally, :func:`mmr_diversity` is applied to
+    reduce repetition by artist or label.
+    """
+
+    def _clamp(x: float) -> float:
+        return 0.0 if x < 0.0 else 1.0 if x > 1.0 else x
+
+    for cand in candidates:
+        score = float(cand.get("score_cf") or 0.0)
+        reasons: list[str] = []
+        feats = cand.get("audio_features") or {}
+        if feats and user_profile:
+            tempo = feats.get("tempo")
+            if tempo is not None and user_profile.get("tempo") is not None:
+                diff = abs(float(tempo) - float(user_profile["tempo"]))
+                score += 0.1 * _clamp(1 - diff / 200.0)
+                if diff < 10:
+                    reasons.append("tempo")
+            for name in ("energy", "valence"):
+                val = feats.get(name)
+                prof_val = user_profile.get(name)
+                if val is not None and prof_val is not None:
+                    diff = abs(float(val) - float(prof_val))
+                    score += 0.1 * _clamp(1 - diff)
+                    if diff < 0.1:
+                        reasons.append(name)
+        cand["final_score"] = _clamp(score)
+        cand["reasons"] = reasons
+
+    ranked = mmr_diversity(candidates)
+    ranked.sort(key=lambda x: x["final_score"], reverse=True)
+    return ranked
+

--- a/sidetrack/services/spotify.py
+++ b/sidetrack/services/spotify.py
@@ -143,3 +143,21 @@ class SpotifyService:
             "GET", f"{self.api_root}/recommendations", params=params
         )
         return data.get("tracks", [])
+
+    async def get_audio_features(self, ids: list[str]) -> list[dict[str, Any]]:
+        """Return Spotify audio features for the given track IDs.
+
+        Spotify's ``audio-features`` endpoint accepts up to 100 IDs per
+        request.  This helper batches requests as needed and flattens the
+        response into a list.  Missing or invalid IDs are ignored.
+        """
+
+        out: list[dict[str, Any]] = []
+        for i in range(0, len(ids), 100):
+            batch = ids[i : i + 100]
+            params = {"ids": ",".join(batch)}
+            data = await self._request(
+                "GET", f"{self.api_root}/audio-features", params=params
+            )
+            out.extend(x for x in data.get("audio_features", []) if x)
+        return out

--- a/tests/api/test_recs_ranked.py
+++ b/tests/api/test_recs_ranked.py
@@ -1,0 +1,38 @@
+import pytest
+
+from sidetrack.common.models import UserSettings
+
+
+@pytest.fixture
+def user_id():
+    return "user1"
+
+
+def test_ranked_recs(client, session, monkeypatch, user_id):
+    session.add(UserSettings(user_id=user_id, lastfm_user="lfm"))
+    session.commit()
+
+    async def fake_generate_candidates(**kwargs):
+        return [
+            {"artist": "A1", "title": "T1", "spotify_id": "s1", "score_cf": 0.9},
+            {"artist": "A2", "title": "T2", "spotify_id": "s2", "score_cf": 0.8},
+        ]
+
+    monkeypatch.setattr(
+        "sidetrack.services.candidates.generate_candidates", fake_generate_candidates
+    )
+
+    resp = client.get("/api/v1/recs/ranked", headers={"X-User-Id": user_id})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    assert len(data) == 2
+    assert data[0]["title"] == "T1"
+    assert pytest.approx(data[0]["final_score"], rel=1e-6) == 0.9
+    assert data[0]["reasons"] == []
+    assert data[1]["title"] == "T2"
+
+    resp = client.get("/api/v1/recs/ranked?limit=1", headers={"X-User-Id": user_id})
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+


### PR DESCRIPTION
## Summary
- implement ranker service for user profiles and diversity-aware scoring
- add Spotify audio feature helper
- expose `/api/v1/recs/ranked` endpoint and tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c107dbbf908333a9203a845b8e5c26