### PR TITLE
feat(ui): add recommendations page and rec components

### DIFF
--- a/services/ui/app/recommendations/page.tsx
+++ b/services/ui/app/recommendations/page.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import RecList, { type Rec } from '../../components/recs/RecList';
+import { apiFetch } from '../../lib/api';
+
+export default function RecommendationsPage() {
+  const [recs, setRecs] = useState<Rec[]>([]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const r = await apiFetch('/recommendations');
+        const j = await r.json();
+        setRecs(j.recommendations ?? []);
+      } catch {
+        setRecs([]);
+      }
+    })();
+  }, []);
+
+  return (
+    <section className="space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold">Recommendations</h2>
+      </div>
+      <RecList recs={recs} />
+    </section>
+  );
+}

--- a/services/ui/components/recs/RecCard.tsx
+++ b/services/ui/components/recs/RecCard.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { Button } from '../ui/button';
+
+export type Rec = {
+  id: string;
+  title: string;
+  artist: string;
+  mbid?: string;
+  isrc?: string;
+  uri?: string;
+  because?: string[];
+};
+
+interface Props {
+  rec: Rec;
+  onLike: () => void;
+  onSkip: () => void;
+  onHideArtist: () => void;
+}
+
+export default function RecCard({ rec, onLike, onSkip, onHideArtist }: Props) {
+  return (
+    <div className="space-y-4 rounded-lg border p-4">
+      <div>
+        <h4 className="text-lg font-semibold">{rec.title}</h4>
+        <p className="text-sm text-muted-foreground">{rec.artist}</p>
+      </div>
+      {rec.because && (
+        <div className="flex flex-wrap gap-2">
+          {rec.because.map((reason) => (
+            <span key={reason} className="rounded-full bg-secondary px-2 py-0.5 text-xs">
+              Because {reason}
+            </span>
+          ))}
+        </div>
+      )}
+      <div className="flex gap-2">
+        <Button onClick={onLike}>Like</Button>
+        <Button variant="outline" onClick={onSkip}>
+          Skip
+        </Button>
+        <Button variant="ghost" onClick={onHideArtist}>
+          Hide artist
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/services/ui/components/recs/RecList.tsx
+++ b/services/ui/components/recs/RecList.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import RecCard, { type Rec } from './RecCard';
+import { saveTrack, createPlaylist } from '../../lib/spotifyClient';
+
+interface Props {
+  recs: Rec[];
+}
+
+function dedupe(recs: Rec[]) {
+  const seen = new Set<string>();
+  return recs.filter((r) => {
+    const key = r.mbid || r.isrc || r.id;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+export default function RecList({ recs }: Props) {
+  const [index, setIndex] = useState(0);
+  const [liked, setLiked] = useState<Rec[]>([]);
+  const [hidden, setHidden] = useState<Set<string>>(new Set());
+
+  const filtered = useMemo(() => {
+    const deduped = dedupe(recs);
+    return deduped.filter((r) => !hidden.has(r.artist));
+  }, [recs, hidden]);
+
+  const current = filtered[index];
+
+  const handleLike = async () => {
+    if (!current) return;
+    setLiked((prev) => [...prev, current]);
+    saveTrack(current.id).catch(() => {});
+    setIndex((i) => i + 1);
+  };
+
+  const handleSkip = () => setIndex((i) => i + 1);
+
+  const handleHide = () => {
+    if (current) setHidden(new Set(hidden).add(current.artist));
+    setIndex((i) => i + 1);
+  };
+
+  const buildMixtape = async () => {
+    if (!liked.length) return;
+    try {
+      await createPlaylist(
+        'Mixtape',
+        liked.map((t) => t.uri || t.id),
+      );
+    } catch {
+      const lines = ['#EXTM3U', ...liked.map((t) => t.uri || t.id)];
+      const blob = new Blob([lines.join('\n')], { type: 'audio/x-mpegurl' });
+      const link = document.createElement('a');
+      link.href = URL.createObjectURL(blob);
+      link.download = 'mixtape.m3u';
+      link.click();
+    }
+  };
+
+  if (!current) {
+    return (
+      <div className="space-y-4">
+        <p>No more recommendations.</p>
+        {liked.length > 0 && (
+          <button onClick={buildMixtape} className="text-sm underline">
+            Build Mixtape
+          </button>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <RecCard rec={current} onLike={handleLike} onSkip={handleSkip} onHideArtist={handleHide} />
+      {liked.length > 0 && (
+        <div className="text-right">
+          <button onClick={buildMixtape} className="text-sm underline">
+            Build Mixtape
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export type { Rec };

--- a/services/ui/lib/spotifyClient.ts
+++ b/services/ui/lib/spotifyClient.ts
@@ -1,0 +1,18 @@
+import { apiFetch } from './api';
+
+export async function saveTrack(trackId: string) {
+  await apiFetch('/api/spotify/save', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ trackId }),
+  });
+}
+
+export async function createPlaylist(name: string, uris: string[]) {
+  const r = await apiFetch('/api/spotify/playlist', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, uris }),
+  });
+  return r.json().catch(() => ({}));
+}


### PR DESCRIPTION
## Summary
- add RecCard and RecList components with like, skip and hide artist actions
- add Spotify client helpers for saving tracks and playlists
- add recommendations page to show deduped swipeable recs

## Testing
- `pre-commit run --files services/ui/app/recommendations/page.tsx services/ui/components/recs/RecCard.tsx services/ui/components/recs/RecList.tsx services/ui/lib/spotifyClient.ts` *(failed: Cannot read config file: services/ui/package.json)*
- `npm test` *(failed: Invalid package.json)*
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c109dd2518833387f7339a53b7d3a3