### PR TITLE
Add feature flags and ListenBrainz routing for recs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,11 @@ MUSICBRAINZ_RATE_LIMIT=1.0
 LASTFM_API_KEY=lfm_xxx
 LASTFM_API_SECRET=lfm_secret
 
+# Recommendations feature flags
+SPOTIFY_RECS_ENABLED=true
+LASTFM_SIMILAR_ENABLED=true
+# LB_CF_ENABLED=false
+
 # Auth.js (NextAuth) – Google OAuth
 NEXTAUTH_URL=https://sidetrack.network
 NEXTAUTH_SECRET=supersecretlongrandom

--- a/sidetrack/common/config.py
+++ b/sidetrack/common/config.py
@@ -32,6 +32,9 @@ class Settings(BaseSettings):
     spotify_client_id: str | None = Field(default=None, env="SPOTIFY_CLIENT_ID")
     spotify_client_secret: str | None = Field(default=None, env="SPOTIFY_CLIENT_SECRET")
     google_client_id: str | None = Field(default=None, env="GOOGLE_CLIENT_ID")
+    spotify_recs_enabled: bool = Field(default=True, env="SPOTIFY_RECS_ENABLED")
+    lastfm_similar_enabled: bool = Field(default=True, env="LASTFM_SIMILAR_ENABLED")
+    lb_cf_enabled: bool = Field(default=False, env="LB_CF_ENABLED")
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 

--- a/sidetrack/services/listenbrainz.py
+++ b/sidetrack/services/listenbrainz.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+
+class ListenBrainzService:
+    """Minimal ListenBrainz API wrapper for recommendations."""
+
+    api_root = "https://api.listenbrainz.org/1"
+
+    def __init__(self, client: httpx.AsyncClient) -> None:
+        self._client = client
+
+    async def get_cf_recommendations(self, user: str, limit: int = 50) -> list[dict[str, Any]]:
+        """Fetch collaborative-filtering recommendations for ``user``."""
+
+        url = f"{self.api_root}/user/{user}/cf/recommendations"
+        params = {"count": limit}
+        resp = await self._client.get(url, params=params, timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+        return (
+            data.get("recommendations")
+            or data.get("recordings")
+            or data.get("recommended_recordings")
+            or []
+        )

--- a/tests/api/test_recs_lb_cf.py
+++ b/tests/api/test_recs_lb_cf.py
@@ -1,0 +1,47 @@
+import pytest
+
+from sidetrack.api.config import get_settings as get_app_settings
+from sidetrack.common.models import UserSettings
+
+
+@pytest.fixture
+def user_id():
+    return "user_lb"
+
+
+def test_lb_cf_recs(client, session, monkeypatch, user_id):
+    session.add(UserSettings(user_id=user_id, listenbrainz_user="lbuser"))
+    session.commit()
+
+    monkeypatch.setenv("LB_CF_ENABLED", "1")
+    get_app_settings.cache_clear()
+
+    async def fake_cf(self, user, limit=50):
+        return [
+            {
+                "recording_mbid": "mbid1",
+                "artist_name": "Artist",
+                "recording_name": "Title",
+                "score": 0.5,
+            }
+        ]
+
+    monkeypatch.setattr(
+        "sidetrack.services.listenbrainz.ListenBrainzService.get_cf_recommendations",
+        fake_cf,
+    )
+
+    resp = client.get("/api/v1/recs", headers={"X-User-Id": user_id})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data == {
+        "candidates": [
+            {
+                "artist": "Artist",
+                "title": "Title",
+                "source": "listenbrainz",
+                "score_cf": 0.5,
+                "recording_mbid": "mbid1",
+            }
+        ]
+    }


### PR DESCRIPTION
## Summary
- add env-based feature flags for recommendation providers
- route recs requests through Spotify, Last.fm, or ListenBrainz CF based on flags and user profile
- document flags and add ListenBrainz CF service with tests

## Testing
- `pre-commit run --files sidetrack/common/config.py .env.example sidetrack/services/listenbrainz.py sidetrack/services/candidates.py sidetrack/api/api/v1/recs.py tests/api/test_recs_lb_cf.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c10d9612048333bf60da3395c2c31c