### PR TITLE
feat(ui): add header with source badges

### DIFF
--- a/services/ui/app/layout.tsx
+++ b/services/ui/app/layout.tsx
@@ -4,11 +4,11 @@ export const metadata = {
 };
 
 import './globals.css';
-import AppShell from '../components/AppShell';
 import PageTransition from '../components/PageTransition';
 import { Inter } from 'next/font/google';
 import Providers from './providers';
 import ThemeProvider from '../components/ThemeProvider';
+import Header from '../components/layout/Header';
 
 const inter = Inter({ subsets: ['latin'], variable: '--font-sans' });
 
@@ -19,7 +19,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <ThemeProvider>
           <Providers>
             <PageTransition>
-              <AppShell>{children}</AppShell>
+              <Header />
+              <main className="container mx-auto w-full max-w-6xl overflow-x-hidden px-4 py-6">{children}</main>
             </PageTransition>
           </Providers>
         </ThemeProvider>
@@ -27,3 +28,4 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     </html>
   );
 }
+

--- a/services/ui/components/layout/Header.tsx
+++ b/services/ui/components/layout/Header.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { Search, Bell, ChevronRight } from 'lucide-react';
+import { useSources } from '../../lib/sources';
+import SourceBadge from './SourceBadge';
+
+export default function Header() {
+  const pathname = usePathname();
+  const { data: sources } = useSources();
+
+  const openSearch = () => {
+    window.dispatchEvent(new CustomEvent('open-search'));
+  };
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        openSearch();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
+  const segments = pathname.split('/').filter(Boolean);
+
+  return (
+    <header className="sticky top-0 z-10 glass flex items-center justify-between gap-4 px-4 py-3">
+      <nav aria-label="Breadcrumb" className="hidden text-sm text-muted-foreground md:block">
+        <ol className="flex items-center gap-1">
+          <li>
+            <Link href="/" className="hover:underline">
+              Home
+            </Link>
+          </li>
+          {segments.map((seg, idx) => (
+            <li key={seg} className="flex items-center gap-1">
+              <ChevronRight size={12} aria-hidden="true" />
+              {idx === segments.length - 1 ? (
+                <span className="capitalize" aria-current="page">
+                  {seg.replace(/-/g, ' ')}
+                </span>
+              ) : (
+                <Link
+                  href={`/${segments.slice(0, idx + 1).join('/')}`}
+                  className="hover:underline capitalize"
+                >
+                  {seg.replace(/-/g, ' ')}
+                </Link>
+              )}
+            </li>
+          ))}
+        </ol>
+      </nav>
+      <button
+        onClick={openSearch}
+        aria-label="Open search (⌘K)"
+        className="flex flex-1 items-center gap-2 rounded-md bg-white/5 px-3 py-2 text-sm text-muted-foreground hover:text-foreground focus:outline-none focus:ring-2 focus:ring-emerald-500 md:mx-8 md:flex-none md:w-72"
+      >
+        <Search size={16} />
+        <span className="hidden sm:inline">Search</span>
+        <kbd className="ml-auto hidden text-xs sm:inline">⌘K</kbd>
+      </button>
+      <div className="flex items-center gap-2">
+        {sources?.map((s) => (
+          <SourceBadge key={s.type} source={s} />
+        ))}
+        <button
+          aria-label="Notifications"
+          className="relative inline-flex h-8 w-8 items-center justify-center rounded-full text-muted-foreground hover:text-foreground focus:outline-none focus:ring-2 focus:ring-emerald-500"
+        >
+          <Bell size={16} />
+        </button>
+      </div>
+    </header>
+  );
+}
+

--- a/services/ui/components/layout/SourceBadge.tsx
+++ b/services/ui/components/layout/SourceBadge.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import * as Tooltip from '@radix-ui/react-tooltip';
+import {
+  Spotify,
+  Radio,
+  Brain,
+  Globe,
+} from 'lucide-react';
+import clsx from 'clsx';
+import { Source } from '../../lib/sources';
+
+const icons: Record<Source['type'], React.ElementType> = {
+  spotify: Spotify,
+  lastfm: Radio,
+  lb: Brain,
+  mb: Globe,
+};
+
+const titles: Record<Source['type'], string> = {
+  spotify: 'Spotify',
+  lastfm: 'Last.fm',
+  lb: 'ListenBrainz',
+  mb: 'MusicBrainz',
+};
+
+const statusColors: Record<Source['status'], string> = {
+  connected: 'text-emerald-400',
+  disconnected: 'text-rose-400',
+  syncing: 'text-amber-400 animate-pulse',
+};
+
+export default function SourceBadge({ source }: { source: Source }) {
+  const router = useRouter();
+  const Icon = icons[source.type];
+  const color = statusColors[source.status];
+
+  const handleClick = () => {
+    router.push(`/settings#${source.type}`);
+  };
+
+  return (
+    <Tooltip.Root>
+      <Tooltip.Trigger asChild>
+        <button
+          onClick={handleClick}
+          aria-label={`${titles[source.type]} ${source.status}`}
+          className={clsx(
+            'relative inline-flex h-8 w-8 items-center justify-center rounded-full',
+            color,
+            'hover:bg-white/5 focus:outline-none focus:ring-2 focus:ring-emerald-500'
+          )}
+        >
+          <Icon size={16} />
+        </button>
+      </Tooltip.Trigger>
+      <Tooltip.Portal>
+        <Tooltip.Content
+          side="bottom"
+          sideOffset={4}
+          className="rounded-md bg-foreground px-2 py-1 text-xs text-background"
+        >
+          {titles[source.type]}
+        </Tooltip.Content>
+      </Tooltip.Portal>
+    </Tooltip.Root>
+  );
+}
+

--- a/services/ui/lib/sources.ts
+++ b/services/ui/lib/sources.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiFetch } from './api';
+
+export type Source = {
+  type: 'spotify' | 'lastfm' | 'lb' | 'mb';
+  status: 'connected' | 'disconnected' | 'syncing';
+};
+
+export function useSources() {
+  return useQuery<Source[]>({
+    queryKey: ['sources'],
+    queryFn: async () => apiFetch('/api/sources'),
+  });
+}
+


### PR DESCRIPTION
## Summary
- add SourceBadge component with tooltip and source status styles
- introduce header with breadcrumbs, search trigger, source badges and notifications bell
- expose `Source` types and hooks for fetching connected sources
- render new header in app layout

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c10fd2b8c08333bedc5846900a3440