### PR TITLE
Add recommendations card stack UI with source chips

### DIFF
--- a/services/ui/app/recommendations/page.tsx
+++ b/services/ui/app/recommendations/page.tsx
@@ -1,30 +1,96 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import RecList, { type Rec } from '../../components/recs/RecList';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import RecCard, { type Rec } from '../../components/recs/RecCard';
 import { apiFetch } from '../../lib/api';
+import { saveTrack, createPlaylist } from '../../lib/spotifyClient';
 
 export default function RecommendationsPage() {
   const [recs, setRecs] = useState<Rec[]>([]);
+  const [index, setIndex] = useState(0);
+  const [liked, setLiked] = useState<Rec[]>([]);
+  const [hidden, setHidden] = useState<Set<string>>(new Set());
+  const [newOnly, setNewOnly] = useState(false);
+  const [freshness, setFreshness] = useState(0);
 
   useEffect(() => {
-    (async () => {
-      try {
-        const r = await apiFetch('/recommendations');
-        const j = await r.json();
-        setRecs(j.recommendations ?? []);
-      } catch {
-        setRecs([]);
-      }
-    })();
+    apiFetch('/api/v1/recs/ranked')
+      .then((r) => r.json())
+      .then((j) => setRecs(j ?? []))
+      .catch(() => setRecs([]));
   }, []);
+
+  const filtered = useMemo(() => recs.filter((r) => !hidden.has(r.artist)), [recs, hidden]);
+  const current = filtered[index];
+
+  const like = useCallback(async () => {
+    if (!current) return;
+    if (current.spotify_id) {
+      saveTrack(current.spotify_id).catch(() => {});
+    }
+    setLiked((prev) => [...prev, current]);
+    setIndex((i) => i + 1);
+  }, [current]);
+
+  const skip = useCallback(() => setIndex((i) => i + 1), []);
+
+  const hideArtist = useCallback(() => {
+    if (current) setHidden((prev) => new Set(prev).add(current.artist));
+    setIndex((i) => i + 1);
+  }, [current]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowRight') like();
+      if (e.key === 'ArrowLeft') skip();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [like, skip]);
+
+  const buildMixtape = useCallback(async () => {
+    const uris = liked.map((t) => t.spotify_id || '').filter(Boolean);
+    if (!uris.length) return;
+    await createPlaylist('Mixtape', uris);
+  }, [liked]);
 
   return (
     <section className="space-y-6">
-      <div>
+      <div className="flex items-center justify-between">
         <h2 className="text-xl font-semibold">Recommendations</h2>
+        {liked.length > 0 && (
+          <button onClick={buildMixtape} className="text-sm underline">
+            Build Mixtape
+          </button>
+        )}
       </div>
-      <RecList recs={recs} />
+      <div className="flex items-center gap-4">
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={newOnly}
+            onChange={() => setNewOnly((v) => !v)}
+          />
+          New artists only
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          Min freshness
+          <input
+            type="range"
+            min={0}
+            max={1}
+            step={0.1}
+            value={freshness}
+            onChange={(e) => setFreshness(parseFloat(e.target.value))}
+          />
+        </label>
+      </div>
+      {current ? (
+        <RecCard rec={current} onLike={like} onSkip={skip} onHideArtist={hideArtist} />
+      ) : (
+        <p>No more recommendations.</p>
+      )}
     </section>
   );
 }
+

--- a/services/ui/components/recs/BecauseChips.tsx
+++ b/services/ui/components/recs/BecauseChips.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import SourceBadge from '../layout/SourceBadge';
+import { chipFromReason, type Reason, type Source } from '../../lib/sources';
+
+export default function BecauseChips({ reasons }: { reasons: Reason[] }) {
+  const chips = reasons?.map(chipFromReason).filter(Boolean) ?? [];
+  if (!chips.length) return null;
+  return (
+    <div className="flex flex-wrap gap-2">
+      {chips.map((c, idx) => {
+        const source: Source = { type: c.source, status: 'connected' } as Source;
+        return (
+          <span
+            key={idx}
+            className="inline-flex items-center gap-1 rounded-full bg-secondary px-2 py-0.5 text-xs"
+          >
+            <SourceBadge source={source} />
+            <span>{c.text}</span>
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+

--- a/services/ui/components/recs/RecActions.tsx
+++ b/services/ui/components/recs/RecActions.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { Button } from '../ui/button';
+import { useToast } from '../ToastProvider';
+
+interface Props {
+  onLike: () => void | Promise<void>;
+  onSkip: () => void | Promise<void>;
+  onHideArtist: () => void | Promise<void>;
+}
+
+export default function RecActions({ onLike, onSkip, onHideArtist }: Props) {
+  const { show } = useToast();
+
+  return (
+    <div className="flex gap-2">
+      <Button
+        onClick={async () => {
+          await onLike();
+          show({ title: 'Saved', kind: 'success' });
+        }}
+      >
+        Like
+      </Button>
+      <Button
+        variant="outline"
+        onClick={async () => {
+          await onSkip();
+        }}
+      >
+        Skip
+      </Button>
+      <Button
+        variant="ghost"
+        onClick={async () => {
+          await onHideArtist();
+          show({ title: 'Artist hidden', kind: 'success' });
+        }}
+      >
+        Hide artist
+      </Button>
+    </div>
+  );
+}
+

--- a/services/ui/components/recs/RecCard.tsx
+++ b/services/ui/components/recs/RecCard.tsx
@@ -1,15 +1,17 @@
 'use client';
 
-import { Button } from '../ui/button';
+import Image from 'next/image';
+import { useEffect, useState } from 'react';
+import BecauseChips from './BecauseChips';
+import RecActions from './RecActions';
+import type { Reason } from '../../lib/sources';
 
 export type Rec = {
-  id: string;
   title: string;
   artist: string;
-  mbid?: string;
-  isrc?: string;
-  uri?: string;
-  because?: string[];
+  spotify_id?: string;
+  recording_mbid?: string;
+  reasons?: Reason[];
 };
 
 interface Props {
@@ -20,30 +22,35 @@ interface Props {
 }
 
 export default function RecCard({ rec, onLike, onSkip, onHideArtist }: Props) {
+  const [img, setImg] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (rec.spotify_id) {
+      fetch(`https://open.spotify.com/oembed?url=spotify:track:${rec.spotify_id}`)
+        .then((r) => r.json())
+        .then((j) => setImg(j?.thumbnail_url))
+        .catch(() => {});
+    }
+  }, [rec.spotify_id]);
+
   return (
     <div className="space-y-4 rounded-lg border p-4">
+      {img && (
+        <Image
+          src={img}
+          alt={`${rec.title} cover`}
+          width={300}
+          height={300}
+          className="w-full rounded"
+        />
+      )}
       <div>
         <h4 className="text-lg font-semibold">{rec.title}</h4>
         <p className="text-sm text-muted-foreground">{rec.artist}</p>
       </div>
-      {rec.because && (
-        <div className="flex flex-wrap gap-2">
-          {rec.because.map((reason) => (
-            <span key={reason} className="rounded-full bg-secondary px-2 py-0.5 text-xs">
-              Because {reason}
-            </span>
-          ))}
-        </div>
-      )}
-      <div className="flex gap-2">
-        <Button onClick={onLike}>Like</Button>
-        <Button variant="outline" onClick={onSkip}>
-          Skip
-        </Button>
-        <Button variant="ghost" onClick={onHideArtist}>
-          Hide artist
-        </Button>
-      </div>
+      {rec.reasons && rec.reasons.length > 0 && <BecauseChips reasons={rec.reasons} />}
+      <RecActions onLike={onLike} onSkip={onSkip} onHideArtist={onHideArtist} />
     </div>
   );
 }
+

--- a/services/ui/lib/sources.ts
+++ b/services/ui/lib/sources.ts
@@ -13,3 +13,25 @@ export function useSources() {
   });
 }
 
+export type Reason =
+  | { source: 'spotify' }
+  | { source: 'lastfm'; tags: string[] }
+  | { source: 'lb'; artist: string }
+  | { source: 'mb'; label: string; yearRange: string };
+
+export function chipFromReason(reason: Reason): { source: Source['type']; text: string } {
+  switch (reason.source) {
+    case 'spotify':
+      return { source: 'spotify', text: 'vibe match: energy + tempo' };
+    case 'lastfm':
+      return { source: 'lastfm', text: `tag overlap: ${(reason as any).tags?.join(', ')}` };
+    case 'lb':
+      return { source: 'lb', text: `co-listened with ${(reason as any).artist}` };
+    case 'mb':
+      const r = reason as any;
+      return { source: 'mb', text: `same label: ${r.label}, era: ${r.yearRange}` };
+    default:
+      return { source: 'spotify', text: '' };
+  }
+}
+


### PR DESCRIPTION
## Summary
- Implement recommendations page fetching ranked recs with card stack controls and keyboard shortcuts
- Add reusable recommendation card, action buttons, and source reason chips
- Provide helper to format source reasons with badges

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q` *(fails: RuntimeError: no compiled object yet for <Library ...>)*
- `npm --prefix services/ui test` *(fails: Invalid package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68c111fb42d48333a5d8dd36c1d0cd47