### PR TITLE
Add inspector drawer for artists and tracks

### DIFF
--- a/services/ui/components/inspect/ArtistPanel.tsx
+++ b/services/ui/components/inspect/ArtistPanel.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { apiFetch } from '../../lib/api';
+import { addToMixtape } from '../../lib/mixtape';
+import { useInspector } from '../../hooks/useInspector';
+
+type SimilarArtist = { artist_id: number; name: string };
+type AlsoListened = { track_id: number; title: string };
+
+type ArtistData = {
+  name?: string;
+  tags?: string[];
+  similar?: SimilarArtist[];
+  mb?: { label?: string; area?: string; firstReleaseYear?: number };
+  alsoListened?: AlsoListened[];
+};
+
+export default function ArtistPanel({ artistId }: { artistId: number }) {
+  const [data, setData] = useState<ArtistData>();
+  const router = useRouter();
+  const { inspect } = useInspector();
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await apiFetch(`/inspect/artist/${artistId}`);
+        if (res.ok) {
+          setData((await res.json()) as ArtistData);
+        } else {
+          setData({});
+        }
+      } catch {
+        setData({});
+      }
+    })();
+  }, [artistId]);
+
+  const handleAddFive = async () => {
+    try {
+      const res = await apiFetch(`/similar/artist/${artistId}?limit=5`);
+      if (res.ok) {
+        const items = (await res.json()) as SimilarArtist[];
+        items.slice(0, 5).forEach((a) => addToMixtape({ track_id: a.artist_id, title: a.name }));
+      }
+    } catch {
+      /* noop */
+    }
+  };
+
+  return (
+    <div className="space-y-6 p-4">
+      {data?.tags && data.tags.length > 0 && (
+        <section>
+          <h3 className="mb-2 text-sm font-semibold">Top Tags</h3>
+          <ul className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+            {data.tags.map((t) => (
+              <li key={t}>#{t}</li>
+            ))}
+          </ul>
+        </section>
+      )}
+      {data?.similar && data.similar.length > 0 && (
+        <section>
+          <h3 className="mb-2 text-sm font-semibold">Similar Artists</h3>
+          <div className="grid grid-cols-3 gap-2 text-sm">
+            {data.similar.map((a) => (
+              <button
+                key={a.artist_id}
+                onClick={() => inspect({ type: 'artist', id: a.artist_id })}
+                className="truncate text-left hover:underline"
+              >
+                {a.name}
+              </button>
+            ))}
+          </div>
+        </section>
+      )}
+      {data?.mb && (
+        <section className="text-sm">
+          <h3 className="mb-2 font-semibold">MusicBrainz</h3>
+          <p>Label: {data.mb.label ?? '—'}</p>
+          <p>Area: {data.mb.area ?? '—'}</p>
+          <p>First release: {data.mb.firstReleaseYear ?? '—'}</p>
+        </section>
+      )}
+      {data?.alsoListened && data.alsoListened.length > 0 && (
+        <section>
+          <h3 className="mb-2 text-sm font-semibold">Also Listened</h3>
+          <ul className="space-y-1 text-sm">
+            {data.alsoListened.map((t) => (
+              <button
+                key={t.track_id}
+                onClick={() => inspect({ type: 'track', id: t.track_id })}
+                className="block w-full truncate text-left hover:underline"
+              >
+                {t.title}
+              </button>
+            ))}
+          </ul>
+        </section>
+      )}
+      <div className="flex gap-2 pt-2">
+        <button
+          className="rounded bg-primary px-3 py-1 text-xs text-primary-foreground"
+          onClick={() => router.push(`/similar?artist=${artistId}`)}
+        >
+          Find similar
+        </button>
+        <button
+          className="rounded bg-primary px-3 py-1 text-xs text-primary-foreground"
+          onClick={() => router.push(`/radio?artist=${artistId}`)}
+        >
+          Start radio
+        </button>
+        <button
+          className="rounded bg-primary px-3 py-1 text-xs text-primary-foreground"
+          onClick={handleAddFive}
+        >
+          Add 5 to mixtape
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/services/ui/components/inspect/Inspector.tsx
+++ b/services/ui/components/inspect/Inspector.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import ArtistPanel from './ArtistPanel';
+import TrackPanel from './TrackPanel';
+import { useInspector } from '../../hooks/useInspector';
+
+export default function Inspector() {
+  const { target, close } = useInspector();
+  const open = Boolean(target);
+
+  return (
+    <aside
+      className={`fixed right-0 top-0 z-50 h-full w-96 bg-background shadow-lg transition-transform ${
+        open ? 'translate-x-0' : 'translate-x-full'
+      }`}
+    >
+      <div className="flex items-center justify-between border-b p-4">
+        <h2 className="text-lg font-semibold">
+          {target?.type === 'artist' ? 'Artist' : target?.type === 'track' ? 'Track' : ''}
+        </h2>
+        <button onClick={close} className="text-sm text-muted-foreground">
+          Close
+        </button>
+      </div>
+      <div className="h-[calc(100%-57px)] overflow-y-auto">
+        {target?.type === 'artist' && <ArtistPanel artistId={target.id} />}
+        {target?.type === 'track' && <TrackPanel trackId={target.id} />}
+      </div>
+    </aside>
+  );
+}

--- a/services/ui/components/inspect/TrackPanel.tsx
+++ b/services/ui/components/inspect/TrackPanel.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { apiFetch } from '../../lib/api';
+import { addToMixtape } from '../../lib/mixtape';
+import RadarChart from '../charts/RadarChart';
+import { useInspector } from '../../hooks/useInspector';
+
+type SimilarArtist = { artist_id: number; name: string };
+type AlsoListened = { track_id: number; title: string };
+
+type TrackData = {
+  title?: string;
+  features?: { valence: number; energy: number; tempo: number; danceability: number };
+  tags?: string[];
+  similar?: SimilarArtist[];
+  mb?: { label?: string; area?: string; firstReleaseYear?: number };
+  alsoListened?: AlsoListened[];
+};
+
+export default function TrackPanel({ trackId }: { trackId: number }) {
+  const [data, setData] = useState<TrackData>();
+  const router = useRouter();
+  const { inspect } = useInspector();
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const res = await apiFetch(`/inspect/track/${trackId}`);
+        if (res.ok) {
+          setData((await res.json()) as TrackData);
+        } else {
+          setData({});
+        }
+      } catch {
+        setData({});
+      }
+    })();
+  }, [trackId]);
+
+  const handleAddFive = async () => {
+    try {
+      const res = await apiFetch(`/similar/track/${trackId}?limit=5`);
+      if (res.ok) {
+        const items = (await res.json()) as AlsoListened[];
+        items.slice(0, 5).forEach((t) => addToMixtape({ track_id: t.track_id, title: t.title }));
+      }
+    } catch {
+      /* noop */
+    }
+  };
+
+  const baseline = { valence: 0.5, energy: 0.5, tempo: 0.5, danceability: 0.5 };
+  const axes = data?.features
+    ? {
+        valence: data.features.valence,
+        energy: data.features.energy,
+        tempo: data.features.tempo / 200,
+        danceability: data.features.danceability,
+      }
+    : baseline;
+
+  return (
+    <div className="space-y-6 p-4">
+      {data?.features && (
+        <section>
+          <h3 className="mb-2 text-sm font-semibold">Audio Features</h3>
+          <RadarChart axes={axes} baseline={baseline} />
+        </section>
+      )}
+      {data?.tags && data.tags.length > 0 && (
+        <section>
+          <h3 className="mb-2 text-sm font-semibold">Top Tags</h3>
+          <ul className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+            {data.tags.map((t) => (
+              <li key={t}>#{t}</li>
+            ))}
+          </ul>
+        </section>
+      )}
+      {data?.similar && data.similar.length > 0 && (
+        <section>
+          <h3 className="mb-2 text-sm font-semibold">Similar Artists</h3>
+          <div className="grid grid-cols-3 gap-2 text-sm">
+            {data.similar.map((a) => (
+              <button
+                key={a.artist_id}
+                onClick={() => inspect({ type: 'artist', id: a.artist_id })}
+                className="truncate text-left hover:underline"
+              >
+                {a.name}
+              </button>
+            ))}
+          </div>
+        </section>
+      )}
+      {data?.mb && (
+        <section className="text-sm">
+          <h3 className="mb-2 font-semibold">MusicBrainz</h3>
+          <p>Label: {data.mb.label ?? '—'}</p>
+          <p>Area: {data.mb.area ?? '—'}</p>
+          <p>First release: {data.mb.firstReleaseYear ?? '—'}</p>
+        </section>
+      )}
+      {data?.alsoListened && data.alsoListened.length > 0 && (
+        <section>
+          <h3 className="mb-2 text-sm font-semibold">Also Listened</h3>
+          <ul className="space-y-1 text-sm">
+            {data.alsoListened.map((t) => (
+              <button
+                key={t.track_id}
+                onClick={() => inspect({ type: 'track', id: t.track_id })}
+                className="block w-full truncate text-left hover:underline"
+              >
+                {t.title}
+              </button>
+            ))}
+          </ul>
+        </section>
+      )}
+      <div className="flex gap-2 pt-2">
+        <button
+          className="rounded bg-primary px-3 py-1 text-xs text-primary-foreground"
+          onClick={() => router.push(`/similar?track=${trackId}`)}
+        >
+          Find similar
+        </button>
+        <button
+          className="rounded bg-primary px-3 py-1 text-xs text-primary-foreground"
+          onClick={() => router.push(`/radio?track=${trackId}`)}
+        >
+          Start radio
+        </button>
+        <button
+          className="rounded bg-primary px-3 py-1 text-xs text-primary-foreground"
+          onClick={handleAddFive}
+        >
+          Add 5 to mixtape
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/services/ui/hooks/useInspector.ts
+++ b/services/ui/hooks/useInspector.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { createContext, ReactNode, useCallback, useContext, useState } from 'react';
+
+export type InspectTarget =
+  | { type: 'artist'; id: number }
+  | { type: 'track'; id: number };
+
+type InspectorContextValue = {
+  target: InspectTarget | null;
+  inspect: (t: InspectTarget) => void;
+  close: () => void;
+};
+
+const InspectorContext = createContext<InspectorContextValue | undefined>(undefined);
+
+export function InspectorProvider({ children }: { children: ReactNode }) {
+  const [target, setTarget] = useState<InspectTarget | null>(null);
+
+  const inspect = useCallback((t: InspectTarget) => setTarget(t), []);
+  const close = useCallback(() => setTarget(null), []);
+
+  return (
+    <InspectorContext.Provider value={{ target, inspect, close }}>
+      {children}
+    </InspectorContext.Provider>
+  );
+}
+
+export function useInspector() {
+  const ctx = useContext(InspectorContext);
+  if (!ctx) throw new Error('useInspector must be used within InspectorProvider');
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- add InspectorProvider hook to open a slide-over drawer for artists or tracks
- implement Inspector component with ArtistPanel and TrackPanel
- show audio features, tags, MusicBrainz, and actions like Find Similar

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1139caf888333915737fb1450d566