### PR TITLE
Add session transition flow analysis

### DIFF
--- a/services/ui/components/flows/FlowChord.tsx
+++ b/services/ui/components/flows/FlowChord.tsx
@@ -1,0 +1,62 @@
+'use client';
+import Plot from 'react-plotly.js';
+
+export type FlowEdge = {
+  source: string;
+  target: string;
+  prob: number;
+  lift?: number | null;
+};
+
+export default function FlowChord({
+  edges,
+  onSelect,
+}: {
+  edges: FlowEdge[];
+  onSelect?: (edge: { source: string; target: string }) => void;
+}) {
+  const nodes = Array.from(new Set(edges.flatMap((e) => [e.source, e.target])));
+  const index: Record<string, number> = Object.fromEntries(
+    nodes.map((n, i) => [n, i]),
+  );
+  const sources = edges.map((e) => index[e.source]);
+  const targets = edges.map((e) => index[e.target]);
+  const values = edges.map((e) => e.prob);
+  const colors = edges.map((e) =>
+    e.lift && e.lift > 1 ? 'rgba(16,185,129,0.8)' : 'rgba(156,163,175,0.4)',
+  );
+
+  return (
+    <Plot
+      data={[
+        {
+          type: 'sankey',
+          orientation: 'h',
+          arrangement: 'fixed',
+          node: { label: nodes },
+          link: {
+            source: sources,
+            target: targets,
+            value: values,
+            color: colors,
+            hovertemplate:
+              '%{source.label} → %{target.label}<br>p(next|current)=%{value:.2f}<extra></extra>',
+          },
+        },
+      ]}
+      layout={{
+        margin: { l: 10, r: 10, t: 10, b: 10 },
+        font: { size: 10 },
+      }}
+      style={{ width: '100%', height: '100%' }}
+      config={{ displayModeBar: false }}
+      onClick={(e) => {
+        const idx = e.points?.[0]?.pointIndex;
+        if (idx != null) {
+          const edge = edges[idx];
+          onSelect?.({ source: edge.source, target: edge.target });
+        }
+      }}
+    />
+  );
+}

--- a/sidetrack/api/api/v1/__init__.py
+++ b/sidetrack/api/api/v1/__init__.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-from ...routers import cohorts, compare, daypart, insights, moods, similar
+from ...routers import cohorts, compare, daypart, insights, moods, similar, flows
 from . import auth, dashboard, listens, musicbrainz, spotify, recs
 
 router = APIRouter(prefix="/api/v1")
@@ -16,3 +16,4 @@ router.include_router(daypart.router)
 router.include_router(cohorts.router)
 router.include_router(compare.router)
 router.include_router(recs.router)
+router.include_router(flows.router)

--- a/sidetrack/api/routers/flows.py
+++ b/sidetrack/api/routers/flows.py
@@ -1,0 +1,86 @@
+"""Endpoints for computing listening transitions."""
+from __future__ import annotations
+
+from collections import defaultdict
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sidetrack.common.models import Listen, Track, Artist, LastfmTags
+
+from ..db import get_db
+from ..security import get_current_user
+
+router = APIRouter()
+
+
+def _top_genre(tags: dict | None) -> str | None:
+    if not tags:
+        return None
+    try:
+        return max(tags.items(), key=lambda x: x[1])[0]
+    except ValueError:  # pragma: no cover - empty dict
+        return None
+
+
+@router.get("/flows")
+async def list_flows(
+    level: str = Query("artist", pattern="^(artist|genre)$"),
+    db: AsyncSession = Depends(get_db),
+    user_id: str = Depends(get_current_user),
+):
+    """Return transition probabilities between artists or genres for the current user.
+
+    The result is a list of directed edges with conditional probabilities
+    :math:`p(\text{next}|\text{current})` and a baseline probability computed
+    across all users. The ``lift`` field highlights unusually strong edges.
+    """
+
+    stmt = (
+        select(Listen.user_id, Listen.played_at, Artist.name, LastfmTags.tags)
+        .join(Track, Track.track_id == Listen.track_id)
+        .join(Artist, Artist.artist_id == Track.artist_id, isouter=True)
+        .join(LastfmTags, LastfmTags.track_id == Track.track_id, isouter=True)
+        .order_by(Listen.user_id, Listen.played_at)
+    )
+    rows = (await db.execute(stmt)).all()
+
+    user_edges: defaultdict[tuple[str, str], int] = defaultdict(int)
+    user_counts: defaultdict[str, int] = defaultdict(int)
+    global_edges: defaultdict[tuple[str, str], int] = defaultdict(int)
+    global_counts: defaultdict[str, int] = defaultdict(int)
+    last_by_user: dict[str, str] = {}
+
+    for uid, _ts, artist, tags in rows:
+        label = artist if level == "artist" else _top_genre(tags)
+        if not label:
+            continue
+        prev = last_by_user.get(uid)
+        if prev:
+            global_edges[(prev, label)] += 1
+            global_counts[prev] += 1
+            if uid == user_id:
+                user_edges[(prev, label)] += 1
+                user_counts[prev] += 1
+        last_by_user[uid] = label
+
+    edges = []
+    for (src, dst), cnt in user_edges.items():
+        prob = cnt / user_counts[src] if user_counts[src] else 0.0
+        baseline = (
+            global_edges[(src, dst)] / global_counts[src]
+            if global_counts[src]
+            else 0.0
+        )
+        lift = prob / baseline if baseline > 0 else None
+        edges.append(
+            {
+                "source": src,
+                "target": dst,
+                "prob": prob,
+                "baseline": baseline,
+                "lift": lift,
+            }
+        )
+    return {"edges": edges}


### PR DESCRIPTION
## Summary
- compute artist/genre transition probabilities with global baseline and lift
- expose `/flows` API endpoint
- add FlowChord Plotly sankey component for visualizing strong transitions

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c115b42ea8833399910f11ebf642e5