### PR TITLE
feat(ui): unify recommendations UX

### DIFF
--- a/services/ui/components/mixtape/MixtapeButton.tsx
+++ b/services/ui/components/mixtape/MixtapeButton.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '../ui/button';
+import MixtapeModal from './MixtapeModal';
+import type { Rec } from '../recs/RecCard';
+
+interface Props {
+  tracks: Rec[];
+}
+
+export default function MixtapeButton({ tracks }: Props) {
+  const [open, setOpen] = useState(false);
+  if (!tracks.length) return null;
+  return (
+    <>
+      <Button variant="ghost" size="sm" onClick={() => setOpen(true)}>
+        Build Mixtape
+      </Button>
+      {open && (
+        <MixtapeModal open={open} onOpenChange={setOpen} tracks={tracks} />
+      )}
+    </>
+  );
+}

--- a/services/ui/components/mixtape/MixtapeModal.tsx
+++ b/services/ui/components/mixtape/MixtapeModal.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../ui/dialog';
+import { Button } from '../ui/button';
+import type { Rec } from '../recs/RecCard';
+import { createPlaylist } from '../../lib/spotifyClient';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  tracks: Rec[];
+}
+
+export default function MixtapeModal({ open, onOpenChange, tracks }: Props) {
+  const [length, setLength] = useState(Math.min(10, tracks.length));
+  const selected = useMemo(() => tracks.slice(0, length), [tracks, length]);
+  const uris = useMemo(
+    () => selected.map((t) => t.spotify_id || '').filter(Boolean),
+    [selected],
+  );
+
+  const exportM3U = () => {
+    const lines = ['#EXTM3U', ...selected.map((t) => t.title)];
+    const blob = new Blob([lines.join('\n')], { type: 'audio/x-mpegurl' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'mixtape.m3u';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const createSpotify = async () => {
+    if (!uris.length) return;
+    await createPlaylist('Mixtape', uris);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Build Mixtape</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <label className="flex items-center gap-2 text-sm">
+            Length
+            <input
+              type="range"
+              min={1}
+              max={tracks.length}
+              value={length}
+              onChange={(e) => setLength(parseInt(e.target.value, 10))}
+            />
+            <span>{length}</span>
+          </label>
+          <div className="flex flex-col gap-2 sm:flex-row">
+            <Button onClick={exportM3U} className="flex-1">
+              Export M3U
+            </Button>
+            <Button
+              variant="outline"
+              onClick={createSpotify}
+              className="flex-1"
+            >
+              Create Spotify playlist
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/services/ui/components/recs/FiltersBar.tsx
+++ b/services/ui/components/recs/FiltersBar.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+interface Filters {
+  newOnly: boolean;
+  freshness: number;
+  diversity: number;
+  energy: number;
+}
+
+interface Props {
+  filters: Filters;
+  onChange: (f: Filters) => void;
+}
+
+export default function FiltersBar({ filters, onChange }: Props) {
+  return (
+    <div className="flex flex-wrap items-center gap-4 text-sm">
+      <label className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          checked={filters.newOnly}
+          onChange={() => onChange({ ...filters, newOnly: !filters.newOnly })}
+        />
+        New artists only
+      </label>
+      <label className="flex items-center gap-2">
+        Min freshness
+        <input
+          type="range"
+          min={0}
+          max={1}
+          step={0.1}
+          value={filters.freshness}
+          onChange={(e) =>
+            onChange({ ...filters, freshness: parseFloat(e.target.value) })
+          }
+        />
+      </label>
+      <label className="flex items-center gap-2">
+        Diversity
+        <input
+          type="range"
+          min={0}
+          max={1}
+          step={0.1}
+          value={filters.diversity}
+          onChange={(e) =>
+            onChange({ ...filters, diversity: parseFloat(e.target.value) })
+          }
+        />
+      </label>
+      <label className="flex items-center gap-2">
+        Energy
+        <input
+          type="range"
+          min={0}
+          max={1}
+          step={0.1}
+          value={filters.energy}
+          onChange={(e) =>
+            onChange({ ...filters, energy: parseFloat(e.target.value) })
+          }
+        />
+      </label>
+    </div>
+  );
+}

--- a/services/ui/components/recs/RecActions.tsx
+++ b/services/ui/components/recs/RecActions.tsx
@@ -26,6 +26,7 @@ export default function RecActions({ onLike, onSkip, onHideArtist }: Props) {
         variant="outline"
         onClick={async () => {
           await onSkip();
+          show({ title: 'Skipped', kind: 'info' });
         }}
       >
         Skip

--- a/services/ui/components/recs/RecCard.tsx
+++ b/services/ui/components/recs/RecCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import BecauseChips from './BecauseChips';
 import RecActions from './RecActions';
 import type { Reason } from '../../lib/sources';
@@ -23,6 +23,7 @@ interface Props {
 
 export default function RecCard({ rec, onLike, onSkip, onHideArtist }: Props) {
   const [img, setImg] = useState<string | null>(null);
+  const startX = useRef<number | null>(null);
 
   useEffect(() => {
     if (rec.spotify_id) {
@@ -34,7 +35,19 @@ export default function RecCard({ rec, onLike, onSkip, onHideArtist }: Props) {
   }, [rec.spotify_id]);
 
   return (
-    <div className="space-y-4 rounded-lg border p-4">
+    <div
+      className="space-y-4 rounded-lg border p-4"
+      onPointerDown={(e) => {
+        startX.current = e.clientX;
+      }}
+      onPointerUp={(e) => {
+        if (startX.current === null) return;
+        const diff = e.clientX - startX.current;
+        if (diff > 40) onLike();
+        if (diff < -40) onSkip();
+        startX.current = null;
+      }}
+    >
       {img && (
         <Image
           src={img}


### PR DESCRIPTION
## Summary
- add swipable RecCard and toast-enabled actions
- add FiltersBar with freshness, diversity, and energy options
- allow building mixtapes via modal with M3U export or Spotify playlist

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c11b7538e48333aa8f351b176b75a9