### PR TITLE
refactor settings into modular sections

### DIFF
--- a/services/ui/components/settings/DataControls.tsx
+++ b/services/ui/components/settings/DataControls.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import { Card } from '../ui/card';
+import { Button } from '../ui/button';
+import { Input } from '../ui/input';
+import { useToast } from '../ToastProvider';
+import { apiFetch } from '../../lib/api';
+
+export default function DataControls() {
+  const { show } = useToast();
+  const [artist, setArtist] = useState('');
+
+  async function resetFeedback() {
+    try {
+      const res = await apiFetch('/api/feedback/reset', { method: 'POST' });
+      if (!res.ok) throw new Error('bad');
+      show({ title: 'Feedback reset', kind: 'success' });
+    } catch {
+      show({ title: 'Failed to reset feedback', kind: 'error' });
+    }
+  }
+
+  async function forgetArtist() {
+    try {
+      const res = await apiFetch(`/api/feedback/forget?artist=${encodeURIComponent(artist)}`, {
+        method: 'POST',
+      });
+      if (!res.ok) throw new Error('bad');
+      show({ title: `Forgot ${artist}`, kind: 'success' });
+      setArtist('');
+    } catch {
+      show({ title: 'Failed to forget artist', kind: 'error' });
+    }
+  }
+
+  async function exportDefaults() {
+    try {
+      const res = await apiFetch('/api/settings/export');
+      if (!res.ok) throw new Error('bad');
+      show({ title: 'Exported defaults', kind: 'success' });
+    } catch {
+      show({ title: 'Failed to export defaults', kind: 'error' });
+    }
+  }
+
+  return (
+    <Card className="p-4 space-y-4">
+      <Button type="button" onClick={resetFeedback} aria-label="reset feedback">
+        Reset feedback
+      </Button>
+      <div className="flex gap-2 items-center">
+        <Input
+          placeholder="Artist name"
+          value={artist}
+          onChange={(e) => setArtist(e.target.value)}
+          aria-label="artist name"
+        />
+        <Button type="button" onClick={forgetArtist} aria-label="forget artist">
+          Forget
+        </Button>
+      </div>
+      <Button type="button" onClick={exportDefaults} aria-label="export defaults">
+        Export defaults
+      </Button>
+    </Card>
+  );
+}
+

--- a/services/ui/components/settings/RankerControls.tsx
+++ b/services/ui/components/settings/RankerControls.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+import { Card } from '../ui/card';
+import { Button } from '../ui/button';
+import { Input } from '../ui/input';
+import { useToast } from '../ToastProvider';
+import { apiFetch } from '../../lib/api';
+
+export default function RankerControls() {
+  const { show } = useToast();
+  const [discovery, setDiscovery] = useState(0.5);
+  const [energy, setEnergy] = useState(0.5);
+  const [tempo, setTempo] = useState(120);
+  const [avoid, setAvoid] = useState(false);
+
+  async function handleSave() {
+    try {
+      const res = await apiFetch('/api/ranker/settings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ discovery, energy, tempo, avoid }),
+      });
+      if (!res.ok) throw new Error('bad');
+      show({ title: 'Ranker settings saved', kind: 'success' });
+    } catch {
+      show({ title: 'Failed to save ranker settings', kind: 'error' });
+    }
+  }
+
+  return (
+    <Card className="p-4 space-y-4">
+      <div>
+        <label className="flex flex-col gap-1">
+          <span>Discovery vs Familiarity</span>
+          <input
+            type="range"
+            min={0}
+            max={1}
+            step={0.1}
+            value={discovery}
+            onChange={(e) => setDiscovery(parseFloat(e.target.value))}
+          />
+        </label>
+      </div>
+      <div className="flex gap-4">
+        <label className="flex flex-col gap-1">
+          <span>Target energy</span>
+          <Input
+            type="number"
+            value={energy}
+            onChange={(e) => setEnergy(parseFloat(e.target.value))}
+            aria-label="target energy"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span>Target tempo</span>
+          <Input
+            type="number"
+            value={tempo}
+            onChange={(e) => setTempo(parseFloat(e.target.value))}
+            aria-label="target tempo"
+          />
+        </label>
+      </div>
+      <label className="flex items-center gap-2">
+        <Input
+          type="checkbox"
+          className="h-4 w-4"
+          checked={avoid}
+          onChange={(e) => setAvoid(e.target.checked)}
+          aria-label="avoid repeats"
+        />
+        <span>Avoid repeats</span>
+      </label>
+      <Button type="button" onClick={handleSave} aria-label="save ranker">
+        Save
+      </Button>
+    </Card>
+  );
+}
+

--- a/services/ui/components/settings/SourceCard.tsx
+++ b/services/ui/components/settings/SourceCard.tsx
@@ -1,0 +1,115 @@
+import { useState } from 'react';
+import { Card } from '../ui/card';
+import { Button } from '../ui/button';
+import { useToast } from '../ToastProvider';
+import { apiFetch } from '../../lib/api';
+
+export type SourceStatus = 'connected' | 'disconnected';
+
+interface SourceCardProps {
+  id: string;
+  name: string;
+  scopes: string[];
+  status: SourceStatus;
+  connectUrl: string;
+  disconnectUrl: string;
+  testUrl: string;
+  onStatusChange?: (s: SourceStatus) => void;
+}
+
+export default function SourceCard({
+  id,
+  name,
+  scopes,
+  status: initialStatus,
+  connectUrl,
+  disconnectUrl,
+  testUrl,
+  onStatusChange,
+}: SourceCardProps) {
+  const [status, setStatus] = useState<SourceStatus>(initialStatus);
+  const { show } = useToast();
+
+  const setAndNotify = (s: SourceStatus) => {
+    setStatus(s);
+    onStatusChange?.(s);
+  };
+
+  async function handleConnect() {
+    try {
+      const callback = encodeURIComponent(`${window.location.origin}/${id}/callback`);
+      const res = await apiFetch(`${connectUrl}?callback=${callback}`);
+      const data = await res.json().catch(() => ({}));
+      if (res.ok && data.url) {
+        window.location.href = data.url as string;
+      } else {
+        show({ title: `Failed to connect ${name}`, kind: 'error' });
+      }
+    } catch {
+      show({ title: `Failed to connect ${name}`, kind: 'error' });
+    }
+  }
+
+  async function handleDisconnect() {
+    try {
+      const res = await apiFetch(disconnectUrl, { method: 'DELETE' });
+      if (!res.ok) throw new Error('bad');
+      setAndNotify('disconnected');
+      show({ title: `Disconnected ${name}`, kind: 'success' });
+    } catch {
+      show({ title: `Failed to disconnect ${name}`, kind: 'error' });
+    }
+  }
+
+  async function handleTest() {
+    try {
+      const res = await apiFetch(testUrl);
+      if (!res.ok) throw new Error('bad');
+      show({ title: `${name} OK`, kind: 'success' });
+    } catch {
+      show({ title: `${name} test failed`, kind: 'error' });
+    }
+  }
+
+  return (
+    <Card id={id} className="p-4 space-y-2">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold">{name}</h3>
+        <span
+          className={
+            status === 'connected'
+              ? 'text-emerald-500 text-sm'
+              : 'text-rose-500 text-sm'
+          }
+        >
+          {status}
+        </span>
+      </div>
+      <ul className="list-disc pl-5 text-sm">
+        {scopes.map((s) => (
+          <li key={s}>{s}</li>
+        ))}
+      </ul>
+      <div className="flex gap-2 pt-2">
+        {status === 'connected' ? (
+          <Button type="button" onClick={handleDisconnect} aria-label={`${name} disconnect`}>
+            Disconnect
+          </Button>
+        ) : (
+          <Button type="button" onClick={handleConnect} aria-label={`${name} connect`}>
+            Connect
+          </Button>
+        )}
+        <Button
+          type="button"
+          variant="secondary"
+          onClick={handleTest}
+          aria-label={`${name} test`}
+        >
+          Test
+        </Button>
+      </div>
+    </Card>
+  );
+}
+


### PR DESCRIPTION
## Summary
- split settings page into Source, Ranker, and Data sections
- add SourceCard with connect, disconnect, and test actions
- add RankerControls and DataControls components

## Testing
- `npm test` *(fails: Invalid package.json)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c121981bf483338991a7c4236a552f