### PR TITLE
feat: improve mobile experience

### DIFF
--- a/services/ui/components/ChartContainer.tsx
+++ b/services/ui/components/ChartContainer.tsx
@@ -1,5 +1,6 @@
-import { ReactNode } from 'react';
+import { ReactNode, useState } from 'react';
 import { Card } from './ui/card';
+import { Dialog, DialogContent } from './ui/dialog';
 
 type Props = {
   title: string;
@@ -9,6 +10,8 @@ type Props = {
 };
 
 export default function ChartContainer({ title, subtitle, actions, children }: Props) {
+  const [open, setOpen] = useState(false);
+
   return (
     <Card asChild variant="glass" className="p-4">
       <section>
@@ -19,7 +22,22 @@ export default function ChartContainer({ title, subtitle, actions, children }: P
           </div>
           {actions && <div className="flex items-center gap-2">{actions}</div>}
         </div>
-        <div className="min-h-[clamp(120px,25vh,160px)]">{children}</div>
+        <div className="min-h-[clamp(120px,25vh,160px)]">
+          <div className="hidden h-full w-full md:block">{children}</div>
+          <div className="md:hidden">
+            <button
+              onClick={() => setOpen(true)}
+              className="flex h-full w-full items-center justify-center rounded-md border text-sm text-muted-foreground"
+            >
+              View full chart
+            </button>
+            <Dialog open={open} onOpenChange={setOpen}>
+              <DialogContent className="sm:max-w-md p-4">
+                <div className="h-[300px] w-full">{children}</div>
+              </DialogContent>
+            </Dialog>
+          </div>
+        </div>
       </section>
     </Card>
   );

--- a/services/ui/components/dashboard/ChartCard.tsx
+++ b/services/ui/components/dashboard/ChartCard.tsx
@@ -1,8 +1,9 @@
 'use client';
-import { ReactNode } from 'react';
+import { ReactNode, useState } from 'react';
 import Plot from 'react-plotly.js';
 import type { Data, Layout, Config } from 'plotly.js';
 import { Card } from '../ui/card';
+import { Dialog, DialogContent } from '../ui/dialog';
 
 export type PlotProps = {
   data: Data[];
@@ -20,6 +21,31 @@ type Props = {
 };
 
 export default function ChartCard({ title, subtitle, actions, plot, children }: Props) {
+  const [open, setOpen] = useState(false);
+
+  const renderPlot = () => (
+    <div tabIndex={0} className="h-full w-full">
+      <Plot
+        data={plot?.data ?? []}
+        layout={{
+          autosize: true,
+          paper_bgcolor: 'transparent',
+          plot_bgcolor: 'transparent',
+          margin: { t: 20, l: 30, r: 10, b: 30 },
+          ...plot?.layout,
+        }}
+        config={{
+          displayModeBar: false,
+          responsive: true,
+          ...plot?.config,
+        }}
+        style={{ width: '100%', height: '100%' }}
+        useResizeHandler
+        aria-label={plot?.ariaLabel ?? ''}
+      />
+    </div>
+  );
+
   return (
     <Card asChild variant="glass" className="p-4">
       <section>
@@ -32,26 +58,22 @@ export default function ChartCard({ title, subtitle, actions, plot, children }: 
         </div>
         <div className="min-h-[clamp(160px,40vh,320px)]">
           {plot ? (
-            <div tabIndex={0} className="h-full w-full">
-              <Plot
-                data={plot.data}
-                layout={{
-                  autosize: true,
-                  paper_bgcolor: 'transparent',
-                  plot_bgcolor: 'transparent',
-                  margin: { t: 20, l: 30, r: 10, b: 30 },
-                  ...plot.layout,
-                }}
-                config={{
-                  displayModeBar: false,
-                  responsive: true,
-                  ...plot.config,
-                }}
-                style={{ width: '100%', height: '100%' }}
-                useResizeHandler
-                aria-label={plot.ariaLabel}
-              />
-            </div>
+            <>
+              <div className="hidden h-full w-full md:block">{renderPlot()}</div>
+              <div className="md:hidden">
+                <button
+                  onClick={() => setOpen(true)}
+                  className="flex h-full w-full items-center justify-center rounded-md border text-sm text-muted-foreground"
+                >
+                  View full chart
+                </button>
+                <Dialog open={open} onOpenChange={setOpen}>
+                  <DialogContent className="sm:max-w-md p-4">
+                    <div className="h-[300px] w-full">{renderPlot()}</div>
+                  </DialogContent>
+                </Dialog>
+              </div>
+            </>
           ) : (
             children
           )}

--- a/services/ui/components/layout/AppShell.tsx
+++ b/services/ui/components/layout/AppShell.tsx
@@ -11,6 +11,8 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
     const stored = localStorage.getItem('sidebar-collapsed');
     if (stored !== null) {
       setCollapsed(stored === 'true');
+    } else if (window.innerWidth < 768) {
+      setCollapsed(true);
     }
   }, []);
 
@@ -19,7 +21,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
   }, [collapsed]);
 
   return (
-    <div className="min-h-dvh overflow-x-hidden md:flex">
+    <div className="min-h-dvh overflow-x-hidden flex">
       <Sidebar collapsed={collapsed} setCollapsed={setCollapsed} />
       <div className="flex min-h-dvh flex-1 flex-col">
         <Header />

--- a/services/ui/components/layout/Header.tsx
+++ b/services/ui/components/layout/Header.tsx
@@ -30,7 +30,7 @@ export default function Header() {
       <button
         onClick={openSearch}
         aria-label="Open search (⌘K)"
-        className="flex flex-1 items-center gap-2 rounded-md bg-muted px-3 py-2 text-sm text-muted-foreground hover:text-foreground focus:outline-none focus:ring-2 focus:ring-emerald-500 md:max-w-sm"
+        className="flex h-9 w-9 items-center justify-center gap-0 rounded-md bg-muted text-sm text-muted-foreground hover:text-foreground focus:outline-none focus:ring-2 focus:ring-emerald-500 sm:h-auto sm:w-auto sm:flex-1 sm:gap-2 sm:px-3 sm:py-2 sm:justify-start md:max-w-sm"
       >
         <Search size={16} />
         <span className="hidden sm:inline">Search</span>

--- a/services/ui/components/layout/Sidebar.tsx
+++ b/services/ui/components/layout/Sidebar.tsx
@@ -26,15 +26,15 @@ export default function Sidebar({
   return (
     <aside
       className={clsx(
-        'hidden border-r bg-background md:flex md:flex-col',
-        collapsed ? 'w-16' : 'w-56',
+        'flex flex-col shrink-0 border-r bg-background',
+        collapsed ? 'w-16' : 'w-16 md:w-56',
         'motion-safe:transition-[width]'
       )}
     >
       <button
         onClick={() => setCollapsed(!collapsed)}
         aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-        className="m-2 inline-flex h-8 w-8 items-center justify-center rounded-md hover:bg-white/5 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+        className="m-2 hidden h-8 w-8 items-center justify-center rounded-md hover:bg-white/5 focus:outline-none focus:ring-2 focus:ring-emerald-500 md:inline-flex"
       >
         <Menu size={16} />
       </button>
@@ -52,7 +52,7 @@ export default function Sidebar({
               )}
             >
               <item.icon size={18} />
-              {!collapsed && <span>{item.label}</span>}
+              {!collapsed && <span className="hidden md:inline">{item.label}</span>}
             </Link>
           );
         })}

--- a/services/ui/components/recs/RecActions.tsx
+++ b/services/ui/components/recs/RecActions.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from '../ui/button';
 import { useToast } from '../ToastProvider';
+import { Dialog, DialogContent, DialogTrigger } from '../ui/dialog';
 
 interface Props {
   onLike: () => void | Promise<void>;
@@ -12,8 +13,8 @@ interface Props {
 export default function RecActions({ onLike, onSkip, onHideArtist }: Props) {
   const { show } = useToast();
 
-  return (
-    <div className="flex gap-2">
+  const ActionButtons = () => (
+    <>
       <Button
         onClick={async () => {
           await onLike();
@@ -40,7 +41,25 @@ export default function RecActions({ onLike, onSkip, onHideArtist }: Props) {
       >
         Hide artist
       </Button>
-    </div>
+    </>
+  );
+
+  return (
+    <>
+      <div className="hidden gap-2 md:flex">
+        <ActionButtons />
+      </div>
+      <Dialog>
+        <DialogTrigger asChild>
+          <Button className="w-full md:hidden">Actions</Button>
+        </DialogTrigger>
+        <DialogContent className="md:hidden bottom-0 left-0 right-0 top-auto translate-x-0 translate-y-0 max-w-full rounded-t-lg p-4">
+          <div className="grid gap-2">
+            <ActionButtons />
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }
 

--- a/services/ui/components/recs/RecCard.tsx
+++ b/services/ui/components/recs/RecCard.tsx
@@ -36,7 +36,7 @@ export default function RecCard({ rec, onLike, onSkip, onHideArtist }: Props) {
 
   return (
     <div
-      className="space-y-4 rounded-lg border p-4"
+      className="space-y-4 rounded-lg border p-4 touch-pan-y"
       onPointerDown={(e) => {
         startX.current = e.clientX;
       }}


### PR DESCRIPTION
## Summary
- show icon-only sidebar on small screens
- collapse search to an icon in header
- wrap card actions and charts in mobile-friendly UI

## Testing
- `pytest -q`
- `npm ci` *(fails: JSON.parse error in package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1be2509508333beaaf79f4644f0db