### PR TITLE
feat: add design tokens and typography

### DIFF
--- a/docs/ui.md
+++ b/docs/ui.md
@@ -1,0 +1,47 @@
+# UI Design Tokens
+
+The UI layer exposes a small set of design tokens as CSS custom properties.
+Tailwind reads these variables so components can stay in sync with the design
+system without duplicating values.
+
+## Spacing
+
+Tokens map `space-1` through `space-6` to a stepped scale:
+
+| Token       | Value     |
+| ----------- | --------- |
+| `--space-1` | `0.25rem` |
+| `--space-2` | `0.5rem`  |
+| `--space-3` | `0.75rem` |
+| `--space-4` | `1rem`    |
+| `--space-5` | `1.25rem` |
+| `--space-6` | `1.5rem`  |
+
+Use the corresponding Tailwind utilities (`p-3`, `gap-4`, etc.) for layout.
+
+## Typography
+
+Font sizes are driven by variables consumed by Tailwind's `text-*` classes:
+
+| Class       | Variable      | Size       |
+| ----------- | ------------- | ---------- |
+| `text-xs`   | `--text-xs`   | `0.75rem`  |
+| `text-sm`   | `--text-sm`   | `0.875rem` |
+| `text-base` | `--text-base` | `1rem`     |
+| `text-lg`   | `--text-lg`   | `1.125rem` |
+| `text-xl`   | `--text-xl`   | `1.25rem`  |
+| `text-2xl`  | `--text-2xl`  | `1.5rem`   |
+
+The `Typography` component wraps these classes to provide consistent heading and
+body styles.
+
+## Shadows
+
+The soft elevation used across surfaces is defined as:
+
+| Token           | Class         | Value                             |
+| --------------- | ------------- | --------------------------------- |
+| `--shadow-soft` | `shadow-soft` | `0 10px 30px rgba(0, 0, 0, 0.12)` |
+
+Components should reference these tokens rather than hard‑coding values to keep
+the interface visually consistent.

--- a/services/ui/app/globals.css
+++ b/services/ui/app/globals.css
@@ -57,6 +57,30 @@
   --space-4: 1rem;
   --space-5: 1.25rem;
   --space-6: 1.5rem;
+
+  /* radius */
+  --radius-sm: 0.5rem;
+  --radius-md: 0.625rem;
+  --radius-lg: 0.75rem;
+  --radius-full: 9999px;
+
+  /* shadows */
+  --shadow-soft: 0 10px 30px rgba(0, 0, 0, 0.12);
+
+  /* typography */
+  --text-xs: 0.75rem;
+  --text-sm: 0.875rem;
+  --text-base: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.25rem;
+  --text-2xl: 1.5rem;
+
+  /* brand palette */
+  --brand-green: 158 84% 58%;
+  --brand-blue: 196 100% 62%;
+  --brand-orange: 32 100% 65%;
+  --brand-red: 0 100% 73%;
+  --brand-purple: 255 100% 77%;
 }
 
 .dark {
@@ -92,4 +116,3 @@ body {
   backdrop-filter: saturate(140%) blur(8px);
   border: 1px solid hsl(var(--border));
 }
-

--- a/services/ui/components/ui/Typography.tsx
+++ b/services/ui/components/ui/Typography.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '../../lib/utils';
+
+const typographyVariants = cva('', {
+  variants: {
+    variant: {
+      h1: 'scroll-m-20 text-2xl font-bold tracking-tight',
+      h2: 'scroll-m-20 text-xl font-semibold tracking-tight',
+      h3: 'scroll-m-20 text-lg font-semibold tracking-tight',
+      p: 'text-base leading-7',
+      muted: 'text-sm text-muted-foreground',
+    },
+  },
+  defaultVariants: {
+    variant: 'p',
+  },
+});
+
+export interface TypographyProps
+  extends React.HTMLAttributes<HTMLElement>,
+    VariantProps<typeof typographyVariants> {
+  as?: React.ElementType;
+}
+
+const Typography = React.forwardRef<HTMLElement, TypographyProps>(
+  ({ className, variant, as: Comp = 'p', ...props }, ref) => (
+    <Comp ref={ref} className={cn(typographyVariants({ variant }), className)} {...props} />
+  ),
+);
+Typography.displayName = 'Typography';
+
+export { Typography, typographyVariants };

--- a/services/ui/tailwind.config.ts
+++ b/services/ui/tailwind.config.ts
@@ -65,10 +65,28 @@ export const tokens = {
     ring: 'hsl(var(--light-ring))',
   },
   radii: {
-    lg: '12px',
-    md: '10px',
-    sm: '8px',
-    full: '9999px',
+    lg: 'var(--radius-lg)',
+    md: 'var(--radius-md)',
+    sm: 'var(--radius-sm)',
+    full: 'var(--radius-full)',
+  },
+  fontSize: {
+    xs: ['var(--text-xs)', { lineHeight: '1rem' }],
+    sm: ['var(--text-sm)', { lineHeight: '1.25rem' }],
+    base: ['var(--text-base)', { lineHeight: '1.5rem' }],
+    lg: ['var(--text-lg)', { lineHeight: '1.75rem' }],
+    xl: ['var(--text-xl)', { lineHeight: '1.75rem' }],
+    '2xl': ['var(--text-2xl)', { lineHeight: '2rem' }],
+  },
+  shadows: {
+    soft: 'var(--shadow-soft)',
+  },
+  brand: {
+    green: 'hsl(var(--brand-green))',
+    blue: 'hsl(var(--brand-blue))',
+    orange: 'hsl(var(--brand-orange))',
+    red: 'hsl(var(--brand-red))',
+    purple: 'hsl(var(--brand-purple))',
   },
 };
 
@@ -78,11 +96,10 @@ const config: Config = {
   theme: {
     extend: {
       spacing: tokens.spacing,
-      colors: tokens.colors,
+      colors: { ...tokens.colors, brand: tokens.brand },
       borderRadius: tokens.radii,
-      boxShadow: {
-        soft: '0 10px 30px rgba(0,0,0,0.12)',
-      },
+      boxShadow: tokens.shadows,
+      fontSize: tokens.fontSize,
       fontFamily: {
         sans: ['var(--font-sans)', 'ui-sans-serif', 'system-ui', 'sans-serif'],
       },


### PR DESCRIPTION
## Summary
- add CSS custom properties for spacing, radii, shadows, fonts and brand colors
- expose tokens to Tailwind and add reusable Typography component
- document available UI tokens and usage

## Testing
- `pre-commit run --files services/ui/app/globals.css services/ui/tailwind.config.ts services/ui/components/ui/Typography.tsx docs/ui.md` *(fails: Failed to read JSON file at services/ui/package.json)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c1c058fb188333a53fa99d0ddb7b53