### PR TITLE
Implement excerpt and Demucs stem options with provenance

### DIFF
--- a/migrations/versions/5d6e1a2b3c4d_add_feature_provenance.py
+++ b/migrations/versions/5d6e1a2b3c4d_add_feature_provenance.py
@@ -1,0 +1,31 @@
+"""add provenance columns to features
+
+Revision ID: 5d6e1a2b3c4d
+Revises: 9c6a1e7c1d9b
+Create Date: 2025-06-02 00:00:00.000000
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "5d6e1a2b3c4d"
+down_revision: str | None = "9c6a1e7c1d9b"
+branch_labels: str | None = None
+depends_on: str | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "features",
+        sa.Column("source", sa.String(length=16), nullable=False, server_default="full"),
+    )
+    op.add_column("features", sa.Column("seconds", sa.Float(), nullable=True))
+    op.add_column("features", sa.Column("model", sa.String(length=64), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("features", "model")
+    op.drop_column("features", "seconds")
+    op.drop_column("features", "source")

--- a/sidetrack/common/models.py
+++ b/sidetrack/common/models.py
@@ -113,6 +113,9 @@ class Feature(Base):
     stereo: Mapped[dict | None] = mapped_column(JSON)
     percussive_harmonic_ratio: Mapped[float | None] = mapped_column(Float)
     pumpiness: Mapped[float | None] = mapped_column(Float)
+    source: Mapped[str] = mapped_column(String(16), default="full")
+    seconds: Mapped[float | None] = mapped_column(Float)
+    model: Mapped[str | None] = mapped_column(String(64))
 
 
 class MoodScore(Base):

--- a/sidetrack/extraction/stems.py
+++ b/sidetrack/extraction/stems.py
@@ -1,18 +1,88 @@
 from __future__ import annotations
 
-"""Stem separation utilities (placeholder)."""
+"""Stem separation utilities using Demucs when available."""
+
+from pathlib import Path
+import os
+import hashlib
 
 import numpy as np
 
+try:  # optional imports
+    import torch
+    from demucs.pretrained import get_model  # type: ignore
+    from demucs.apply import apply_model  # type: ignore
+except Exception:  # pragma: no cover - demucs is optional
+    torch = None  # type: ignore
+    get_model = None  # type: ignore
+    apply_model = None  # type: ignore
 
-def separate(y: np.ndarray, sr: int, use_demucs: bool) -> dict[str, np.ndarray]:
-    """Return separated stems if requested.
 
-    For now this is a trivial passthrough used for testing; when ``use_demucs``
-    is ``False`` the mixture is returned unchanged, and when ``True`` the
-    behaviour is identical but signals that a stem extraction step occurred.
+DEFAULT_MODEL = "htdemucs"
+
+
+def _content_hash(path: str) -> str:
+    st = os.stat(path)
+    key = f"{path}:{int(st.st_mtime)}".encode()
+    return hashlib.sha256(key).hexdigest()
+
+
+def separate(
+    y: np.ndarray,
+    sr: int,
+    use_demucs: bool,
+    track_path: str | None = None,
+    cache_dir: Path | None = None,
+) -> tuple[dict[str, np.ndarray], str | None]:
+    """Separate ``y`` into stems.
+
+    Parameters
+    ----------
+    y, sr:
+        Audio signal and sampling rate.
+    use_demucs:
+        If ``True`` and a GPU with Demucs is available, separation will be
+        performed.  Otherwise the mixture is returned unchanged.
+    track_path:
+        Optional original file path used to compute a cache key.
+    cache_dir:
+        Directory where separated stems are cached.
+
+    Returns
+    -------
+    stems: dict
+        Mapping stem name to waveform (channels are preserved).
+    model: str or None
+        Name of the Demucs model used, or ``None`` if separation was skipped.
     """
 
-    if use_demucs:
-        return {"vocals": y, "accompaniment": y}
-    return {"mix": y}
+    if not use_demucs or torch is None or not torch.cuda.is_available() or get_model is None:
+        return {"mix": y}, None
+
+    cache_path: Path | None = None
+    if track_path and cache_dir is not None:
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        hash_key = _content_hash(track_path)
+        cache_path = cache_dir / f"{hash_key}.npz"
+        if cache_path.exists():
+            data = np.load(cache_path)
+            stems = {name: data[name] for name in data.files}
+            return stems, DEFAULT_MODEL
+
+    try:
+        model = get_model(DEFAULT_MODEL)
+        model.to("cuda")
+        wav = torch.tensor(y, dtype=torch.float32)
+        if wav.ndim == 1:
+            wav = wav.unsqueeze(0)
+        wav = wav.unsqueeze(0).to("cuda")
+        with torch.no_grad():
+            out = apply_model(model, wav, device="cuda", progress=False)
+        out_np = out.squeeze(0).cpu().numpy()
+        stems = {name: out_np[i] for i, name in enumerate(model.sources)}
+    except Exception:  # pragma: no cover - demucs failures fall back
+        return {"mix": y}, None
+
+    if cache_path is not None:
+        np.savez(cache_path, **stems)
+    return stems, DEFAULT_MODEL

--- a/sidetrack/extractor/run.py
+++ b/sidetrack/extractor/run.py
@@ -175,6 +175,12 @@ def compute_embeddings(wav_path: str, models: list[str]) -> dict[str, list[float
 
 
 def estimate_features(wav_path: str) -> dict:
+    import os
+    import tempfile
+
+    # Ensure numba has a writable cache directory to avoid RuntimeError during
+    # librosa's lazy imports.
+    os.environ.setdefault("NUMBA_CACHE_DIR", os.path.join(tempfile.gettempdir(), "numba-cache"))
     import librosa as lb
 
     y_st, sr = safe_load_audio(wav_path, sr=44100, mono=False)

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -31,6 +31,9 @@ class FeatureFactory(factory.Factory):
     bpm = 120.0
     pumpiness = 0.5
     percussive_harmonic_ratio = 0.3
+    source = "full"
+    seconds = 0.0
+    model = None
 
     class Params:
         zero = factory.Trait(bpm=0.0, pumpiness=0.0, percussive_harmonic_ratio=0.0)

--- a/tests/test_excerpt_audio.py
+++ b/tests/test_excerpt_audio.py
@@ -1,0 +1,16 @@
+import numpy as np
+import pytest
+
+from sidetrack.extraction import dsp
+
+pytestmark = pytest.mark.unit
+
+
+def test_excerpt_audio_centers_on_loudest_region():
+    sr = 44100
+    y = np.zeros(sr * 5, dtype=np.float32)
+    y[2 * sr : 3 * sr] = 1.0  # loud section in the middle
+    out = dsp.excerpt_audio(y, sr, 1.0)
+    assert out.shape[-1] == sr
+    # Loud section should dominate the excerpt
+    assert out.mean() > 0.5

--- a/tests/test_extraction_pipeline.py
+++ b/tests/test_extraction_pipeline.py
@@ -30,6 +30,9 @@ def test_pipeline_extracts_and_upserts(session, redis_conn, tmp_path):
 
     feat = session.execute(select(Feature).where(Feature.track_id == tid)).scalar_one()
     assert feat.dataset_version == cfg.dataset_version
+    assert feat.source == "full"
+    assert feat.seconds == pytest.approx(1.0)
+    assert feat.model is None
     emb = session.execute(select(Embedding).where(Embedding.track_id == tid)).scalar_one()
     assert emb.model == cfg.embedding_model
 

--- a/tests/test_stems.py
+++ b/tests/test_stems.py
@@ -1,0 +1,13 @@
+import numpy as np
+import pytest
+
+from sidetrack.extraction import stems
+
+pytestmark = pytest.mark.unit
+
+
+def test_stems_fallback_without_gpu(tmp_path):
+    y = np.zeros(44100, dtype=np.float32)
+    stems_out, model = stems.separate(y, 44100, True, cache_dir=tmp_path)
+    assert "mix" in stems_out
+    assert model is None


### PR DESCRIPTION
## Summary
- Center excerpts on the loudest window when EXCERPT_SECONDS is set
- Support Demucs stem separation with GPU fallback and caching
- Track audio provenance (source, seconds, model) in features table and schema

## Testing
- `python -m pip install -r requirements-dev.txt`
- `python -m pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1c633be388333872971381de5a596