### PR TITLE
Document test strategy and add marker-based test matrix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+.PHONY: test test-unit test-contract test-integration test-e2e test-all
+
+# Fast default suite (excludes slow/gpu/e2e)
+test:
+	pytest -q
+
+# Sub-suites
+test-unit:
+	pytest -m unit -q
+
+test-contract:
+	pytest -m contract -q
+
+test-integration:
+	pytest -m integration -q
+
+test-e2e:
+	pytest -m e2e -q
+
+# Run everything including slow/gpu/e2e
+test-all:
+	pytest -q -m ""

--- a/README.md
+++ b/README.md
@@ -262,6 +262,9 @@ http://localhost:3000
 
 ## Testing
 
+See [`tests/README.md`](tests/README.md) for the full pyramid, speed budget and
+fixture layout.
+
 - Synthetic audio fixtures; golden feature vectors
 - Deterministic seeds for embeddings/UMAP
 - Snapshot tests for API responses and charts

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,4 +7,8 @@ markers =
     worker: tests for worker service
     integration: integration tests
     unit: unit tests
-addopts = --cov=services --cov-report=term-missing --cov-report=xml --cov-append
+    contract: contract tests with stubbed external APIs
+    e2e: end-to-end smoke tests
+    slow: tests exceeding the default speed budget
+    gpu: tests requiring GPU hardware
+addopts = -m "not slow and not gpu and not e2e" --cov=services --cov-report=term-missing --cov-report=xml --cov-append

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,60 @@
+# Testing Strategy
+
+## Test Pyramid
+
+```
+       e2e smoke (3–5 flows)
+      -----------------------
+      integration (API+DB+Redis)
+      --------------------------
+      contract (HTTP clients)
+      -----------------------
+      unit (pure funcs, adapters)
+```
+
+- **Unit**: pure functions and adapters. Target 60–70% of the suite. Keep each test under 1s.
+- **Contract**: stubbed HTTP clients to external APIs with snapshot responses. Use when an
+  external contract is important but full integration would be flaky.
+- **Integration**: exercises FastAPI with TimescaleDB and Redis, but no internet access.
+  Keep each test ≤10s and cover only critical paths.
+- **E2E smoke**: docker-compose a minimal stack and walk 3–5 critical flows
+  (`/health`, `/api/v1/ingest/listens`, `/tags/lastfm/sync`, `/analyze/track/{id}`,
+  `/score/track/{id}`, `/api/v1/dashboard/*`). These are slow and run nightly.
+
+## Markers & Speed Budget
+
+- `@pytest.mark.unit` – default; < 1s each
+- `@pytest.mark.contract` – stubbed HTTP clients
+- `@pytest.mark.integration` – API + DB + Redis; ≤10s each
+- `@pytest.mark.e2e` – full stack smoke tests
+- `@pytest.mark.slow` – anything exceeding the budgets
+- `@pytest.mark.gpu` – requires a GPU
+
+`pytest` excludes `slow`, `gpu` and `e2e` by default. Use `-m` to include them when needed.
+
+## Adding Tests
+
+1. Prefer unit tests; add contract/integration/e2e only when necessary.
+2. Snapshot HTTP responses for contract tests to detect upstream changes.
+3. Integration tests must run offline; mock external calls.
+4. E2E smoke tests should spin up the minimal compose stack and cover the flows above.
+
+## Fixtures & Factories
+
+- Shared factories live in [`tests/factories`](factories/README.md).
+- Service‑specific fixtures belong in `services/<service>/tests/conftest.py`.
+- Use the `redis_conn` fixture for Redis and `SessionLocal` for DB access.
+- Mark heavy fixtures with `slow` or `gpu` as appropriate.
+
+## Running Tests
+
+Use the make targets:
+
+```
+make test          # fast suite (no slow/gpu/e2e)
+make test-unit     # just unit tests
+make test-contract # contract tests
+make test-integration
+make test-e2e      # end-to-end smoke
+make test-all      # everything
+```


### PR DESCRIPTION
## Summary
- add comprehensive testing strategy with pyramid, markers and speed budgets
- document fixtures and make targets in tests/README
- update pytest.ini to exclude slow/gpu/e2e by default and add Makefile targets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c1ca25b78c8333927feeccf34eecae