### PR TITLE
Add ListenBrainz adapter tests and contract test marker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
-.PHONY: test.unit test.int test.all test.slow test.e2e
+.PHONY: test.unit test.int test.contract test.all test.slow test.e2e
 
 test.unit:
 	pytest -m "unit and not slow and not gpu"
 
 test.int:
-	pytest -m "integration"
+        pytest -m "integration"
+
+test.contract:
+        pytest -m "contract"
 
 test.all:
 	pytest -m "not gpu and not slow"

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,4 +6,4 @@ markers =
     slow: tests exceeding the default speed budget
     gpu: tests requiring GPU hardware
     e2e: end-to-end tests
-addopts = -q -x --strict-markers --disable-warnings
+addopts = -q -x --strict-markers --disable-warnings -m "not contract"

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -14,3 +14,5 @@ isort
 ruff
 freezegun
 pytest-socket
+respx
+syrupy

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -270,6 +270,8 @@ requests==2.32.3
     #   docker
     #   pooch
     #   sidetrack
+respx==0.22.0
+    # via -r requirements-dev.in
 rich==14.1.0
     # via
     #   rich-toolkit
@@ -314,6 +316,8 @@ starlette==0.37.2
     # via fastapi
 structlog==25.4.0
     # via sidetrack
+syrupy==4.9.1
+    # via -r requirements-dev.in
 tenacity==8.2.3
     # via sidetrack
 testcontainers==4.12.0

--- a/tests/README.md
+++ b/tests/README.md
@@ -30,7 +30,7 @@
 - `@pytest.mark.slow` – anything exceeding the budgets
 - `@pytest.mark.gpu` – requires a GPU
 
-`pytest` excludes `slow`, `gpu` and `e2e` by default. Use `-m` to include them when needed.
+`pytest` excludes `slow`, `gpu`, `e2e`, and `contract` by default. Use `-m` to include them when needed.
 
 ## Adding Tests
 
@@ -51,10 +51,9 @@
 Use the make targets:
 
 ```
-make test          # fast suite (no slow/gpu/e2e)
-make test-unit     # just unit tests
-make test-contract # contract tests
-make test-integration
-make test-e2e      # end-to-end smoke
-make test-all      # everything
+make test.unit       # unit tests
+make test.contract   # contract tests
+make test.int        # integration tests
+make test.e2e        # end-to-end smoke
+make test.all        # everything
 ```

--- a/tests/services/__snapshots__/test_listenbrainz.ambr
+++ b/tests/services/__snapshots__/test_listenbrainz.ambr
@@ -1,0 +1,45 @@
+# serializer version: 1
+# name: test_get_cf_recommendations_contract
+  list([
+    dict({
+      'artist_name': 'Artist A',
+      'recording_mbid': 'rec1',
+      'recording_name': 'Track A',
+      'score': 0.9,
+    }),
+    dict({
+      'artist_name': 'Artist B',
+      'recording_mbid': 'rec2',
+      'recording_name': 'Track B',
+      'score': 0.8,
+    }),
+  ])
+# ---
+# name: test_listenbrainz_candidates_normalization
+  list([
+    dict({
+      'artist': 'Artist A',
+      'isrc': None,
+      'recording_mbid': 'rec1',
+      'score_cf': 0.9,
+      'seeds': dict({
+        'user': 'alice',
+      }),
+      'source': 'listenbrainz',
+      'spotify_id': None,
+      'title': 'Track A',
+    }),
+    dict({
+      'artist': 'Artist B',
+      'isrc': None,
+      'recording_mbid': 'rec2',
+      'score_cf': 0.8,
+      'seeds': dict({
+        'user': 'alice',
+      }),
+      'source': 'listenbrainz',
+      'spotify_id': None,
+      'title': 'Track B',
+    }),
+  ])
+# ---

--- a/tests/services/test_listenbrainz.py
+++ b/tests/services/test_listenbrainz.py
@@ -1,0 +1,60 @@
+import httpx
+import pytest
+
+from sidetrack.services.listenbrainz import ListenBrainzService
+from sidetrack.services.candidates import _listenbrainz_candidates
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_listenbrainz_candidates_normalization(snapshot):
+    class StubLB:
+        async def get_cf_recommendations(self, user: str, limit: int = 50):
+            return [
+                {
+                    "recording_mbid": "rec1",
+                    "recording_name": "Track A",
+                    "artist_name": "Artist A",
+                    "score": 0.9,
+                },
+                {
+                    "recording_mbid": "rec2",
+                    "recording_name": "Track B",
+                    "artist_name": "Artist B",
+                    "score": 0.8,
+                },
+            ]
+
+    result = await _listenbrainz_candidates(StubLB(), "alice")
+    snapshot.assert_match(result)
+
+
+@pytest.mark.contract
+@pytest.mark.asyncio
+async def test_get_cf_recommendations_contract(snapshot, respx_mock):
+    payload = {
+        "recommendations": [
+            {
+                "recording_mbid": "rec1",
+                "recording_name": "Track A",
+                "artist_name": "Artist A",
+                "score": 0.9,
+            },
+            {
+                "recording_mbid": "rec2",
+                "recording_name": "Track B",
+                "artist_name": "Artist B",
+                "score": 0.8,
+            },
+        ]
+    }
+
+    respx_mock.get(
+        "https://api.listenbrainz.org/1/user/alice/cf/recommendations"
+    ).respond(200, json=payload)
+
+    async with httpx.AsyncClient() as client:
+        service = ListenBrainzService(client)
+        result = await service.get_cf_recommendations("alice")
+
+    snapshot.assert_match(result)


### PR DESCRIPTION
## Summary
- add ListenBrainz unit and contract tests with snapshot coverage
- skip contract tests by default and document dedicated make targets
- include respx and syrupy in dev dependencies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1e1ece6c48333888f2c003e868d53