### PR TITLE
Expose RQ queue metrics

### DIFF
--- a/sidetrack/api/main.py
+++ b/sidetrack/api/main.py
@@ -659,5 +659,7 @@ async def submit_label(
 
 
 from .api import router as api_router
+from .routers import ops as ops_router
 
 app.include_router(api_router)
+app.include_router(ops_router.router)

--- a/sidetrack/api/routers/ops.py
+++ b/sidetrack/api/routers/ops.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import math
+from fastapi import APIRouter
+from rq import Queue
+from rq.job import Job
+from rq.registry import FailedJobRegistry, FinishedJobRegistry, StartedJobRegistry
+
+from ..config import get_settings as get_api_settings
+
+router = APIRouter(prefix="/ops", tags=["ops"])
+
+
+def _percentile(sorted_data: list[float], percent: float) -> float:
+    """Return the percentile value from a pre-sorted list.
+
+    Args:
+        sorted_data: Sequence of numbers sorted in ascending order.
+        percent: Desired percentile between 0 and 100.
+
+    Returns:
+        The percentile value or ``0.0`` when ``sorted_data`` is empty.
+    """
+    if not sorted_data:
+        return 0.0
+    k = (len(sorted_data) - 1) * percent / 100
+    f = math.floor(k)
+    c = math.ceil(k)
+    if f == c:
+        return sorted_data[int(k)]
+    return sorted_data[f] + (sorted_data[c] - sorted_data[f]) * (k - f)
+
+
+@router.get("/queue")
+def queue_metrics() -> dict[str, dict[str, float | int]]:
+    """Return basic metrics for all RQ queues.
+
+    The metrics include counts of queued, running and failed jobs as well as
+    p50 and p95 execution times (in seconds) for recently finished jobs.
+    """
+    from ..main import _get_redis_connection
+
+    settings = get_api_settings()
+    conn = _get_redis_connection(settings)
+    metrics: dict[str, dict[str, float | int]] = {}
+    for q in Queue.all(connection=conn):
+        started = StartedJobRegistry(q.name, connection=conn)
+        failed = FailedJobRegistry(q.name, connection=conn)
+        finished = FinishedJobRegistry(q.name, connection=conn)
+
+        durations: list[float] = []
+        for job_id in finished.get_job_ids()[:100]:
+            job = Job.fetch(job_id, connection=conn)
+            if job.started_at and job.ended_at:
+                durations.append((job.ended_at - job.started_at).total_seconds())
+        durations.sort()
+        metrics[q.name] = {
+            "queued": q.count,
+            "running": started.count,
+            "failed": failed.count,
+            "p50": _percentile(durations, 50),
+            "p95": _percentile(durations, 95),
+        }
+    return metrics

--- a/tests/api/test_ops_queue.py
+++ b/tests/api/test_ops_queue.py
@@ -1,0 +1,39 @@
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+import sidetrack.api.main as api_main
+from sidetrack.api.config import ApiSettings
+
+
+@pytest.mark.asyncio
+async def test_queue_metrics(redis_conn, monkeypatch):
+    """The /ops/queue endpoint should report queue statistics."""
+
+    def _settings() -> ApiSettings:
+        return ApiSettings(
+            _env_file=".env.test",
+            database_url="postgresql://user:pass@localhost:5432/sidetrack",
+            redis_url="redis://localhost:6379/0",
+        )
+
+    class _DummyDB:
+        async def execute(self, *args, **kwargs):  # pragma: no cover - stub
+            raise Exception("db not available")
+
+    async def _get_db():  # pragma: no cover - stub
+        yield _DummyDB()
+
+    app = api_main.app
+    app.dependency_overrides[api_main.get_app_settings] = _settings
+    app.dependency_overrides[api_main.get_db] = _get_db
+    monkeypatch.setattr(api_main, "_get_redis_connection", lambda settings: redis_conn)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://testserver") as client:
+        resp = await client.get("/ops/queue")
+
+    app.dependency_overrides.clear()
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, dict)
+    for stats in data.values():
+        assert {"queued", "running", "failed", "p50", "p95"} <= stats.keys()


### PR DESCRIPTION
## Summary
- add `/ops/queue` endpoint to report queued, running, failed, and latency percentiles for all RQ queues
- wire new ops router into FastAPI app
- test queue metrics endpoint

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1e86d89bc8333a43bdde56834fdfc