### PR TITLE
Add enrichment adapters for music services

### DIFF
--- a/sidetrack/enrichment/__init__.py
+++ b/sidetrack/enrichment/__init__.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+
+@dataclass
+class TrackRef:
+    """Normalized reference to a track across services."""
+
+    title: str
+    artists: List[str]
+    isrc: Optional[str] = None
+    spotify_id: Optional[str] = None
+    lastfm_mbid: Optional[str] = None

--- a/sidetrack/enrichment/lastfm.py
+++ b/sidetrack/enrichment/lastfm.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from typing import Any, List
+
+import httpx
+
+from . import TrackRef
+
+
+class LastfmAdapter:
+    """Thin wrapper around the Last.fm API."""
+
+    api_root = "https://ws.audioscrobbler.com/2.0/"
+
+    def __init__(self, api_key: str, client: httpx.AsyncClient | None = None) -> None:
+        self.api_key = api_key
+        self._client = client or httpx.AsyncClient()
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+    async def _request(self, params: dict[str, Any]) -> dict[str, Any]:
+        params = dict(params)
+        params["api_key"] = self.api_key
+        params["format"] = "json"
+        resp = await self._client.get(self.api_root, params=params, timeout=30)
+        resp.raise_for_status()
+        return resp.json()
+
+    @staticmethod
+    def _to_track_ref(track: dict[str, Any]) -> TrackRef:
+        title = track.get("name") or ""
+        artist = track.get("artist") or {}
+        if isinstance(artist, dict):
+            artist_name = artist.get("name")
+        else:
+            artist_name = str(artist)
+        artists = [artist_name] if artist_name else []
+        mbid = track.get("mbid") or None
+        return TrackRef(title=title, artists=artists, lastfm_mbid=mbid)
+
+    async def get_recent_tracks(self, user: str, limit: int = 50) -> List[TrackRef]:
+        params = {"method": "user.getrecenttracks", "user": user, "limit": limit}
+        data = await self._request(params)
+        tracks = data.get("recenttracks", {}).get("track", [])
+        return [self._to_track_ref(t) for t in tracks]
+
+    async def get_top_artists(self, user: str, period: str = "7day", limit: int = 50) -> List[str]:
+        params = {
+            "method": "user.gettopartists",
+            "user": user,
+            "period": period,
+            "limit": limit,
+        }
+        data = await self._request(params)
+        artists = data.get("topartists", {}).get("artist", [])
+        return [a.get("name", "") for a in artists]
+
+    async def get_top_tracks(self, user: str, period: str = "7day", limit: int = 50) -> List[TrackRef]:
+        params = {
+            "method": "user.gettoptracks",
+            "user": user,
+            "period": period,
+            "limit": limit,
+        }
+        data = await self._request(params)
+        tracks = data.get("toptracks", {}).get("track", [])
+        return [self._to_track_ref(t) for t in tracks]
+
+    async def get_tags(
+        self, artist: str, track: str | None = None, limit: int = 50
+    ) -> List[str]:
+        if track:
+            params = {
+                "method": "track.gettoptags",
+                "artist": artist,
+                "track": track,
+                "limit": limit,
+            }
+        else:
+            params = {"method": "artist.gettoptags", "artist": artist, "limit": limit}
+        data = await self._request(params)
+        tags = data.get("toptags", {}).get("tag", [])
+        return [t.get("name", "") for t in tags]
+
+    async def get_similar_artists(
+        self, *, name: str | None = None, mbid: str | None = None, limit: int = 50
+    ) -> List[str]:
+        params = {"method": "artist.getsimilar", "limit": limit}
+        if mbid:
+            params["mbid"] = mbid
+        elif name:
+            params["artist"] = name
+        else:
+            raise ValueError("name or mbid required")
+        data = await self._request(params)
+        artists = data.get("similarartists", {}).get("artist", [])
+        return [a.get("name", "") for a in artists]
+
+    async def get_similar_tracks(
+        self,
+        *,
+        artist: str | None = None,
+        track: str | None = None,
+        mbid: str | None = None,
+        limit: int = 50,
+    ) -> List[TrackRef]:
+        params = {"method": "track.getsimilar", "limit": limit}
+        if mbid:
+            params["mbid"] = mbid
+        else:
+            if not artist or not track:
+                raise ValueError("artist and track required when mbid not provided")
+            params["artist"] = artist
+            params["track"] = track
+        data = await self._request(params)
+        tracks = data.get("similartracks", {}).get("track", [])
+        return [self._to_track_ref(t) for t in tracks]

--- a/sidetrack/enrichment/listenbrainz.py
+++ b/sidetrack/enrichment/listenbrainz.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Any, List
+
+import httpx
+
+from . import TrackRef
+
+
+class ListenBrainzAdapter:
+    """Wrapper around the ListenBrainz API."""
+
+    api_root = "https://api.listenbrainz.org/1"
+
+    def __init__(self, client: httpx.AsyncClient | None = None) -> None:
+        self._client = client or httpx.AsyncClient()
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+    @staticmethod
+    def _to_track_ref(rec: dict[str, Any]) -> TrackRef:
+        title = rec.get("track_name") or rec.get("title") or ""
+        artist = rec.get("artist_name") or rec.get("artist") or ""
+        artists = [artist] if isinstance(artist, str) else artist
+        mbid = rec.get("recording_mbid") or rec.get("mbid")
+        return TrackRef(title=title, artists=artists, lastfm_mbid=mbid)
+
+    async def get_cf_recommendations(self, user: str, limit: int = 50) -> List[TrackRef]:
+        url = f"{self.api_root}/user/{user}/cf/recommendations"
+        params = {"count": limit}
+        resp = await self._client.get(url, params=params, timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+        recs = (
+            data.get("recommendations")
+            or data.get("recordings")
+            or data.get("recommended_recordings")
+            or []
+        )
+        return [self._to_track_ref(r) for r in recs]
+
+    async def get_colisten_similar_artists(
+        self, artist_mbid: str, limit: int = 10
+    ) -> List[str]:
+        """Return artists frequently co-listened with the given artist."""
+
+        url = f"{self.api_root}/artist/{artist_mbid}/similar"
+        params = {"count": limit}
+        resp = await self._client.get(url, params=params, timeout=30)
+        if resp.status_code == 404:
+            return []
+        resp.raise_for_status()
+        data = resp.json()
+        artists = data.get("similar_artists") or data.get("artists") or []
+        return [a.get("artist_name", "") for a in artists]

--- a/sidetrack/enrichment/mb.py
+++ b/sidetrack/enrichment/mb.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, List
+
+import httpx
+
+from . import TrackRef
+
+
+class MusicBrainzAdapter:
+    """Simple wrapper for MusicBrainz lookups."""
+
+    api_root = "https://musicbrainz.org/ws/2"
+
+    def __init__(self, client: httpx.AsyncClient | None = None) -> None:
+        headers = {"User-Agent": "SideTrack/0.1 (+https://example.com)"}
+        self._client = client or httpx.AsyncClient(headers=headers)
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+    async def recording_by_isrc(self, isrc: str) -> TrackRef | None:
+        """Return basic metadata for a recording identified by its ISRC."""
+
+        url = f"{self.api_root}/isrc/{isrc}"
+        params = {"inc": "recordings+artist-credits", "fmt": "json"}
+        resp = await self._client.get(url, params=params, timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+        recording = (data.get("recordings") or [{}])[0]
+        title = recording.get("title") or ""
+        artists = [
+            c.get("artist", {}).get("name")
+            for c in recording.get("artist-credit", [])
+            if c.get("artist", {}).get("name")
+        ]
+        mbid = recording.get("id")
+        # Honour MusicBrainz rate-limiting guidelines
+        await asyncio.sleep(1)
+        return TrackRef(title=title, artists=artists, isrc=isrc, lastfm_mbid=mbid)

--- a/sidetrack/enrichment/spotify.py
+++ b/sidetrack/enrichment/spotify.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any, List
+
+import httpx
+
+from . import TrackRef
+
+
+class SpotifyAdapter:
+    """Adapter for the Spotify Web API with minimal OAuth support."""
+
+    auth_root = "https://accounts.spotify.com"
+    api_root = "https://api.spotify.com/v1"
+
+    def __init__(
+        self,
+        access_token: str,
+        *,
+        refresh_token: str | None = None,
+        client_id: str | None = None,
+        client_secret: str | None = None,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self.access_token = access_token
+        self.refresh_token = refresh_token
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self._client = client or httpx.AsyncClient()
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    async def _refresh(self) -> None:
+        if not self.refresh_token or not self.client_id or not self.client_secret:
+            raise RuntimeError("cannot refresh token without credentials")
+        data = {"grant_type": "refresh_token", "refresh_token": self.refresh_token}
+        auth = httpx.BasicAuth(self.client_id, self.client_secret)
+        resp = await self._client.post(
+            f"{self.auth_root}/api/token", data=data, auth=auth, timeout=30
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+        self.access_token = payload.get("access_token", self.access_token)
+
+    async def _request(self, method: str, url: str, **kwargs: Any) -> dict[str, Any]:
+        headers = kwargs.pop("headers", {})
+        while True:
+            headers["Authorization"] = f"Bearer {self.access_token}"
+            resp = await self._client.request(
+                method, url, headers=headers, timeout=30, **kwargs
+            )
+            if resp.status_code == 401 and self.refresh_token:
+                await self._refresh()
+                continue
+            if resp.status_code == 429:
+                retry = int(resp.headers.get("Retry-After", "1"))
+                await asyncio.sleep(retry)
+                continue
+            resp.raise_for_status()
+            return resp.json()
+
+    @staticmethod
+    def _to_track_ref(data: dict[str, Any]) -> TrackRef:
+        track = data.get("track") or data
+        return TrackRef(
+            title=track.get("name", ""),
+            artists=[a.get("name") for a in track.get("artists", []) if a.get("name")],
+            isrc=(track.get("external_ids") or {}).get("isrc"),
+            spotify_id=track.get("id"),
+        )
+
+    # ------------------------------------------------------------------
+    # API methods
+    # ------------------------------------------------------------------
+    async def get_recently_played(self, limit: int = 50) -> List[TrackRef]:
+        params = {"limit": min(limit, 50)}
+        data = await self._request(
+            "GET", f"{self.api_root}/me/player/recently-played", params=params
+        )
+        return [self._to_track_ref(x) for x in data.get("items", [])]
+
+    async def get_saved_tracks(self, limit: int = 50) -> List[TrackRef]:
+        url = f"{self.api_root}/me/tracks"
+        params: dict[str, Any] | None = {"limit": min(limit, 50)}
+        out: List[TrackRef] = []
+        while url:
+            data = await self._request("GET", url, params=params)
+            out.extend(self._to_track_ref(x) for x in data.get("items", []))
+            url = data.get("next")
+            params = None
+        return out[:limit]
+
+    async def get_top_items(
+        self, type_: str = "tracks", time_range: str = "short_term", limit: int = 20
+    ) -> List[TrackRef]:
+        params = {"time_range": time_range, "limit": limit}
+        data = await self._request("GET", f"{self.api_root}/me/top/{type_}", params=params)
+        return [self._to_track_ref(x) for x in data.get("items", [])]
+
+    async def audio_features(self, ids: List[str]) -> List[dict[str, Any]]:
+        out: List[dict[str, Any]] = []
+        for i in range(0, len(ids), 100):
+            batch = ids[i : i + 100]
+            params = {"ids": ",".join(batch)}
+            data = await self._request(
+                "GET", f"{self.api_root}/audio-features", params=params
+            )
+            out.extend(x for x in data.get("audio_features", []) if x)
+        return out


### PR DESCRIPTION
## Summary
- introduce `TrackRef` dataclass for normalized track references
- add Spotify adapter with token refresh, rate-limit handling, and common track queries
- add Last.fm, ListenBrainz, and MusicBrainz enrichment adapters

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1eb6dc3d8833381ad0279db0f66c2