### PR TITLE
Add MusicBrainz recording lookup with caching and fallback

### DIFF
--- a/sidetrack/common/models.py
+++ b/sidetrack/common/models.py
@@ -132,9 +132,7 @@ class TrackFeature(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
     )
-    dataset_version: Mapped[str] = mapped_column(
-        String(16), default="v1", primary_key=True
-    )
+    dataset_version: Mapped[str] = mapped_column(String(16), default="v1", primary_key=True)
 
 
 class TrackEmbedding(Base):
@@ -142,9 +140,7 @@ class TrackEmbedding(Base):
 
     track_id: Mapped[int] = mapped_column(ForeignKey("track.track_id"), primary_key=True)
     model: Mapped[str] = mapped_column(String(64), primary_key=True)
-    dataset_version: Mapped[str] = mapped_column(
-        String(16), default="v1", primary_key=True
-    )
+    dataset_version: Mapped[str] = mapped_column(String(16), default="v1", primary_key=True)
     dim: Mapped[int] = mapped_column(Integer)
     vec: Mapped[list[float] | None] = mapped_column(Vector(), nullable=True)
     norm: Mapped[float | None] = mapped_column(Float)
@@ -229,6 +225,20 @@ class LastfmTags(Base):
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
     )
+
+
+class MusicBrainzRecording(Base):
+    """Cached MusicBrainz lookups by ISRC."""
+
+    __tablename__ = "mb_recording"
+
+    isrc: Mapped[str] = mapped_column(String(16), primary_key=True)
+    recording_mbid: Mapped[str | None] = mapped_column(String(36), index=True)
+    artist_mbid: Mapped[str | None] = mapped_column(String(36), index=True)
+    release_group_mbid: Mapped[str | None] = mapped_column(String(36), index=True)
+    year: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    label: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    tags: Mapped[list[str] | None] = mapped_column(JSON, nullable=True)
 
 
 class UserSettings(Base):

--- a/sidetrack/services/mb.py
+++ b/sidetrack/services/mb.py
@@ -1,0 +1,166 @@
+"""MusicBrainz lookup helpers."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from typing import Any
+
+import httpx
+from redis import Redis
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sidetrack.api.db import SessionLocal
+from sidetrack.common.models import MusicBrainzRecording
+
+_MB_LOCK = asyncio.Lock()
+_CACHE_TTL = 24 * 3600  # one day
+
+
+async def _rate_limit() -> None:
+    rate = float(os.getenv("MUSICBRAINZ_RATE_LIMIT", "1.0"))
+    await asyncio.sleep(max(0.0, 1.0 / rate))
+
+
+async def recording_by_isrc(
+    isrc: str,
+    *,
+    title: str | None = None,
+    artist: str | None = None,
+    client: httpx.AsyncClient | None = None,
+    redis_conn: Redis | None = None,
+    db: AsyncSession | None = None,
+) -> dict[str | None, Any]:
+    """Return MusicBrainz metadata for a recording given its ISRC.
+
+    Falls back to a title/artist search when the ISRC is missing from
+    MusicBrainz.  Results are cached in Redis and persisted to the database.
+    """
+
+    cache_key = f"mb:isrc:{isrc}"
+    if redis_conn is not None:
+        cached = await asyncio.to_thread(redis_conn.get, cache_key)
+        if cached:
+            return json.loads(cached)
+
+    close_client = False
+    if client is None:
+        client = httpx.AsyncClient()
+        close_client = True
+
+    headers = {"User-Agent": "SideTrack/0.1 (+https://example.com)"}
+    params = {"inc": "recordings+releases+release-groups+artist-credits+tags", "fmt": "json"}
+
+    data: dict[str, Any] | None = None
+    async with _MB_LOCK:
+        resp = await client.get(
+            f"https://musicbrainz.org/ws/2/isrc/{isrc}",
+            params=params,
+            headers=headers,
+            timeout=30,
+        )
+        if resp.status_code != 404:
+            resp.raise_for_status()
+            data = resp.json()
+        await _rate_limit()
+
+    if (data is None or not data.get("recordings")) and title and artist:
+        async with _MB_LOCK:
+            q = f'recording:"{title}" AND artist:"{artist}"'
+            search_params = {
+                "query": q,
+                "fmt": "json",
+                "limit": 1,
+                "inc": "releases+release-groups+artist-credits+tags",
+            }
+            resp = await client.get(
+                "https://musicbrainz.org/ws/2/recording",
+                params=search_params,
+                headers=headers,
+                timeout=30,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            await _rate_limit()
+
+    if close_client:
+        await client.aclose()
+
+    recording = (data.get("recordings") or [{}])[0] if data else {}
+    recording_mbid = recording.get("id")
+    artist_credit = (recording.get("artist-credit") or [{}])[0].get("artist", {})
+    artist_mbid = artist_credit.get("id")
+
+    releases = recording.get("releases") or []
+    release_year: int | None = None
+    release_group_mbid: str | None = None
+    label: str | None = None
+    if releases:
+
+        def _year(rel: dict[str, Any]) -> int:
+            date = rel.get("date") or "9999"
+            try:
+                return int(str(date)[:4])
+            except Exception:
+                return 9999
+
+        rel = min(releases, key=_year)
+        date = rel.get("date")
+        if isinstance(date, str) and len(date) >= 4:
+            try:
+                release_year = int(date[:4])
+            except ValueError:
+                release_year = None
+        label_info = rel.get("label-info") or rel.get("label-info-list") or []
+        if label_info:
+            label = (label_info[0].get("label") or {}).get("name")
+        rg = rel.get("release-group") or {}
+        if isinstance(rg, dict):
+            release_group_mbid = rg.get("id")
+
+    tags = [t.get("name") for t in recording.get("tags", []) if t.get("name")]
+
+    result = {
+        "recording_mbid": recording_mbid,
+        "artist_mbid": artist_mbid,
+        "release_group_mbid": release_group_mbid,
+        "year": release_year,
+        "label": label,
+        "tags": tags,
+    }
+
+    if redis_conn is not None:
+        await asyncio.to_thread(redis_conn.setex, cache_key, _CACHE_TTL, json.dumps(result))
+
+    close_db = False
+    if db is None:
+        db = SessionLocal()
+        close_db = True
+    try:
+        inst = await db.get(MusicBrainzRecording, isrc)
+        if inst:
+            inst.recording_mbid = recording_mbid
+            inst.artist_mbid = artist_mbid
+            inst.release_group_mbid = release_group_mbid
+            inst.year = release_year
+            inst.label = label
+            inst.tags = tags
+        else:
+            db.add(
+                MusicBrainzRecording(
+                    isrc=isrc,
+                    recording_mbid=recording_mbid,
+                    artist_mbid=artist_mbid,
+                    release_group_mbid=release_group_mbid,
+                    year=release_year,
+                    label=label,
+                    tags=tags,
+                )
+            )
+        await db.commit()
+    finally:
+        if close_db:
+            await db.close()
+
+    return result

--- a/tests/test_mb_service.py
+++ b/tests/test_mb_service.py
@@ -1,0 +1,117 @@
+import asyncio
+import asyncio
+import httpx
+import pytest
+
+from sidetrack.services.mb import recording_by_isrc
+from sidetrack.common.models import MusicBrainzRecording
+
+
+@pytest.mark.asyncio
+async def test_recording_by_isrc_db_cache(redis_conn, async_session, monkeypatch):
+    payload = {
+        "isrc": "US1234567890",
+        "recordings": [
+            {
+                "id": "rec-1",
+                "artist-credit": [{"artist": {"id": "art-1"}}],
+                "releases": [
+                    {
+                        "id": "rel-old",
+                        "date": "1999-02-01",
+                        "label-info": [{"label": {"name": "Label A"}}],
+                        "release-group": {"id": "rg-1"},
+                    },
+                    {
+                        "id": "rel-new",
+                        "date": "2005-01-01",
+                        "label-info": [{"label": {"name": "Label B"}}],
+                        "release-group": {"id": "rg-2"},
+                    },
+                ],
+                "tags": [{"name": "rock"}, {"name": "indie"}],
+            }
+        ],
+    }
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=payload)
+
+    transport = httpx.MockTransport(handler)
+
+    async def no_sleep(_):
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", no_sleep)
+
+    async with httpx.AsyncClient(transport=transport) as client:
+        res = await recording_by_isrc(
+            "US1234567890", client=client, redis_conn=redis_conn, db=async_session
+        )
+        assert res == {
+            "recording_mbid": "rec-1",
+            "artist_mbid": "art-1",
+            "release_group_mbid": "rg-1",
+            "year": 1999,
+            "label": "Label A",
+            "tags": ["rock", "indie"],
+        }
+
+        db_rec = await async_session.get(MusicBrainzRecording, "US1234567890")
+        assert db_rec and db_rec.release_group_mbid == "rg-1"
+
+        called = False
+
+        async def fail_handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover
+            nonlocal called
+            called = True
+            return httpx.Response(500)
+
+        client._transport = httpx.MockTransport(fail_handler)
+        res2 = await recording_by_isrc(
+            "US1234567890", client=client, redis_conn=redis_conn, db=async_session
+        )
+        assert res2["recording_mbid"] == "rec-1"
+        assert not called
+
+
+@pytest.mark.asyncio
+async def test_recording_by_isrc_fallback(redis_conn, async_session, monkeypatch):
+    payload = {
+        "recordings": [
+            {
+                "id": "rec-fb",
+                "artist-credit": [{"artist": {"id": "art-fb"}}],
+                "releases": [
+                    {
+                        "id": "rel",
+                        "date": "2010-01-01",
+                        "release-group": {"id": "rg-fb"},
+                    }
+                ],
+            }
+        ]
+    }
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if "isrc" in str(request.url):
+            return httpx.Response(404)
+        return httpx.Response(200, json=payload)
+
+    transport = httpx.MockTransport(handler)
+
+    async def no_sleep(_):
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", no_sleep)
+
+    async with httpx.AsyncClient(transport=transport) as client:
+        res = await recording_by_isrc(
+            "MISSING",
+            title="Song",
+            artist="Artist",
+            client=client,
+            redis_conn=redis_conn,
+            db=async_session,
+        )
+        assert res["recording_mbid"] == "rec-fb"


### PR DESCRIPTION
## Summary
- cache MusicBrainz recording lookups in Redis and database
- add MusicBrainzRecording model for persisted metadata
- fallback to title/artist search when ISRC lookup fails

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c1ed575c2c833387f77d2dacefa4da