### PR TITLE
Handle optional audio dependencies

### DIFF
--- a/sidetrack/extraction/features.py
+++ b/sidetrack/extraction/features.py
@@ -5,17 +5,24 @@ from __future__ import annotations
 import time
 
 import numpy as np
-import librosa
 import structlog
 
 from .dsp import melspectrogram
 from .io import _resources
+
+try:  # pragma: no cover - optional dependency
+    import librosa  # type: ignore
+except Exception:  # pragma: no cover - librosa is optional
+    librosa = None  # type: ignore
 
 
 logger = structlog.get_logger(__name__)
 
 
 def extract_features(track_id: int, y: np.ndarray, sr: int, cache_dir) -> dict:
+    if librosa is None:
+        raise ImportError("librosa is required for feature extraction; install sidetrack[extractor]")
+
     start = time.perf_counter()
     mel = melspectrogram(track_id, y, sr, cache_dir)
     rms = librosa.feature.rms(S=mel)[0]

--- a/sidetrack/extraction/io.py
+++ b/sidetrack/extraction/io.py
@@ -7,13 +7,17 @@ from typing import Tuple
 import time
 
 import numpy as np
-import soundfile as sf
 import structlog
 
 try:  # pragma: no cover - optional dependency
-    import psutil
+    import soundfile as sf  # type: ignore
+except Exception:  # pragma: no cover - soundfile is optional
+    sf = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    import psutil  # type: ignore
 except Exception:  # pragma: no cover - psutil not installed
-    psutil = None
+    psutil = None  # type: ignore
 
 
 logger = structlog.get_logger(__name__)
@@ -32,6 +36,11 @@ def cache_path(cache_dir: Path, track_id: int, kind: str, suffix: str) -> Path:
 
 def decode(track_id: int, path: str, cache_dir: Path) -> Tuple[np.ndarray, int]:
     """Decode ``path`` into a waveform, optionally caching the result."""
+
+    if sf is None:
+        raise ImportError(
+            "soundfile is required for audio decoding; install sidetrack[extractor]"
+        )
 
     start = time.perf_counter()
     cp = cache_path(cache_dir, track_id, "raw", "npz")


### PR DESCRIPTION
## Summary
- guard soundfile and librosa imports for extraction utilities
- raise clear ImportError when audio libraries are missing

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q` *(logging error from opentelemetry, tests otherwise completed)*


------
https://chatgpt.com/codex/tasks/task_e_68c1f7b3dc288333a512e503ac7bcff1