### PR TITLE
Use TimescaleDB with pgvector

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -5,7 +5,9 @@ services:
       dockerfile: services/base/Dockerfile
     image: sidetrack/base:dev
   db:
-    image: pgvector/pgvector:pg16
+    build:
+      context: .
+      dockerfile: services/db/Dockerfile
     environment:
       - POSTGRES_DB=${POSTGRES_DB}
       - POSTGRES_USER=${POSTGRES_USER}

--- a/services/db/Dockerfile
+++ b/services/db/Dockerfile
@@ -1,0 +1,6 @@
+FROM timescale/timescaledb:latest-pg16
+
+# Install pgvector extension
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends postgresql-16-pgvector && \
+    rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- Build a TimescaleDB-based database image and install the pgvector extension
- Point docker compose's db service at the new TimescaleDB image

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c23f73878483339dd72c9a5987b869