### PR TITLE
Cache pip wheels using BuildKit

### DIFF
--- a/services/base/Dockerfile
+++ b/services/base/Dockerfile
@@ -19,8 +19,10 @@ COPY pyproject.toml ./
 COPY sidetrack ./sidetrack
 
 # Build wheels for the core package and all extras so downstream builds don't
-# need internet access to resolve dependencies
-RUN pip wheel --no-cache-dir --wheel-dir /wheels \
+# need internet access to resolve dependencies. Use a BuildKit cache mount so
+# downloaded packages persist across builds.
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip wheel --wheel-dir /wheels \
     '.[api]' '.[worker]' '.[scheduler]' '.[extractor]' \
     && ls -l /wheels
 


### PR DESCRIPTION
## Summary
- reuse pip downloads in base Dockerfile using BuildKit cache mount

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c248951c84833390e7c075ef67f8cf