### PR TITLE
Fix timezone handling for user registration

### DIFF
--- a/sidetrack/api/api/v1/auth.py
+++ b/sidetrack/api/api/v1/auth.py
@@ -2,7 +2,7 @@
 
 import re
 import secrets
-from datetime import datetime
+from datetime import datetime, timezone
 from hashlib import sha256
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -49,7 +49,7 @@ async def register(creds: Credentials, db: AsyncSession = Depends(get_db)):
     user = UserAccount(
         user_id=creds.username,
         password_hash=hash_password(creds.password),
-        created_at=datetime.utcnow(),
+        created_at=datetime.now(timezone.utc),
     )
     db.add(user)
     await db.commit()


### PR DESCRIPTION
## Summary
- ensure registration uses timezone-aware timestamps to avoid 500 errors

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2488bf72083338a19017353244e90