### PR TITLE
fix: configure UI to reach API service

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -90,6 +90,8 @@ services:
   ui:
     build: ./services/ui
     env_file: .env
+    environment:
+      NEXT_PUBLIC_API_BASE: http://api:8000
     depends_on: [api]
     ports: ["3000:3000"]
 


### PR DESCRIPTION
## Summary
- ensure docker-compose UI container targets the API container via `NEXT_PUBLIC_API_BASE`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c24cb24ba0833390b2f84622a7664e