### PR TITLE
Expose unversioned auth register endpoint

### DIFF
--- a/sidetrack/api/api/__init__.py
+++ b/sidetrack/api/api/__init__.py
@@ -2,9 +2,11 @@ from fastapi import APIRouter
 from fastapi.responses import RedirectResponse
 
 from .v1 import router as v1_router
+from .v1 import auth as auth_v1
 
 router = APIRouter()
 router.include_router(v1_router)
+router.include_router(auth_v1.router)
 
 
 @router.get("/", include_in_schema=False)

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -55,3 +55,11 @@ def test_register_rate_limit(client):
         json={"username": "rate-final", "password": "ValidPass1!"},
     )
     assert resp.status_code == 429
+
+
+def test_register_without_version_prefix(client):
+    resp = client.post(
+        "/auth/register",
+        json={"username": "noversion", "password": "ValidPass1!"},
+    )
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- expose auth routes without the `/api/v1` prefix so `/auth/register` is valid
- add test covering `/auth/register` without version prefix

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2540d3b588333bd8b2039c085c41d