### PR TITLE
fix: refresh user after registration

### DIFF
--- a/sidetrack/api/api/v1/auth.py
+++ b/sidetrack/api/api/v1/auth.py
@@ -53,6 +53,7 @@ async def register(creds: Credentials, db: AsyncSession = Depends(get_db)):
     )
     db.add(user)
     await db.commit()
+    await db.refresh(user)
     return UserOut.model_validate(user)
 
 

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -63,3 +63,13 @@ def test_register_without_version_prefix(client):
         json={"username": "noversion", "password": "ValidPass1!"},
     )
     assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_register_async_client(async_client):
+    resp = await async_client.post(
+        "/auth/register",
+        json={"username": "asyncuser", "password": "ValidPass1!"},
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"user_id": "asyncuser"}


### PR DESCRIPTION
## Summary
- refresh newly created user after commit to avoid MissingGreenlet errors
- add async registration test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c25a754fb48333a8e7b719abaf3a46