### PR TITLE
feat(ui): add dashboard summary hook

### DIFF
--- a/services/ui/app/(dashboard)/page.tsx
+++ b/services/ui/app/(dashboard)/page.tsx
@@ -3,14 +3,21 @@
 import KpiCard from '../../components/dashboard/KpiCard';
 import InsightCard from '../../components/dashboard/InsightCard';
 import QuickActions from '../../components/dashboard/QuickActions';
+import Skeleton from '../../components/Skeleton';
+import { useDashboard } from '../../lib/query';
 
 export default function DashboardPage() {
-  const lastArtist = 'Daft Punk';
-  const insights = [
-    { id: 'new-artists', summary: '5 new artists discovered' },
-    { id: 'daypart', summary: 'Afternoon energy peaked' },
-    { id: 'freshness', summary: 'Catalog stayed fresh this week' },
-  ];
+  const { data, isLoading, error } = useDashboard();
+
+  if (error) {
+    return (
+      <section className="@container space-y-6">
+        <p className="text-sm text-rose-400">
+          Failed to load dashboard: {(error as Error).message}
+        </p>
+      </section>
+    );
+  }
 
   return (
     <section className="@container space-y-6">
@@ -20,19 +27,22 @@ export default function DashboardPage() {
       </div>
 
       <div className="grid gap-4 @[640px]:grid-cols-3">
-        <KpiCard title="DiscoveryScore" value={72} delta={{ value: 3 }} />
-        <KpiCard title="Day-part highlight" value="Evening" />
-        <KpiCard title="Freshness delta" value="12%" delta={{ value: 2, suffix: '%' }} />
+        {isLoading
+          ? [1, 2, 3].map((i) => <Skeleton key={i} className="h-24" />)
+          : data?.kpis.map((kpi) => <KpiCard key={kpi.id} kpi={kpi} />)}
       </div>
 
       <div className="flex gap-4 overflow-x-auto pb-2">
-        {insights.map((ins) => (
-          <InsightCard key={ins.id} insight={ins} />
-        ))}
+        {isLoading
+          ? [1, 2, 3].map((i) => <Skeleton key={i} className="h-24 min-w-[200px]" />)
+          : data?.insights.map((ins) => <InsightCard key={ins.id} insight={ins} />)}
       </div>
 
-      <QuickActions lastArtist={lastArtist} />
+      {isLoading ? (
+        <Skeleton className="h-32" />
+      ) : (
+        <QuickActions lastArtist={data?.lastArtist ?? ''} />
+      )}
     </section>
   );
 }
-

--- a/services/ui/components/dashboard/InsightCard.tsx
+++ b/services/ui/components/dashboard/InsightCard.tsx
@@ -2,29 +2,34 @@
 
 import Link from 'next/link';
 import { Card } from '../ui/card';
-
-type Insight = {
-  id: string;
-  summary: string;
-};
+import type { DashboardInsight } from '../../lib/query';
 
 type Props = {
-  insight: Insight;
+  insight: DashboardInsight;
 };
 
 export default function InsightCard({ insight }: Props) {
+  if (insight.error) {
+    return (
+      <Card variant="glass" className="min-w-[200px] p-4 shadow-soft">
+        <div className="text-sm text-rose-400">{insight.error}</div>
+      </Card>
+    );
+  }
+
   return (
     <Card variant="glass" className="min-w-[200px] p-4 shadow-soft">
       <div className="space-y-2">
-        <div className="text-sm font-medium">{insight.summary}</div>
-        <Link
-          href={`/insights?focus=${insight.id}`}
-          className="text-xs text-emerald-300 hover:underline"
-        >
-          View details
-        </Link>
+        <div className="text-sm font-medium">{insight.summary ?? 'No insight available'}</div>
+        {insight.summary && (
+          <Link
+            href={`/insights?focus=${insight.id}`}
+            className="text-xs text-emerald-300 hover:underline"
+          >
+            View details
+          </Link>
+        )}
       </div>
     </Card>
   );
 }
-

--- a/services/ui/components/dashboard/KpiCard.tsx
+++ b/services/ui/components/dashboard/KpiCard.tsx
@@ -2,15 +2,14 @@
 import { motion } from 'framer-motion';
 import { Card } from '../ui/card';
 import { useMemo } from 'react';
+import type { DashboardKpi } from '../../lib/query';
 
 type Props = {
-  title: string;
-  value: string | number;
-  delta?: { value: number; suffix?: string };
-  series?: number[];
+  kpi: DashboardKpi;
 };
 
-export default function KpiCard({ title, value, delta, series }: Props) {
+export default function KpiCard({ kpi }: Props) {
+  const { title, value, delta, series, error } = kpi;
   const deltaText =
     delta && typeof delta.value === 'number'
       ? `${delta.value > 0 ? '+' : ''}${delta.value}${delta.suffix ?? ''}`
@@ -43,17 +42,22 @@ export default function KpiCard({ title, value, delta, series }: Props) {
         whileTap={{ scale: 0.98 }}
       >
         <div className="text-xs uppercase tracking-wide text-muted-foreground">{title}</div>
-        <div className="mt-2 flex items-baseline gap-2">
-          <div className="text-2xl font-semibold">{value}</div>
-          {deltaText && <div className={`text-xs ${deltaClass}`}>{deltaText}</div>}
-        </div>
-        {path && (
-          <svg viewBox="0 0 100 24" className="mt-2 h-6 w-full text-emerald-400">
-            <path d={path} fill="none" stroke="currentColor" strokeWidth={2} />
-          </svg>
+        {error ? (
+          <div className="mt-2 text-sm text-rose-400">{error}</div>
+        ) : (
+          <>
+            <div className="mt-2 flex items-baseline gap-2">
+              <div className="text-2xl font-semibold">{value ?? '--'}</div>
+              {deltaText && <div className={`text-xs ${deltaClass}`}>{deltaText}</div>}
+            </div>
+            {path && (
+              <svg viewBox="0 0 100 24" className="mt-2 h-6 w-full text-emerald-400">
+                <path d={path} fill="none" stroke="currentColor" strokeWidth={2} />
+              </svg>
+            )}
+          </>
         )}
       </motion.div>
     </Card>
   );
 }
-

--- a/services/ui/lib/query.ts
+++ b/services/ui/lib/query.ts
@@ -5,6 +5,43 @@ export type TrajectoryPoint = { week: string; x: number; y: number; r?: number }
 export type TrajectoryArrow = { from: TrajectoryPoint; to: TrajectoryPoint };
 export type TrajectoryData = { points: TrajectoryPoint[]; arrows: TrajectoryArrow[] };
 
+export type DashboardKpi = {
+  id: string;
+  title: string;
+  value?: string | number | null;
+  delta?: { value: number; suffix?: string };
+  series?: number[];
+  error?: string;
+};
+
+export type DashboardInsight = {
+  id: string;
+  summary?: string;
+  error?: string;
+};
+
+export type DashboardData = {
+  lastArtist: string;
+  kpis: DashboardKpi[];
+  insights: DashboardInsight[];
+};
+
+export function useDashboard() {
+  return useQuery<DashboardData>({
+    queryKey: ['dashboard-summary'],
+    queryFn: async () => {
+      const res = await apiFetch('/dashboard/summary');
+      if (!res.ok) throw new Error('Failed to fetch dashboard summary');
+      const json = await res.json();
+      return {
+        lastArtist: json.last_artist ?? '',
+        kpis: json.kpis ?? [],
+        insights: json.insights ?? [],
+      } as DashboardData;
+    },
+  });
+}
+
 export function useTrajectory() {
   return useQuery<TrajectoryData>({
     queryKey: ['trajectory'],


### PR DESCRIPTION
## Summary
- add `useDashboard` hook for summary data
- load dashboard KPIs and insights via new hook with skeleton placeholders
- make KPI and insight cards tolerant of API errors

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q`
- `pre-commit run --files services/ui/lib/query.ts services/ui/components/dashboard/KpiCard.tsx services/ui/components/dashboard/InsightCard.tsx 'services/ui/app/(dashboard)/page.tsx'`


------
https://chatgpt.com/codex/tasks/task_e_68c26100c1048333836bd38f9cf8fbdf