### PR TITLE
feat(ui): enhance filter bar with switch and slider

### DIFF
--- a/services/ui/components/recs/FiltersBar.tsx
+++ b/services/ui/components/recs/FiltersBar.tsx
@@ -1,5 +1,10 @@
 'use client';
 
+import { useEffect, useRef, useState } from 'react';
+import { Button } from '../ui/button';
+import { Switch } from '../ui/switch';
+import { Slider } from '../ui/slider';
+
 interface Filters {
   newOnly: boolean;
   freshness: number;
@@ -12,56 +17,117 @@ interface Props {
   onChange: (f: Filters) => void;
 }
 
+const DEFAULTS: Filters = {
+  newOnly: false,
+  freshness: 0,
+  diversity: 0,
+  energy: 0,
+};
+
 export default function FiltersBar({ filters, onChange }: Props) {
+  const [draft, setDraft] = useState<Filters>(filters);
+  const first = useRef(true);
+  const timeout = useRef<NodeJS.Timeout>();
+
+  useEffect(() => {
+    setDraft(filters);
+  }, [filters]);
+
+  useEffect(() => {
+    if (first.current) {
+      first.current = false;
+      return;
+    }
+    if (timeout.current) clearTimeout(timeout.current);
+    timeout.current = setTimeout(() => onChange(draft), 300);
+    return () => {
+      if (timeout.current) clearTimeout(timeout.current);
+    };
+  }, [draft, onChange]);
+
+  const apply = () => {
+    if (timeout.current) clearTimeout(timeout.current);
+    onChange(draft);
+  };
+
   return (
-    <div className="flex flex-wrap items-center gap-4 text-sm">
-      <label className="flex items-center gap-2">
-        <input
-          type="checkbox"
-          checked={filters.newOnly}
-          onChange={() => onChange({ ...filters, newOnly: !filters.newOnly })}
-        />
-        New artists only
-      </label>
-      <label className="flex items-center gap-2">
-        Min freshness
-        <input
-          type="range"
-          min={0}
-          max={1}
-          step={0.1}
-          value={filters.freshness}
-          onChange={(e) =>
-            onChange({ ...filters, freshness: parseFloat(e.target.value) })
-          }
-        />
-      </label>
-      <label className="flex items-center gap-2">
-        Diversity
-        <input
-          type="range"
-          min={0}
-          max={1}
-          step={0.1}
-          value={filters.diversity}
-          onChange={(e) =>
-            onChange({ ...filters, diversity: parseFloat(e.target.value) })
-          }
-        />
-      </label>
-      <label className="flex items-center gap-2">
-        Energy
-        <input
-          type="range"
-          min={0}
-          max={1}
-          step={0.1}
-          value={filters.energy}
-          onChange={(e) =>
-            onChange({ ...filters, energy: parseFloat(e.target.value) })
-          }
-        />
-      </label>
+    <div className="space-y-4 text-sm">
+      <div className="space-y-2">
+        <span className="font-medium">Artist filters</span>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <span>New artists only</span>
+            {draft.newOnly && (
+              <span className="rounded-full bg-emerald-500/15 px-2 py-0.5 text-xs text-emerald-300">
+                On
+              </span>
+            )}
+          </div>
+          <Switch
+            checked={draft.newOnly}
+            onCheckedChange={(checked) => setDraft({ ...draft, newOnly: checked })}
+          />
+        </div>
+      </div>
+      <div className="space-y-2">
+        <span className="font-medium">Track attributes</span>
+        <div className="space-y-4">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <span>Min freshness</span>
+              {draft.freshness > DEFAULTS.freshness && (
+                <span className="rounded-full bg-emerald-500/15 px-2 py-0.5 text-xs text-emerald-300">
+                  {draft.freshness.toFixed(1)}
+                </span>
+              )}
+            </div>
+            <Slider
+              value={[draft.freshness]}
+              min={0}
+              max={1}
+              step={0.1}
+              onValueChange={(v) => setDraft({ ...draft, freshness: v[0] })}
+            />
+          </div>
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <span>Diversity</span>
+              {draft.diversity > DEFAULTS.diversity && (
+                <span className="rounded-full bg-emerald-500/15 px-2 py-0.5 text-xs text-emerald-300">
+                  {draft.diversity.toFixed(1)}
+                </span>
+              )}
+            </div>
+            <Slider
+              value={[draft.diversity]}
+              min={0}
+              max={1}
+              step={0.1}
+              onValueChange={(v) => setDraft({ ...draft, diversity: v[0] })}
+            />
+          </div>
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <span>Energy</span>
+              {draft.energy > DEFAULTS.energy && (
+                <span className="rounded-full bg-emerald-500/15 px-2 py-0.5 text-xs text-emerald-300">
+                  {draft.energy.toFixed(1)}
+                </span>
+              )}
+            </div>
+            <Slider
+              value={[draft.energy]}
+              min={0}
+              max={1}
+              step={0.1}
+              onValueChange={(v) => setDraft({ ...draft, energy: v[0] })}
+            />
+          </div>
+        </div>
+      </div>
+      <Button type="button" onClick={apply} className="mt-2">
+        Apply
+      </Button>
     </div>
   );
 }

--- a/services/ui/components/ui/slider.tsx
+++ b/services/ui/components/ui/slider.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import * as SliderPrimitive from '@radix-ui/react-slider';
+import { cn } from '../../lib/utils';
+
+const Slider = React.forwardRef<
+  React.ElementRef<typeof SliderPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <SliderPrimitive.Root
+    ref={ref}
+    className={cn('relative flex w-full touch-none select-none items-center', className)}
+    {...props}
+  >
+    <SliderPrimitive.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-secondary">
+      <SliderPrimitive.Range className="absolute h-full bg-primary" />
+    </SliderPrimitive.Track>
+    <SliderPrimitive.Thumb className="block h-4 w-4 rounded-full border-2 border-primary bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50" />
+  </SliderPrimitive.Root>
+));
+Slider.displayName = SliderPrimitive.Root.displayName;
+
+export { Slider };

--- a/services/ui/components/ui/switch.tsx
+++ b/services/ui/components/ui/switch.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import * as SwitchPrimitive from '@radix-ui/react-switch';
+import { cn } from '../../lib/utils';
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitive.Root
+    className={cn(
+      'peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input',
+      className,
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitive.Thumb
+      className="pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0"
+    />
+  </SwitchPrimitive.Root>
+));
+Switch.displayName = SwitchPrimitive.Root.displayName;
+
+export { Switch };


### PR DESCRIPTION
## Summary
- add Radix-based Switch and Slider components for consistent theming
- revamp recommendation FiltersBar with grouped controls, badges, and Apply button
- debounce filter changes before invoking onChange

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -vv`


------
https://chatgpt.com/codex/tasks/task_e_68c2610e6710833385d08ad349359c43