### PR TITLE
feat: add nav feature flags and accessibility

### DIFF
--- a/services/ui/app/providers.tsx
+++ b/services/ui/app/providers.tsx
@@ -3,13 +3,16 @@
 import { useState } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider } from '../lib/auth';
+import { NavProvider } from '../components/NavContext';
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   const [queryClient] = useState(() => new QueryClient());
 
   return (
     <AuthProvider>
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      <QueryClientProvider client={queryClient}>
+        <NavProvider>{children}</NavProvider>
+      </QueryClientProvider>
     </AuthProvider>
   );
 }

--- a/services/ui/components/MobileNav.tsx
+++ b/services/ui/components/MobileNav.tsx
@@ -4,6 +4,7 @@ import { usePathname } from 'next/navigation';
 import clsx from 'clsx';
 import * as Icons from 'lucide-react';
 import nav from '../nav.json';
+import useFeatureFlag from '../hooks/useFeatureFlag';
 
 type NavItem = {
   path: string;
@@ -16,15 +17,22 @@ const items = nav as NavItem[];
 
 export default function MobileNav() {
   const pathname = usePathname();
+  const visibleItems = items.filter((item) => useFeatureFlag(item.featureFlag));
   return (
-    <nav className="fixed bottom-0 left-0 right-0 z-40 flex border-t border-white/10 bg-black/70 p-2 backdrop-blur md:hidden">
-      {items.map((item) => {
+    <nav
+      className="fixed bottom-0 left-0 right-0 z-40 flex border-t border-white/10 bg-black/70 p-2 backdrop-blur md:hidden"
+      aria-label="Primary"
+    >
+      {visibleItems.map((item, idx) => {
         const Icon = Icons[item.icon];
         const active = pathname === item.path || pathname.startsWith(`${item.path}/`);
         return (
           <Link
             key={item.path}
             href={item.path}
+            aria-label={item.label}
+            aria-current={active ? 'page' : undefined}
+            accessKey={(idx + 1).toString()}
             className={clsx(
               'flex flex-1 min-h-[48px] flex-col items-center justify-center gap-1 rounded-md p-3 text-sm',
               active ? 'text-emerald-300' : 'text-muted-foreground hover:text-foreground',

--- a/services/ui/components/NavContext.tsx
+++ b/services/ui/components/NavContext.tsx
@@ -1,12 +1,36 @@
 'use client';
-import { createContext, useContext } from 'react';
+import { createContext, useContext, useEffect, useState } from 'react';
 
 export type NavContextValue = {
   collapsed: boolean;
   setCollapsed: (v: boolean) => void;
 };
 
+const STORAGE_KEY = 'sidebar-collapsed';
+
 export const NavContext = createContext<NavContextValue | null>(null);
+
+export function NavProvider({ children }: { children: React.ReactNode }) {
+  const [collapsed, setCollapsed] = useState(false);
+
+  // Hydrate from localStorage on mount
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored !== null) {
+      setCollapsed(stored === 'true');
+    } else if (window.innerWidth < 768) {
+      // default to collapsed on small screens
+      setCollapsed(true);
+    }
+  }, []);
+
+  // Persist to localStorage whenever value changes
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, collapsed.toString());
+  }, [collapsed]);
+
+  return <NavContext.Provider value={{ collapsed, setCollapsed }}>{children}</NavContext.Provider>;
+}
 
 export function useNav() {
   const ctx = useContext(NavContext);

--- a/services/ui/components/NavRail.tsx
+++ b/services/ui/components/NavRail.tsx
@@ -8,6 +8,7 @@ import * as Icons from 'lucide-react';
 import nav from '../nav.json';
 import { useNav } from './NavContext';
 import Avatar from './ui/Avatar';
+import useFeatureFlag from '../hooks/useFeatureFlag';
 
 const { ChevronLeft, ChevronRight } = Icons;
 
@@ -23,6 +24,7 @@ const items = nav as NavItem[];
 export default function NavRail() {
   const pathname = usePathname();
   const { collapsed, setCollapsed } = useNav();
+  const visibleItems = items.filter((item) => useFeatureFlag(item.featureFlag));
   return (
     <div className="flex h-full flex-col gap-2 p-3 glass">
       <div className="flex items-center gap-2 px-2 py-3">
@@ -30,8 +32,8 @@ export default function NavRail() {
         {!collapsed && <strong className="text-lg">SideTrack</strong>}
       </div>
       <Tooltip.Provider>
-        <nav className="flex flex-col gap-2">
-          {items.map((item) => {
+        <nav className="flex flex-col gap-2" aria-label="Primary">
+          {visibleItems.map((item, idx) => {
             const Icon = Icons[item.icon];
             const active = pathname === item.path || pathname.startsWith(`${item.path}/`);
             return (
@@ -39,6 +41,9 @@ export default function NavRail() {
                 <Tooltip.Trigger asChild>
                   <Link
                     href={item.path}
+                    aria-label={item.label}
+                    aria-current={active ? 'page' : undefined}
+                    accessKey={(idx + 1).toString()}
                     className={clsx(
                       'relative flex h-11 items-center gap-3 rounded-lg px-4 text-sm transition-colors',
                       active
@@ -81,6 +86,8 @@ export default function NavRail() {
       </Tooltip.Provider>
       <button
         onClick={() => setCollapsed(!collapsed)}
+        aria-label={collapsed ? 'Expand navigation' : 'Collapse navigation'}
+        accessKey="b"
         className="mt-auto flex h-11 items-center gap-2 px-4 text-sm text-muted-foreground"
       >
         {collapsed ? <ChevronRight size={16} /> : <ChevronLeft size={16} />}

--- a/services/ui/hooks/useFeatureFlag.ts
+++ b/services/ui/hooks/useFeatureFlag.ts
@@ -1,0 +1,10 @@
+'use client';
+
+export default function useFeatureFlag(flag?: string | null) {
+  const flags = (process.env.NEXT_PUBLIC_FEATURE_FLAGS || '')
+    .split(',')
+    .map((f) => f.trim())
+    .filter(Boolean);
+  if (!flag) return true;
+  return flags.includes(flag);
+}


### PR DESCRIPTION
## Summary
- persist nav collapse state in context using localStorage
- gate navigation items behind feature flags
- improve nav accessibility with ARIA labels and keyboard shortcuts

## Testing
- `pytest -q`
- `cd services/ui && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2611495f48333a53ad3c18bd9b345