### PR TITLE
feat(ui): optimize artwork fetching

### DIFF
--- a/services/ui/app/api/artwork/route.ts
+++ b/services/ui/app/api/artwork/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+/**
+ * Fetch artwork URLs for given track identifiers. Results are cached by
+ * Next.js' built-in fetch caching to avoid repeated lookups.
+ */
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const spotifyId = searchParams.get('spotify_id');
+  const recordingMbid = searchParams.get('recording_mbid');
+
+  let url: string | null = null;
+
+  try {
+    if (spotifyId) {
+      const r = await fetch(
+        `https://open.spotify.com/oembed?url=spotify:track:${spotifyId}`,
+        { next: { revalidate: 60 * 60 * 24 } },
+      );
+      const j = await r.json();
+      url = j?.thumbnail_url ?? null;
+    } else if (recordingMbid) {
+      const r = await fetch(
+        `https://coverartarchive.org/release/${recordingMbid}/front`,
+        { next: { revalidate: 60 * 60 * 24 } },
+      );
+      if (r.ok) {
+        // coverartarchive returns the image directly
+        url = r.url;
+      }
+    }
+  } catch {
+    // Ignore errors and return null
+  }
+
+  return NextResponse.json({ url });
+}
+

--- a/services/ui/components/recs/RecCard.tsx
+++ b/services/ui/components/recs/RecCard.tsx
@@ -4,6 +4,8 @@ import Image from 'next/image';
 import { useEffect, useRef, useState } from 'react';
 import BecauseChips from './BecauseChips';
 import RecActions from './RecActions';
+import Skeleton from '../Skeleton';
+import { getArtworkUrl } from '../../lib/artwork';
 import type { Reason } from '../../lib/sources';
 
 export type Rec = {
@@ -23,16 +25,15 @@ interface Props {
 
 export default function RecCard({ rec, onLike, onSkip, onHideArtist }: Props) {
   const [img, setImg] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
   const startX = useRef<number | null>(null);
 
   useEffect(() => {
-    if (rec.spotify_id) {
-      fetch(`https://open.spotify.com/oembed?url=spotify:track:${rec.spotify_id}`)
-        .then((r) => r.json())
-        .then((j) => setImg(j?.thumbnail_url))
-        .catch(() => {});
-    }
-  }, [rec.spotify_id]);
+    setLoading(true);
+    getArtworkUrl(rec.spotify_id, rec.recording_mbid)
+      .then((url) => setImg(url))
+      .finally(() => setLoading(false));
+  }, [rec.spotify_id, rec.recording_mbid]);
 
   return (
     <div
@@ -48,9 +49,11 @@ export default function RecCard({ rec, onLike, onSkip, onHideArtist }: Props) {
         startX.current = null;
       }}
     >
-      {img && (
+      {loading ? (
+        <Skeleton className="h-[300px]" />
+      ) : (
         <Image
-          src={img}
+          src={img ?? '/default-cover.svg'}
           alt={`${rec.title} cover`}
           width={300}
           height={300}

--- a/services/ui/lib/artwork.ts
+++ b/services/ui/lib/artwork.ts
@@ -1,0 +1,33 @@
+const cache = new Map<string, string | null>();
+
+export async function getArtworkUrl(
+  spotifyId?: string,
+  recordingMbid?: string,
+): Promise<string | null> {
+  const key = spotifyId
+    ? `spotify:${spotifyId}`
+    : recordingMbid
+      ? `mbid:${recordingMbid}`
+      : null;
+  if (!key) return null;
+  if (cache.has(key)) return cache.get(key)!;
+
+  try {
+    const params = new URLSearchParams();
+    if (spotifyId) params.set('spotify_id', spotifyId);
+    if (recordingMbid) params.set('recording_mbid', recordingMbid);
+    const r = await fetch(`/api/artwork?${params.toString()}`);
+    if (!r.ok) {
+      cache.set(key, null);
+      return null;
+    }
+    const j = await r.json();
+    const url = j?.url ?? null;
+    cache.set(key, url);
+    return url;
+  } catch {
+    cache.set(key, null);
+    return null;
+  }
+}
+

--- a/services/ui/next.config.mjs
+++ b/services/ui/next.config.mjs
@@ -1,6 +1,25 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'standalone',
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'i.scdn.co',
+        pathname: '/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'coverartarchive.org',
+        pathname: '/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'lastfm.freetls.fastly.net',
+        pathname: '/**',
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/services/ui/public/default-cover.svg
+++ b/services/ui/public/default-cover.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 300">
+  <rect width="300" height="300" fill="#e5e7eb"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="48" fill="#9ca3af">🎵</text>
+</svg>
+


### PR DESCRIPTION
## Summary
- allow remote images from Spotify, Cover Art Archive, and Last.fm
- add server-side artwork lookup with basic caching
- show skeleton and default artwork while covers load

## Testing
- `npm test -s`
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/eslint-plugin')*
- `pip install -r requirements-dev.txt`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2612800048333a66b9d079494102b