### PR TITLE
fix(ui): wrap app providers with ToastProvider

### DIFF
--- a/services/ui/app/providers.tsx
+++ b/services/ui/app/providers.tsx
@@ -4,13 +4,16 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { AuthProvider } from '../lib/auth';
 import { queryClient } from '../lib/query';
 import { NavProvider } from '../components/NavContext';
+import ToastProvider from '../components/ToastProvider';
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   return (
-    <AuthProvider>
-      <QueryClientProvider client={queryClient}>
-        <NavProvider>{children}</NavProvider>
-      </QueryClientProvider>
-    </AuthProvider>
+    <ToastProvider>
+      <AuthProvider>
+        <QueryClientProvider client={queryClient}>
+          <NavProvider>{children}</NavProvider>
+        </QueryClientProvider>
+      </AuthProvider>
+    </ToastProvider>
   );
 }


### PR DESCRIPTION
## Summary
- wrap app `Providers` with `ToastProvider` so `useToast` has context

## Testing
- `pytest -q`
- `(cd services/ui && npm test)`

------
https://chatgpt.com/codex/tasks/task_e_68c276d8c04c8333bc51c5e1361b49bd