### PR TITLE
Add dev test extras and update setup docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,7 @@
 
 1. Install dependencies:
    ```bash
-   pip install -r requirements-dev.txt
-   pip install -e .
+   pip install -e ".[api,extractor,scheduler,worker,dev]"
    ```
 2. Run tests:
    ```bash

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Developer tooling (optional):
 
 ```bash
 python3.11 -m venv .venv && source .venv/bin/activate
-pip install pre-commit
+pip install -e ".[api,extractor,scheduler,worker,dev]"
 pre-commit install && pre-commit run --all-files
 ```
 
@@ -261,6 +261,14 @@ http://localhost:3000
 ---
 
 ## Testing
+
+Set up a virtual environment and install the test dependencies:
+
+```bash
+python3.11 -m venv .venv && source .venv/bin/activate
+pip install -e ".[api,extractor,scheduler,worker,dev]"
+pytest -q
+```
 
 See [`tests/README.md`](tests/README.md) for the full pyramid, speed budget and
 fixture layout.

--- a/conftest.py
+++ b/conftest.py
@@ -11,7 +11,7 @@ from pytest_socket import disable_socket, enable_socket, socket_allow_hosts
 from sidetrack.api import main as api_main
 from sidetrack.api.config import ApiSettings
 
-pytest_plugins = ["services.tests.conftest"]
+from services.tests.conftest import *  # noqa: F401,F403
 
 _MARKERS = ["unit", "integration", "contract", "slow", "gpu", "e2e"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,19 @@ worker = [
     "fakeredis==2.23.2",
 ]
 
+dev = [
+    "pytest==7.4.4",
+    "pytest-cov==5.0.0",
+    "testcontainers[postgres,redis]==4.7.1",
+    "factory-boy==3.3.0",
+    "pre-commit==3.7.0",
+    "docker==7.1.0",
+    "freezegun==1.5.1",
+    "pytest-socket==0.7.0",
+    "syrupy==4.6.0",
+    "respx==0.20.2",
+]
+
 [tool.setuptools.packages.find]
 include = ["sidetrack*"]
 

--- a/sidetrack/api/api/v1/recs.py
+++ b/sidetrack/api/api/v1/recs.py
@@ -11,9 +11,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from sidetrack.common.models import UserSettings
 from sidetrack.services.candidates import generate_candidates
-from sidetrack.services.lastfm import LastfmService
 from sidetrack.services.listenbrainz import ListenBrainzClient
-from sidetrack.services.mb_map import recording_by_isrc
+from sidetrack.services.musicbrainz import MusicBrainzService
 from sidetrack.services.ranker import profile_from_spotify, rank
 from sidetrack.services.spotify import SpotifyService
 from ...clients.lastfm import LastfmClient

--- a/sidetrack/services/candidates.py
+++ b/sidetrack/services/candidates.py
@@ -6,7 +6,6 @@ from typing import Any
 
 
 from sidetrack.api.clients.lastfm import LastfmClient
-from .lastfm import LastfmService
 from .listenbrainz import ListenBrainzClient
 
 from .spotify import SpotifyService


### PR DESCRIPTION
## Summary
- add `[dev]` extra with testing dependencies
- fix stale service imports and expose shared fixtures
- document new dev/test install instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5d03429e48333956d486d5ad4e760