### PR TITLE
Refactor candidate generation with dataclass and dedupe helpers

### DIFF
--- a/tests/services/__snapshots__/test_listenbrainz.ambr
+++ b/tests/services/__snapshots__/test_listenbrainz.ambr
@@ -23,7 +23,9 @@
       'recording_mbid': 'rec1',
       'score_cf': 0.9,
       'seeds': dict({
-        'user': 'alice',
+        'user': list([
+          'alice',
+        ]),
       }),
       'source': 'listenbrainz',
       'spotify_id': None,
@@ -35,7 +37,9 @@
       'recording_mbid': 'rec2',
       'score_cf': 0.8,
       'seeds': dict({
-        'user': 'alice',
+        'user': list([
+          'alice',
+        ]),
       }),
       'source': 'listenbrainz',
       'spotify_id': None,


### PR DESCRIPTION
## Summary
- Introduce `Candidate` dataclass and helpers for normalization and deduplication
- Refactor candidate generators to use shared helpers and return consistent seeds
- Update ListenBrainz snapshot for new candidate structure

## Testing
- `pip install -e ".[api,extractor,scheduler,worker,dev]"`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5d8ae20cc83339a5a4e365b695481