### PR TITLE
Handle unexpected ListenBrainz responses

### DIFF
--- a/tests/services/__snapshots__/test_listenbrainz.ambr
+++ b/tests/services/__snapshots__/test_listenbrainz.ambr
@@ -1,5 +1,37 @@
 # serializer version: 1
-# name: test_get_cf_recommendations_contract
+# name: test_get_cf_recommendations_contract[recommendations]
+  list([
+    dict({
+      'artist_name': 'Artist A',
+      'recording_mbid': 'rec1',
+      'recording_name': 'Track A',
+      'score': 0.9,
+    }),
+    dict({
+      'artist_name': 'Artist B',
+      'recording_mbid': 'rec2',
+      'recording_name': 'Track B',
+      'score': 0.8,
+    }),
+  ])
+# ---
+# name: test_get_cf_recommendations_contract[recordings]
+  list([
+    dict({
+      'artist_name': 'Artist A',
+      'recording_mbid': 'rec1',
+      'recording_name': 'Track A',
+      'score': 0.9,
+    }),
+    dict({
+      'artist_name': 'Artist B',
+      'recording_mbid': 'rec2',
+      'recording_name': 'Track B',
+      'score': 0.8,
+    }),
+  ])
+# ---
+# name: test_get_cf_recommendations_contract[recommended_recordings]
   list([
     dict({
       'artist_name': 'Artist A',


### PR DESCRIPTION
## Summary
- harden ListenBrainz client against unknown recommendation payloads
- log and raise on invalid recommendation formats
- test and snapshot all documented ListenBrainz response shapes

## Testing
- `pip install -e ".[api,extractor,scheduler,worker,dev]"`
- `pytest tests/services/test_listenbrainz.py -q`
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68c655c10fac8333971e7b94fe78a1ac