### PR TITLE
Add listen conversion helpers for Spotify and Last.fm

### DIFF
--- a/tests/services/test_listen_service_converters.py
+++ b/tests/services/test_listen_service_converters.py
@@ -1,0 +1,79 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from sidetrack.api.services.listen_service import ListenService
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("socket_enabled")
+async def test_ingest_spotify_rows_converts_and_filters_items():
+    service = ListenService(AsyncMock(), AsyncMock(), AsyncMock(), AsyncMock())
+    service.ingest_lb_rows = AsyncMock(return_value=0)
+
+    items = [
+        {
+            "track": {
+                "artists": [{"name": "Artist"}],
+                "name": "Title",
+                "mbid": "mbid1",
+            },
+            "played_at": "2024-01-01T00:00:00Z",
+        },
+        {  # missing artist
+            "track": {"name": "No Artist"},
+            "played_at": "2024-01-01T00:00:01Z",
+        },
+        {  # missing title
+            "track": {"artists": [{"name": "No Title"}]},
+            "played_at": "2024-01-01T00:00:02Z",
+        },
+        {  # bad timestamp
+            "track": {"artists": [{"name": "Bad"}], "name": "Time"},
+            "played_at": "not-a-date",
+        },
+    ]
+
+    await service.ingest_spotify_rows(items, "tester")
+
+    service.ingest_lb_rows.assert_awaited_once()
+    rows = service.ingest_lb_rows.await_args.args[0]
+    assert len(rows) == 3
+    assert rows[1]["track_metadata"]["artist_name"] is None
+    assert rows[2]["track_metadata"]["track_name"] is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("socket_enabled")
+async def test_ingest_lastfm_rows_converts_and_filters_tracks():
+    service = ListenService(AsyncMock(), AsyncMock(), AsyncMock(), AsyncMock())
+    service.ingest_lb_rows = AsyncMock(return_value=0)
+
+    tracks = [
+        {
+            "artist": {"#text": "Artist"},
+            "name": "Title",
+            "date": {"uts": "1704067200"},
+        },
+        {  # missing artist
+            "name": "No Artist",
+            "date": {"uts": "1704067201"},
+        },
+        {  # missing title
+            "artist": {"#text": "No Title"},
+            "date": {"uts": "1704067202"},
+        },
+        {  # bad timestamp
+            "artist": {"#text": "Bad"},
+            "name": "Time",
+            "date": {"uts": "bad"},
+        },
+    ]
+
+    await service.ingest_lastfm_rows(tracks, "tester")
+
+    service.ingest_lb_rows.assert_awaited_once()
+    rows = service.ingest_lb_rows.await_args.args[0]
+    assert len(rows) == 3
+    assert rows[1]["track_metadata"]["artist_name"] is None
+    assert rows[2]["track_metadata"]["track_name"] is None


### PR DESCRIPTION
## Summary
- add `convert_spotify_item` and `convert_lastfm_track` helpers to normalize listen payloads
- refactor ingestion methods to reuse helpers and handle invalid data
- cover missing fields and bad timestamps in unit tests

## Testing
- `SKIP=prettier,eslint-ui pre-commit run --files sidetrack/api/services/listen_service.py tests/services/test_listen_service_converters.py`
- `pytest tests/services/test_listen_service_converters.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c655cfa77c8333aa419d23affea8bb