### PR TITLE
Refactor weekly insights to commit atomically

### DIFF
--- a/tests/services/test_insights.py
+++ b/tests/services/test_insights.py
@@ -1,0 +1,75 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from sidetrack.common.models import Listen, Track
+from sidetrack.services.insights import InsightEvent, compute_weekly_insights
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_compute_weekly_insights_commits_once(async_session, monkeypatch):
+    now = datetime.now(UTC)
+    t1 = Track(title="t1")
+    t2 = Track(title="t2")
+    async_session.add_all([t1, t2])
+    await async_session.flush()
+
+    listens = [
+        Listen(user_id="u1", track_id=t1.track_id, played_at=now - timedelta(days=1)),
+        Listen(user_id="u1", track_id=t2.track_id, played_at=now - timedelta(days=2)),
+    ]
+    async_session.add_all(listens)
+    await async_session.commit()
+
+    calls = 0
+    orig_commit = AsyncSession.commit
+
+    async def counted_commit(self):
+        nonlocal calls
+        calls += 1
+        await orig_commit(self)
+
+    monkeypatch.setattr(AsyncSession, "commit", counted_commit)
+
+    events = await compute_weekly_insights(async_session, "u1")
+    assert calls == 1
+    assert {e.type for e in events} == {"weekly_listens", "weekly_unique_tracks"}
+
+    rows = (
+        (await async_session.execute(select(InsightEvent).where(InsightEvent.user_id == "u1")))
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 2
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_compute_weekly_insights_rolls_back(async_session, monkeypatch):
+    now = datetime.now(UTC)
+    t = Track(title="t1")
+    async_session.add(t)
+    await async_session.flush()
+    async_session.add_all(
+        [Listen(user_id="u1", track_id=t.track_id, played_at=now - timedelta(days=1))]
+    )
+    await async_session.commit()
+
+    async def failing_commit(self):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(AsyncSession, "commit", failing_commit)
+
+    with pytest.raises(RuntimeError):
+        await compute_weekly_insights(async_session, "u1")
+
+    await async_session.rollback()
+    rows = (
+        (await async_session.execute(select(InsightEvent).where(InsightEvent.user_id == "u1")))
+        .scalars()
+        .all()
+    )
+    assert rows == []


### PR DESCRIPTION
## Summary
- Generate weekly insight events without interim commits and batch persistence inside a transaction
- Support multiple insight types, including unique track counts, prior to a single commit
- Add tests ensuring insight events commit only once and rollback on failure

## Testing
- `pip install -e ".[api,extractor,scheduler,worker,dev]"`
- `pytest tests/services/test_insights.py -q` *(skipped: Docker not available)*
- `pytest -q` *(failed: hung/keyboard interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68c65f2eb1748333878c515e48838a04