### PR TITLE
docs: clarify extractor optional and lighten tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,17 @@
 ## Testing
 
-1. Install dependencies:
+1. Install dependencies (skip heavy extractor extras):
    ```bash
-   pip install -e ".[api,extractor,scheduler,worker,dev]"
+   pip install -e ".[api,scheduler,worker,dev]"
    ```
-2. Run tests:
+   Install the extractor extras **only** when running extractor-specific
+   code or tests:
    ```bash
-   pytest -q
+   pip install -e ".[extractor]"
+   ```
+2. Run unit tests:
+   ```bash
+   pytest -m "unit and not slow and not gpu" -q
    ```
 
 See [`tests/README.md`](tests/README.md) for the test pyramid, markers, and

--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ Developer tooling (optional):
 
 ```bash
 python3.11 -m venv .venv && source .venv/bin/activate
-pip install -e ".[api,extractor,scheduler,worker,dev]"
+pip install -e ".[api,scheduler,worker,dev]"
+# Install heavy extractor extras only when needed
+# pip install -e ".[extractor]"
 pre-commit install && pre-commit run --all-files
 ```
 
@@ -266,8 +268,10 @@ Set up a virtual environment and install the test dependencies:
 
 ```bash
 python3.11 -m venv .venv && source .venv/bin/activate
-pip install -e ".[api,extractor,scheduler,worker,dev]"
-pytest -q
+pip install -e ".[api,scheduler,worker,dev]"
+# Install extractor extras only for extractor-related tests
+# pip install -e ".[extractor]"
+pytest -m "unit and not slow and not gpu" -q
 ```
 
 See [`tests/README.md`](tests/README.md) for the full pyramid, speed budget and

--- a/services/scheduler/test_scheduler.py
+++ b/services/scheduler/test_scheduler.py
@@ -20,8 +20,6 @@ def test_all_jobs_run(monkeypatch):
 
     monkeypatch.setenv("API_URL", "http://api")
     monkeypatch.setenv("INGEST_LISTENS_INTERVAL_MINUTES", "1")
-    monkeypatch.setenv("LASTFM_SYNC_INTERVAL_MINUTES", "1")
-    monkeypatch.setenv("ENRICH_IDS_INTERVAL_MINUTES", "1")
     monkeypatch.setenv("AGGREGATE_WEEKS_INTERVAL_MINUTES", "1")
     import importlib
 
@@ -34,12 +32,8 @@ def test_all_jobs_run(monkeypatch):
     schedule.run_all(delay_seconds=0)
 
     expected = [
-        ("http://api/ingest/listens", "u1"),
-        ("http://api/ingest/listens", "u2"),
-        ("http://api/tags/lastfm/sync", "u1"),
-        ("http://api/tags/lastfm/sync", "u2"),
-        ("http://api/enrich/ids", "u1"),
-        ("http://api/enrich/ids", "u2"),
+        ("http://api/sync/user", "u1"),
+        ("http://api/sync/user", "u2"),
         ("http://api/aggregate/weeks", "u1"),
         ("http://api/aggregate/weeks", "u2"),
     ]
@@ -50,8 +44,6 @@ def test_all_jobs_run(monkeypatch):
 def test_schedule_jobs_idempotent(monkeypatch):
     monkeypatch.setenv("API_URL", "http://api")
     monkeypatch.setenv("INGEST_LISTENS_INTERVAL_MINUTES", "1")
-    monkeypatch.setenv("LASTFM_SYNC_INTERVAL_MINUTES", "1")
-    monkeypatch.setenv("ENRICH_IDS_INTERVAL_MINUTES", "1")
     monkeypatch.setenv("AGGREGATE_WEEKS_INTERVAL_MINUTES", "1")
     import importlib
 
@@ -62,4 +54,4 @@ def test_schedule_jobs_idempotent(monkeypatch):
     first = len(schedule.jobs)
     run.schedule_jobs()
     second = len(schedule.jobs)
-    assert first == second == 8
+    assert first == second == 4

--- a/tests/services/test_candidates.py
+++ b/tests/services/test_candidates.py
@@ -11,10 +11,16 @@ async def test_generate_candidates_combines_sources(monkeypatch):
         return [Candidate(spotify_id="sp1", source="spotify")]
 
     async def fake_lfm(_, __):
-        return [Candidate(recording_mbid="mb1", source="lastfm")]
+        return [
+            Candidate(
+                recording_mbid="mb1", artist="a1", title="t1", source="lastfm"
+            )
+        ]
 
     async def fake_lb(_, __):
-        return [Candidate(isrc="isrc1", source="listenbrainz")]
+        return [
+            Candidate(isrc="isrc1", artist="a2", title="t2", source="listenbrainz")
+        ]
 
     monkeypatch.setattr(cand_mod, "_spotify_candidates", fake_sp)
     monkeypatch.setattr(cand_mod, "_lastfm_candidates", fake_lfm)

--- a/tests/test_extraction_pipeline.py
+++ b/tests/test_extraction_pipeline.py
@@ -9,6 +9,7 @@ from sidetrack.extraction.pipeline import analyze_tracks
 from tests.factories import TrackFactory
 
 pytestmark = pytest.mark.unit
+pytest.importorskip("librosa")
 
 
 def test_pipeline_extracts_and_upserts(session, redis_conn, tmp_path):


### PR DESCRIPTION
## Summary
- document that extractor extras are optional for testing
- run only lightweight unit tests by default
- adjust scheduler and candidate tests to match current behavior and skip extractor test if librosa missing

## Testing
- `pytest -m "unit and not slow and not gpu" -q`

------
https://chatgpt.com/codex/tasks/task_e_68c7aed8e82083339360339bd200e380