### PR TITLE
refactor: migrate extractor run to extraction CLI

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -57,7 +57,7 @@ services:
         condition: service_started
       db:
         condition: service_healthy
-    command: python -m sidetrack.extractor.run --schedule "@daily"
+    command: python -m sidetrack.extraction --schedule "@daily"
 
   scheduler:
     build:

--- a/services/extractor/Dockerfile
+++ b/services/extractor/Dockerfile
@@ -11,6 +11,6 @@ FROM sidetrack/base:dev AS runtime
 RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local /usr/local
-RUN python -c "import sidetrack; print('extractor runtime deps OK')"
+RUN python -c "import sidetrack; print('extraction runtime deps OK')"
 
-CMD ["python", "-m", "sidetrack.extractor.run", "--schedule", "@daily"]
+CMD ["python", "-m", "sidetrack.extraction", "--schedule", "@daily"]

--- a/sidetrack/extraction/__main__.py
+++ b/sidetrack/extraction/__main__.py
@@ -1,0 +1,11 @@
+"""Entry point for ``python -m sidetrack.extraction``."""
+
+from .cli import app
+
+
+def main() -> None:
+    app()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    main()

--- a/sidetrack/extractor/.gitkeep
+++ b/sidetrack/extractor/.gitkeep
@@ -1,1 +1,0 @@
-# Keep this directory in git


### PR DESCRIPTION
## Summary
- add Typer-based CLI under `sidetrack.extraction`
- remove legacy `sidetrack.extractor` package
- update Docker/Docker Compose to call new module

## Testing
- `pre-commit run --files sidetrack/extraction/cli.py sidetrack/extraction/__main__.py compose.yml services/extractor/Dockerfile`
- `pytest -m "unit and not slow and not gpu"`


------
https://chatgpt.com/codex/tasks/task_e_68c7b27d8f20833382bb0f0581ce962d