### PR TITLE
refactor: invoke services directly in scheduler

### DIFF
--- a/services/scheduler/test_scheduler.py
+++ b/services/scheduler/test_scheduler.py
@@ -5,26 +5,17 @@ pytestmark = pytest.mark.unit
 
 
 def test_all_jobs_run(monkeypatch):
-    calls = []
+    calls: list[tuple[str, str]] = []
 
-    def fake_post(url, timeout=10, headers=None):
-        calls.append((url, headers.get("X-User-Id") if headers else None))
+    def fake_run_job(user_id: str, job_type: str, func):
+        calls.append((job_type, user_id))
 
-        class Resp:
-            status_code = 200
-
-            def json(self):
-                return {}
-
-        return Resp()
-
-    monkeypatch.setenv("API_URL", "http://api")
     monkeypatch.setenv("INGEST_LISTENS_INTERVAL_MINUTES", "1")
     monkeypatch.setenv("AGGREGATE_WEEKS_INTERVAL_MINUTES", "1")
     import importlib
 
     run = importlib.import_module("sidetrack.scheduler.run")
-    monkeypatch.setattr(run.requests, "post", fake_post)
+    monkeypatch.setattr(run, "_run_job", fake_run_job)
     monkeypatch.setattr(run, "fetch_user_ids", lambda: ["u1", "u2"])
 
     schedule.clear()
@@ -32,17 +23,16 @@ def test_all_jobs_run(monkeypatch):
     schedule.run_all(delay_seconds=0)
 
     expected = [
-        ("http://api/sync/user", "u1"),
-        ("http://api/sync/user", "u2"),
-        ("http://api/aggregate/weeks", "u1"),
-        ("http://api/aggregate/weeks", "u2"),
+        ("sync:user", "u1"),
+        ("sync:user", "u2"),
+        ("aggregate:weeks", "u1"),
+        ("aggregate:weeks", "u2"),
     ]
     for item in expected:
         assert item in calls
 
 
 def test_schedule_jobs_idempotent(monkeypatch):
-    monkeypatch.setenv("API_URL", "http://api")
     monkeypatch.setenv("INGEST_LISTENS_INTERVAL_MINUTES", "1")
     monkeypatch.setenv("AGGREGATE_WEEKS_INTERVAL_MINUTES", "1")
     import importlib


### PR DESCRIPTION
## Summary
- call datasync and aggregation services directly instead of HTTP posts
- simplify scheduler by removing URL and header handling
- adjust scheduler unit tests for service-driven execution

## Testing
- `pip install -e ".[api,scheduler,worker,dev]"`
- `pre-commit run --files sidetrack/scheduler/run.py services/scheduler/test_scheduler.py`
- `pytest -m "unit and not slow and not gpu" -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7b4b460dc8333bf3ffba438851011