### PR TITLE
Refactor embedding normalization into extraction module

### DIFF
--- a/services/worker/tests/test_jobs.py
+++ b/services/worker/tests/test_jobs.py
@@ -1,11 +1,11 @@
 import numpy as np
-import numpy as np
 import pytest
 import soundfile as sf
 from rq import Queue, SimpleWorker
 
 from sidetrack.api.db import SessionLocal
 from sidetrack.common.models import Feature
+from sidetrack.config.extraction import ExtractionConfig
 from sidetrack.extraction.pipeline import analyze_track
 from sidetrack.worker.jobs import compute_embeddings
 from tests.factories import TrackFactory
@@ -16,7 +16,10 @@ pytestmark = pytest.mark.integration
 def test_jobs_are_executed(redis_conn, tmp_path):
     """Jobs enqueued on RQ queues should be picked up and executed."""
     audio_path = tmp_path / "test_worker.wav"
-    sf.write(audio_path, np.zeros(1024), 22050)
+    data = np.array([0.0, 1.0, 2.0, 3.0])
+    sr = 22050
+    sf.write(audio_path, data, sr)
+    y, sr = sf.read(audio_path)
 
     with SessionLocal() as db:
         from sidetrack.common.models import Base
@@ -31,8 +34,9 @@ def test_jobs_are_executed(redis_conn, tmp_path):
     analysis_q = Queue("analysis", connection=redis_conn)
     scoring_q = Queue("scoring", connection=redis_conn)
 
-    job1 = analysis_q.enqueue(analyze_track, track_id)
-    job2 = scoring_q.enqueue(compute_embeddings, [1.0, 2.0, 3.0])
+    cfg = ExtractionConfig()
+    job1 = analysis_q.enqueue(analyze_track, track_id, cfg)
+    job2 = scoring_q.enqueue(compute_embeddings, track_id, y, sr, cfg)
 
     worker = SimpleWorker([analysis_q, scoring_q], connection=redis_conn)
     worker.work(burst=True)
@@ -41,4 +45,8 @@ def test_jobs_are_executed(redis_conn, tmp_path):
         feat = db.get(Feature, job1.result)
         assert feat and feat.track_id == track_id
 
-    assert job2.result == [round(x, 4) for x in [1 / 3, 2 / 3, 1.0]]
+    mean = float(np.mean(y))
+    std = float(np.std(y))
+    max_val = max(abs(mean), abs(std)) or 1.0
+    expected = [round(mean / max_val, 4), round(std / max_val, 4)]
+    assert job2.result == {"openl3": expected}

--- a/sidetrack/extraction/__init__.py
+++ b/sidetrack/extraction/__init__.py
@@ -1,0 +1,6 @@
+"""Extraction package exposing high level helpers."""
+
+from .embeddings import compute_embeddings
+
+__all__ = ["compute_embeddings"]
+

--- a/sidetrack/extraction/pipeline.py
+++ b/sidetrack/extraction/pipeline.py
@@ -14,7 +14,8 @@ from sidetrack.api.db import SessionLocal
 from sidetrack.common.models import Embedding, Feature, Track
 from sidetrack.config.extraction import ExtractionConfig
 
-from . import io, dsp, features as feat_mod, embeddings as emb_mod, stems, scoring
+from . import io, dsp, features as feat_mod, stems, scoring
+from sidetrack.extraction import compute_embeddings
 
 
 def _upsert_feature(db: Session, track_id: int, data: dict, dataset_version: str) -> None:
@@ -61,7 +62,7 @@ def analyze_tracks(db: Session, track_ids: Iterable[int], cfg: ExtractionConfig,
         if stem_model:
             source = "stems"
         feats.update({"source": source, "seconds": seconds, "model": stem_model})
-        embeds = emb_mod.compute_embeddings(tid, y, sr, cfg, redis_conn=redis_conn)
+        embeds = compute_embeddings(tid, y, sr, cfg, redis_conn=redis_conn)
         _upsert_feature(db, tid, feats, cfg.dataset_version)
         for name, vec in embeds.items():
             _upsert_embedding(db, tid, name, vec, cfg.dataset_version)

--- a/sidetrack/worker/jobs.py
+++ b/sidetrack/worker/jobs.py
@@ -19,34 +19,12 @@ from sidetrack.services.musicbrainz import MusicBrainzService
 # Heavy numerical deps are imported lazily inside functions to keep
 # API-only environments lightweight when importing this module.
 from sidetrack.services.spotify import SpotifyClient
+from sidetrack.extraction import compute_embeddings
 
 from .config import get_settings
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s:%(message)s")
 logger = logging.getLogger("worker")
-
-
-def compute_embeddings(data: list[float]) -> list[float]:
-    """Compute a simple normalised embedding vector.
-
-    Normalisation is performed by dividing each value by the largest absolute
-    value in ``data`` so that the output preserves the sign of the original
-    values while remaining within ``[-1, 1]``.
-
-    Args:
-        data: List of floats representing raw features.
-
-    Returns:
-        A list of floats normalised by the maximum absolute value.
-    """
-    if not data:
-        return []
-    max_val = max(abs(x) for x in data)
-    if max_val == 0:
-        return [0 for _ in data]
-    embeddings = [round(x / max_val, 4) for x in data]
-    logger.info("computed embeddings")
-    return embeddings
 
 
 KEYS = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]


### PR DESCRIPTION
## Summary
- normalize embedding vectors in `sidetrack/extraction/embeddings.py`
- export `compute_embeddings` via `sidetrack.extraction` and reuse in pipeline and worker
- adjust worker job tests to use shared embedding computation

## Testing
- `pip install -e ".[api,jobrunner,worker,dev]"`
- `pytest -m "unit and not slow and not gpu" -q`

------
https://chatgpt.com/codex/tasks/task_e_68c7bbfa6c6083338403d30eae9d46e0