### PR TITLE
feat: centralize tag helpers

### DIFF
--- a/sidetrack/analytics/__init__.py
+++ b/sidetrack/analytics/__init__.py
@@ -1,0 +1,1 @@
+"""Analytics helpers."""

--- a/sidetrack/analytics/tags.py
+++ b/sidetrack/analytics/tags.py
@@ -1,0 +1,110 @@
+"""Helpers for canonicalising and analysing tag data."""
+
+from __future__ import annotations
+
+import math
+from collections import Counter
+from collections.abc import Iterable, Mapping
+
+
+def canonicalize_tag(tag: str) -> str:
+    """Return a normalised representation of *tag*.
+
+    Tags are converted to lowercase and stripped of surrounding whitespace;
+    hyphens are treated as spaces. This conservative approach keeps the helper
+    predictable while remaining sufficient for the controlled vocabularies used
+    in tests.
+    """
+
+    return tag.strip().lower().replace("-", " ")
+
+
+def merge_tags(
+    lastfm: Mapping[str, int] | None, mb: Mapping[str, int] | Iterable[str] | None
+) -> dict[str, int]:
+    """Merge tag counts from Last.fm and MusicBrainz.
+
+    ``lastfm`` is expected to be a mapping of tag → play-count as returned by
+    :class:`~sidetrack.api.clients.lastfm.LastfmClient`. ``mb`` may be either a
+    mapping or an iterable of tag names. Tags from both sources are canonicalised
+    before being combined.
+    """
+
+    counts: Counter[str] = Counter()
+
+    def _add(src: Mapping[str, int] | Iterable[str] | None) -> None:
+        if not src:
+            return
+        if isinstance(src, Mapping):
+            items = src.items()
+        else:
+            items = ((t, 1) for t in src)
+        for tag, cnt in items:
+            key = canonicalize_tag(str(tag))
+            if key:
+                counts[key] += int(cnt)
+
+    _add(lastfm)
+    _add(mb)
+    return dict(counts)
+
+
+def compute_user_tfidf(
+    user_tags: Mapping[str, int], all_user_tags: Iterable[Mapping[str, int]]
+) -> dict[str, float]:
+    """Compute TF–IDF weights for ``user_tags``."""
+
+    total_docs = 0
+    doc_freq: Counter[str] = Counter()
+    for tags in all_user_tags:
+        total_docs += 1
+        seen = set()
+        for tag in tags:
+            key = canonicalize_tag(tag)
+            if key:
+                seen.add(key)
+        doc_freq.update(seen)
+
+    total_terms = sum(user_tags.values()) or 1
+    scores: dict[str, float] = {}
+    for tag, cnt in user_tags.items():
+        key = canonicalize_tag(tag)
+        if not key:
+            continue
+        tf = cnt / total_terms
+        df = doc_freq.get(key, 0)
+        # add-one smoothing to avoid division by zero
+        idf = math.log((total_docs or 1) / (1 + df)) + 1.0
+        scores[key] = tf * idf
+    return scores
+
+
+def label_rollups(
+    labels: Iterable[Mapping[str, str | None]], release_year: int | None
+) -> dict[str, str | None]:
+    """Derive simple label-based rollups."""
+
+    primary_label = None
+    label_country = None
+    for lab in labels:
+        primary_label = lab.get("name") or primary_label
+        label_country = lab.get("country") or label_country
+        if primary_label and label_country:
+            break
+
+    era = None
+    if release_year:
+        if 1990 <= release_year < 2000:
+            era = "90s"
+        elif 2000 <= release_year < 2010:
+            era = "00s"
+        elif 2010 <= release_year < 2020:
+            era = "10s"
+        elif 2020 <= release_year < 2030:
+            era = "20s"
+
+    return {
+        "primary_label": primary_label,
+        "label_country": label_country,
+        "era": era,
+    }

--- a/sidetrack/enrichment/fusion.py
+++ b/sidetrack/enrichment/fusion.py
@@ -1,142 +1,33 @@
-from __future__ import annotations
-
 """Utilities for merging tag data from multiple sources.
 
 This module provides helpers for combining Last.fm and MusicBrainz tag data
 into a canonical tag space and for deriving aggregate information such as
-TF–IDF scores or label rollups.  The functions are intentionally lightweight so
+TF–IDF scores or label rollups. The functions are intentionally lightweight so
 that they can be reused in both batch jobs and API handlers.
 """
 
-from collections import Counter
-import math
-from typing import Iterable, Mapping
+from __future__ import annotations
+
+from collections.abc import Mapping
 
 from sqlalchemy import delete
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from sidetrack.analytics.tags import canonicalize_tag, compute_user_tfidf, label_rollups, merge_tags
 from sidetrack.common.models import MBLabel, MBTag
 
-
-def canonicalize_tag(tag: str) -> str:
-    """Return a normalised representation of *tag*.
-
-    The canonicalisation here is deliberately conservative: tags are converted
-    to lowercase and stripped of surrounding whitespace; hyphens are treated as
-    spaces.  This is sufficient for the small, controlled vocabularies used in
-    tests while remaining predictable for callers.
-    """
-
-    return tag.strip().lower().replace("-", " ")
+# Re-export helpers from ``sidetrack.analytics.tags`` for backward compatibility
+__all__ = [
+    "canonicalize_tag",
+    "merge_tags",
+    "compute_user_tfidf",
+    "label_rollups",
+    "persist_mb_tags",
+    "persist_mb_label",
+]
 
 
-def merge_tags(
-    lastfm: Mapping[str, int] | None, mb: Mapping[str, int] | Iterable[str] | None
-) -> dict[str, int]:
-    """Merge tag counts from Last.fm and MusicBrainz.
-
-    ``lastfm`` is expected to be a mapping of tag → play-count as returned by
-    :class:`~sidetrack.api.clients.lastfm.LastfmClient`.  ``mb`` may be either a
-    mapping or an iterable of tag names.  Tags from both sources are
-    canonicalised before being combined.
-    """
-
-    counts: Counter[str] = Counter()
-
-    def _add(src: Mapping[str, int] | Iterable[str] | None) -> None:
-        if not src:
-            return
-        if isinstance(src, Mapping):
-            items = src.items()
-        else:
-            items = ((t, 1) for t in src)
-        for tag, cnt in items:
-            key = canonicalize_tag(str(tag))
-            if key:
-                counts[key] += int(cnt)
-
-    _add(lastfm)
-    _add(mb)
-    return dict(counts)
-
-
-def compute_user_tfidf(
-    user_tags: Mapping[str, int], all_user_tags: Iterable[Mapping[str, int]]
-) -> dict[str, float]:
-    """Compute TF–IDF weights for ``user_tags``.
-
-    ``user_tags`` contains raw tag counts for a single user.  ``all_user_tags``
-    is an iterable of tag-count mappings for every user in the population,
-    including the current one.  Both inputs are canonicalised prior to
-    calculation.  The returned dictionary maps canonical tag names to TF–IDF
-    scores.
-    """
-
-    total_docs = 0
-    doc_freq: Counter[str] = Counter()
-    for tags in all_user_tags:
-        total_docs += 1
-        seen = set()
-        for tag in tags:
-            key = canonicalize_tag(tag)
-            if key:
-                seen.add(key)
-        doc_freq.update(seen)
-
-    total_terms = sum(user_tags.values()) or 1
-    scores: dict[str, float] = {}
-    for tag, cnt in user_tags.items():
-        key = canonicalize_tag(tag)
-        if not key:
-            continue
-        tf = cnt / total_terms
-        df = doc_freq.get(key, 0)
-        # add-one smoothing to avoid division by zero
-        idf = math.log((total_docs or 1) / (1 + df)) + 1.0
-        scores[key] = tf * idf
-    return scores
-
-
-def label_rollups(
-    labels: Iterable[Mapping[str, str | None]], release_year: int | None
-) -> dict[str, str | None]:
-    """Derive simple label-based rollups.
-
-    ``labels`` should be an iterable of dictionaries with optional ``name`` and
-    ``country`` keys describing MusicBrainz labels.  ``release_year`` is used to
-    bucket a recording into coarse era bins.  The function returns a mapping
-    with ``primary_label``, ``label_country`` and ``era`` keys.
-    """
-
-    primary_label = None
-    label_country = None
-    for lab in labels:
-        primary_label = lab.get("name") or primary_label
-        label_country = lab.get("country") or label_country
-        if primary_label and label_country:
-            break
-
-    era = None
-    if release_year:
-        if 1990 <= release_year < 2000:
-            era = "90s"
-        elif 2000 <= release_year < 2010:
-            era = "00s"
-        elif 2010 <= release_year < 2020:
-            era = "10s"
-        elif 2020 <= release_year < 2030:
-            era = "20s"
-
-    return {
-        "primary_label": primary_label,
-        "label_country": label_country,
-        "era": era,
-    }
-
-
-async def persist_mb_tags(
-    db: AsyncSession, track_id: int, tags: Mapping[str, float]
-) -> None:
+async def persist_mb_tags(db: AsyncSession, track_id: int, tags: Mapping[str, float]) -> None:
     """Persist tag scores for a track to the ``mb_tag`` table."""
 
     await db.execute(delete(MBTag).where(MBTag.track_id == track_id))


### PR DESCRIPTION
## Summary
- move tag canonicalisation and analytics helpers to new module
- reuse shared tag canon in insights and ranker services
- re-export analytics helpers in fusion for backwards compatibility

## Testing
- `pre-commit run --files sidetrack/analytics/__init__.py sidetrack/analytics/tags.py sidetrack/enrichment/fusion.py sidetrack/services/insights.py sidetrack/services/ranker.py`
- `pytest -m "unit and not slow and not gpu" -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7c679819c8333bdb490e3cb68579b