### PR TITLE
refactor: relocate listen service

### DIFF
--- a/services/api/tests/test_listen_service.py
+++ b/services/api/tests/test_listen_service.py
@@ -7,7 +7,7 @@ from sidetrack.api.repositories.artist_repository import ArtistRepository
 from sidetrack.api.repositories.listen_repository import ListenRepository
 from sidetrack.api.repositories.release_repository import ReleaseRepository
 from sidetrack.api.repositories.track_repository import TrackRepository
-from sidetrack.api.services.listen_service import ListenService
+from sidetrack.services.listens import ListenService
 from sidetrack.common.models import Listen
 
 pytestmark = pytest.mark.integration

--- a/sidetrack/api/api/v1/listens.py
+++ b/sidetrack/api/api/v1/listens.py
@@ -19,7 +19,7 @@ from ...config import Settings, get_settings
 from ...db import get_db
 from ...schemas.listens import IngestResponse, ListenIn, RecentListensResponse
 from ...security import get_current_user
-from ...services.listen_service import ListenService, get_listen_service
+from sidetrack.services.listens import ListenService, get_listen_service
 
 router = APIRouter()
 

--- a/sidetrack/api/main.py
+++ b/sidetrack/api/main.py
@@ -47,7 +47,7 @@ from .schemas.tracks import (
     TrackPathResponse,
 )
 from .security import get_current_user, hash_password, require_role
-from .services.listen_service import ListenService, get_listen_service
+from sidetrack.services.listens import ListenService, get_listen_service
 
 setup_logging()
 setup_tracing("sidetrack-api")

--- a/sidetrack/services/__init__.py
+++ b/sidetrack/services/__init__.py
@@ -1,1 +1,14 @@
 """Service layer utilities."""
+
+from .listenbrainz import ListenBrainzClient, get_listenbrainz_client
+from .listens import ListenService, get_listen_service
+from .spotify import SpotifyClient, get_spotify_client
+
+__all__ = [
+    "ListenService",
+    "get_listen_service",
+    "SpotifyClient",
+    "get_spotify_client",
+    "ListenBrainzClient",
+    "get_listenbrainz_client",
+]

--- a/sidetrack/services/datasync.py
+++ b/sidetrack/services/datasync.py
@@ -3,7 +3,7 @@
 This module orchestrates the full data synchronisation pipeline for a user:
 
 1. Fetch listens from external providers (Spotify, Last.fm, ListenBrainz).
-2. Normalise and store listens via :class:`~sidetrack.api.services.listen_service.ListenService`.
+2. Normalise and store listens via :class:`~sidetrack.services.listens.ListenService`.
 3. Enrich tracks with tags and external identifiers.
 
 The main entry point is :func:`sync_user` which is designed for use by the
@@ -19,7 +19,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from sidetrack.api.config import Settings
-from sidetrack.api.services.listen_service import ListenService
+from sidetrack.services.listens import ListenService
 from sidetrack.common.models import Artist, Listen, Track, UserSettings
 from sidetrack.services.base_client import MusicServiceClient
 from sidetrack.api.clients.lastfm import LastfmClient

--- a/sidetrack/services/listens.py
+++ b/sidetrack/services/listens.py
@@ -3,12 +3,12 @@ from datetime import datetime
 from fastapi import Depends
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from ..db import get_db
-from ..repositories.artist_repository import ArtistRepository
-from ..repositories.listen_repository import ListenRepository
-from ..repositories.release_repository import ReleaseRepository
-from ..repositories.track_repository import TrackRepository
-from ..utils import mb_sanitize
+from sidetrack.api.db import get_db
+from sidetrack.api.repositories.artist_repository import ArtistRepository
+from sidetrack.api.repositories.listen_repository import ListenRepository
+from sidetrack.api.repositories.release_repository import ReleaseRepository
+from sidetrack.api.repositories.track_repository import TrackRepository
+from sidetrack.api.utils import mb_sanitize
 
 
 def convert_spotify_item(item: dict, user_id: str) -> dict | None:

--- a/sidetrack/services/providers/lastfm.py
+++ b/sidetrack/services/providers/lastfm.py
@@ -27,7 +27,7 @@ import httpx
 from sidetrack.api.clients.lastfm import LastfmClient
 from sidetrack.api.config import get_settings
 from sidetrack.api.db import SessionLocal
-from sidetrack.api.services.listen_service import ListenService, get_listen_service
+from sidetrack.services.listens import ListenService, get_listen_service
 
 
 class LastfmIngester:

--- a/sidetrack/worker/jobs.py
+++ b/sidetrack/worker/jobs.py
@@ -9,7 +9,7 @@ import httpx
 from sidetrack.api.clients.lastfm import LastfmClient
 from sidetrack.api.db import SessionLocal
 from sidetrack.api.main import aggregate_weeks as aggregate_weeks_service
-from sidetrack.api.services.listen_service import get_listen_service
+from sidetrack.services.listens import get_listen_service
 from sidetrack.common.models import Feature, Track
 from sidetrack.services.datasync import sync_user as datasync_sync_user
 from sidetrack.services.insights import compute_weekly_insights

--- a/tests/services/test_datasync.py
+++ b/tests/services/test_datasync.py
@@ -6,7 +6,7 @@ from sidetrack.api.repositories.artist_repository import ArtistRepository
 from sidetrack.api.repositories.listen_repository import ListenRepository
 from sidetrack.api.repositories.release_repository import ReleaseRepository
 from sidetrack.api.repositories.track_repository import TrackRepository
-from sidetrack.api.services.listen_service import ListenService
+from sidetrack.services.listens import ListenService
 from sidetrack.api.clients.lastfm import LastfmClient
 from sidetrack.common.models import UserSettings
 from sidetrack.services.datasync import sync_user

--- a/tests/services/test_listen_service_benchmark.py
+++ b/tests/services/test_listen_service_benchmark.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from sidetrack.api.services.listen_service import ListenService
+from sidetrack.services.listens import ListenService
 
 
 def _make_rows(n: int) -> list[dict]:

--- a/tests/services/test_listen_service_converters.py
+++ b/tests/services/test_listen_service_converters.py
@@ -2,7 +2,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from sidetrack.api.services.listen_service import ListenService
+from sidetrack.services.listens import ListenService
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- move listen service module to sidetrack/services/listens.py
- update API code to import ListenService from new module
- expose get_listen_service alongside other service factories

## Testing
- `pip install -e .[api,jobrunner,worker,dev]`
- `pytest -m "unit and not slow and not gpu" -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7c8aad66883339ec26402baa1012b