### PR TITLE
Refactor provider clients into shared services

### DIFF
--- a/sidetrack/analytics/tags.py
+++ b/sidetrack/analytics/tags.py
@@ -25,7 +25,7 @@ def merge_tags(
     """Merge tag counts from Last.fm and MusicBrainz.
 
     ``lastfm`` is expected to be a mapping of tag → play-count as returned by
-    :class:`~sidetrack.api.clients.lastfm.LastfmClient`. ``mb`` may be either a
+    :class:`~sidetrack.services.lastfm.LastfmClient`. ``mb`` may be either a
     mapping or an iterable of tag names. Tags from both sources are canonicalised
     before being combined.
     """

--- a/sidetrack/api/api/v1/listens.py
+++ b/sidetrack/api/api/v1/listens.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from sidetrack.common.models import Artist, Listen, Track, UserSettings
 
-from ...clients.lastfm import LastfmClient, get_lastfm_client
+from sidetrack.services.lastfm import LastfmClient, get_lastfm_client
 from ....services.spotify import SpotifyClient, get_spotify_client
 from sidetrack.services.listenbrainz import ListenBrainzClient, get_listenbrainz_client
 from ...config import Settings, get_settings

--- a/sidetrack/api/api/v1/recs.py
+++ b/sidetrack/api/api/v1/recs.py
@@ -15,7 +15,7 @@ from sidetrack.services.listenbrainz import ListenBrainzClient
 from sidetrack.services.musicbrainz import MusicBrainzService
 from sidetrack.services.ranker import profile_from_spotify, rank
 from sidetrack.services.spotify import SpotifyUserClient
-from ...clients.lastfm import LastfmClient
+from sidetrack.services.lastfm import LastfmClient
 
 from ...config import Settings
 from ...config import get_settings as get_app_settings

--- a/sidetrack/api/main.py
+++ b/sidetrack/api/main.py
@@ -31,7 +31,7 @@ from sidetrack.services.musicbrainz import MusicBrainzService
 
 from ..services.spotify import SpotifyClient, get_spotify_client
 from . import scoring as mood_scoring
-from .clients.lastfm import LastfmClient, get_lastfm_client
+from sidetrack.services.lastfm import LastfmClient, get_lastfm_client
 from .config import Settings
 from .config import get_settings as get_app_settings
 from .constants import AXES, DEFAULT_METHOD

--- a/sidetrack/enrichment/__init__.py
+++ b/sidetrack/enrichment/__init__.py
@@ -1,15 +1,5 @@
-from __future__ import annotations
+"""Helpers and shared data structures for enrichment pipelines."""
 
-from dataclasses import dataclass
-from typing import List, Optional
+from sidetrack.services.models import TrackRef
 
-
-@dataclass
-class TrackRef:
-    """Normalized reference to a track across services."""
-
-    title: str
-    artists: List[str]
-    isrc: Optional[str] = None
-    spotify_id: Optional[str] = None
-    lastfm_mbid: Optional[str] = None
+__all__ = ["TrackRef"]

--- a/sidetrack/enrichment/lastfm.py
+++ b/sidetrack/enrichment/lastfm.py
@@ -1,130 +1,55 @@
 from __future__ import annotations
 
-import asyncio
-import logging
-from typing import Any, List
+from typing import List
 
 import httpx
 
+from sidetrack.services.lastfm import LastfmClient
+
 from . import TrackRef
 
-
-logger = logging.getLogger(__name__)
-
-
 class LastfmAdapter:
-    """Thin wrapper around the Last.fm API."""
-
-    api_root = "https://ws.audioscrobbler.com/2.0/"
+    """Thin wrapper around :class:`sidetrack.services.lastfm.LastfmClient`."""
 
     def __init__(self, api_key: str, client: httpx.AsyncClient | None = None) -> None:
         self.api_key = api_key
-        self._client = client or httpx.AsyncClient()
+        self._httpx = client or httpx.AsyncClient()
+        self._owns_client = client is None
+        self._client = LastfmClient(self._httpx, api_key, api_secret=None)
 
     async def close(self) -> None:
-        await self._client.aclose()
-
-    async def _request(
-        self, params: dict[str, Any], *, max_retries: int = 3
-    ) -> dict[str, Any]:
-        params = dict(params)
-        params["api_key"] = self.api_key
-        params["format"] = "json"
-
-        delay = 1.0
-        for attempt in range(1, max_retries + 1):
-            try:
-                resp = await self._client.get(
-                    self.api_root, params=params, timeout=30
-                )
-                resp.raise_for_status()
-                return resp.json()
-            except (httpx.RequestError, httpx.HTTPStatusError) as exc:
-                status = getattr(getattr(exc, "response", None), "status_code", None)
-                retryable = status is None or status >= 500 or status == 429
-                if not retryable or attempt == max_retries:
-                    logger.error(
-                        "Last.fm request failed after %d attempts", attempt, exc_info=exc
-                    )
-                    raise
-                logger.warning(
-                    "Last.fm request failed (attempt %d/%d): %s",
-                    attempt,
-                    max_retries,
-                    exc,
-                )
-                await asyncio.sleep(delay)
-                delay *= 2
-
-    @staticmethod
-    def _to_track_ref(track: dict[str, Any]) -> TrackRef:
-        title = track.get("name") or ""
-        artist = track.get("artist") or {}
-        if isinstance(artist, dict):
-            artist_name = artist.get("name")
-        else:
-            artist_name = str(artist)
-        artists = [artist_name] if artist_name else []
-        mbid = track.get("mbid") or None
-        return TrackRef(title=title, artists=artists, lastfm_mbid=mbid)
+        if self._owns_client:
+            await self._httpx.aclose()
 
     async def get_recent_tracks(self, user: str, limit: int = 50) -> List[TrackRef]:
-        params = {"method": "user.getrecenttracks", "user": user, "limit": limit}
-        data = await self._request(params)
-        tracks = data.get("recenttracks", {}).get("track", [])
-        return [self._to_track_ref(t) for t in tracks]
+        tracks = await self._client.fetch_recent_tracks(user, limit=limit)
+        return [LastfmClient.to_track_ref(t) for t in tracks]
 
-    async def get_top_artists(self, user: str, period: str = "7day", limit: int = 50) -> List[str]:
-        params = {
-            "method": "user.gettopartists",
-            "user": user,
-            "period": period,
-            "limit": limit,
-        }
-        data = await self._request(params)
-        artists = data.get("topartists", {}).get("artist", [])
-        return [a.get("name", "") for a in artists]
+    async def get_top_artists(
+        self, user: str, period: str = "7day", limit: int = 50
+    ) -> List[str]:
+        artists = await self._client.get_top_artists(user, period=period, limit=limit)
+        return [a.get("name", "") for a in artists if isinstance(a, dict)]
 
-    async def get_top_tracks(self, user: str, period: str = "7day", limit: int = 50) -> List[TrackRef]:
-        params = {
-            "method": "user.gettoptracks",
-            "user": user,
-            "period": period,
-            "limit": limit,
-        }
-        data = await self._request(params)
-        tracks = data.get("toptracks", {}).get("track", [])
-        return [self._to_track_ref(t) for t in tracks]
+    async def get_top_tracks(
+        self, user: str, period: str = "7day", limit: int = 50
+    ) -> List[TrackRef]:
+        tracks = await self._client.get_top_tracks(user, period=period, limit=limit)
+        return [LastfmClient.to_track_ref(t) for t in tracks if isinstance(t, dict)]
 
     async def get_tags(
         self, artist: str, track: str | None = None, limit: int = 50
     ) -> List[str]:
-        if track:
-            params = {
-                "method": "track.gettoptags",
-                "artist": artist,
-                "track": track,
-                "limit": limit,
-            }
-        else:
-            params = {"method": "artist.gettoptags", "artist": artist, "limit": limit}
-        data = await self._request(params)
-        tags = data.get("toptags", {}).get("tag", [])
-        return [t.get("name", "") for t in tags]
+        tags = await self._client.get_top_tags(artist=artist, track=track, limit=limit)
+        return [t.get("name", "") for t in tags if isinstance(t, dict) and t.get("name")]
 
     async def get_similar_artists(
         self, *, name: str | None = None, mbid: str | None = None, limit: int = 50
     ) -> List[str]:
-        params = {"method": "artist.getsimilar", "limit": limit}
-        if mbid:
-            params["mbid"] = mbid
-        elif name:
-            params["artist"] = name
-        else:
-            raise ValueError("name or mbid required")
-        data = await self._request(params)
-        artists = data.get("similarartists", {}).get("artist", [])
-        return [a.get("name", "") for a in artists]
+        artists = await self._client.get_similar_artist(
+            name=name, mbid=mbid, limit=limit
+        )
+        return [a.get("name", "") for a in artists if isinstance(a, dict)]
 
     async def get_similar_tracks(
         self,
@@ -134,14 +59,7 @@ class LastfmAdapter:
         mbid: str | None = None,
         limit: int = 50,
     ) -> List[TrackRef]:
-        params = {"method": "track.getsimilar", "limit": limit}
-        if mbid:
-            params["mbid"] = mbid
-        else:
-            if not artist or not track:
-                raise ValueError("artist and track required when mbid not provided")
-            params["artist"] = artist
-            params["track"] = track
-        data = await self._request(params)
-        tracks = data.get("similartracks", {}).get("track", [])
-        return [self._to_track_ref(t) for t in tracks]
+        tracks = await self._client.get_similar_track(
+            artist=artist, track=track, mbid=mbid, limit=limit
+        )
+        return [LastfmClient.to_track_ref(t) for t in tracks if isinstance(t, dict)]

--- a/sidetrack/enrichment/listenbrainz.py
+++ b/sidetrack/enrichment/listenbrainz.py
@@ -1,56 +1,34 @@
 from __future__ import annotations
 
-from typing import Any, List
+from typing import List
 
 import httpx
+
+from sidetrack.services.listenbrainz import ListenBrainzClient
 
 from . import TrackRef
 
 
 class ListenBrainzAdapter:
-    """Wrapper around the ListenBrainz API."""
-
-    api_root = "https://api.listenbrainz.org/1"
+    """Wrapper around :class:`sidetrack.services.listenbrainz.ListenBrainzClient`."""
 
     def __init__(self, client: httpx.AsyncClient | None = None) -> None:
-        self._client = client or httpx.AsyncClient()
+        self._httpx = client or httpx.AsyncClient()
+        self._owns_client = client is None
+        self._client = ListenBrainzClient(self._httpx)
 
     async def close(self) -> None:
-        await self._client.aclose()
-
-    @staticmethod
-    def _to_track_ref(rec: dict[str, Any]) -> TrackRef:
-        title = rec.get("track_name") or rec.get("title") or ""
-        artist = rec.get("artist_name") or rec.get("artist") or ""
-        artists = [artist] if isinstance(artist, str) else artist
-        mbid = rec.get("recording_mbid") or rec.get("mbid")
-        return TrackRef(title=title, artists=artists, lastfm_mbid=mbid)
+        if self._owns_client:
+            await self._httpx.aclose()
 
     async def get_cf_recommendations(self, user: str, limit: int = 50) -> List[TrackRef]:
-        url = f"{self.api_root}/user/{user}/cf/recommendations"
-        params = {"count": limit}
-        resp = await self._client.get(url, params=params, timeout=30)
-        resp.raise_for_status()
-        data = resp.json()
-        recs = (
-            data.get("recommendations")
-            or data.get("recordings")
-            or data.get("recommended_recordings")
-            or []
-        )
-        return [self._to_track_ref(r) for r in recs]
+        recs = await self._client.get_cf_recommendations(user, limit)
+        return [ListenBrainzClient.to_track_ref(r) for r in recs]
 
     async def get_colisten_similar_artists(
         self, artist_mbid: str, limit: int = 10
     ) -> List[str]:
         """Return artists frequently co-listened with the given artist."""
 
-        url = f"{self.api_root}/artist/{artist_mbid}/similar"
-        params = {"count": limit}
-        resp = await self._client.get(url, params=params, timeout=30)
-        if resp.status_code == 404:
-            return []
-        resp.raise_for_status()
-        data = resp.json()
-        artists = data.get("similar_artists") or data.get("artists") or []
-        return [a.get("artist_name", "") for a in artists]
+        artists = await self._client.get_similar_artists(artist_mbid, limit)
+        return [a.get("artist_name", "") for a in artists if isinstance(a, dict)]

--- a/sidetrack/enrichment/spotify.py
+++ b/sidetrack/enrichment/spotify.py
@@ -1,18 +1,16 @@
 from __future__ import annotations
 
-import asyncio
 from typing import Any, List
 
 import httpx
+
+from sidetrack.services.spotify import SpotifyClient, SpotifyUserClient
 
 from . import TrackRef
 
 
 class SpotifyAdapter:
-    """Adapter for the Spotify Web API with minimal OAuth support."""
-
-    auth_root = "https://accounts.spotify.com"
-    api_root = "https://api.spotify.com/v1"
+    """Adapter for the Spotify Web API relying on shared service clients."""
 
     def __init__(
         self,
@@ -23,92 +21,35 @@ class SpotifyAdapter:
         client_secret: str | None = None,
         client: httpx.AsyncClient | None = None,
     ) -> None:
-        self.access_token = access_token
-        self.refresh_token = refresh_token
-        self.client_id = client_id
-        self.client_secret = client_secret
-        self._client = client or httpx.AsyncClient()
+        self._httpx = client or httpx.AsyncClient()
+        self._owns_client = client is None
+        self._client = SpotifyUserClient(
+            self._httpx,
+            access_token,
+            client_id=client_id,
+            client_secret=client_secret,
+            refresh_token=refresh_token,
+        )
 
     async def close(self) -> None:
-        await self._client.aclose()
+        if self._owns_client:
+            await self._httpx.aclose()
 
-    # ------------------------------------------------------------------
-    # Internal helpers
-    # ------------------------------------------------------------------
-    async def _refresh(self) -> None:
-        if not self.refresh_token or not self.client_id or not self.client_secret:
-            raise RuntimeError("cannot refresh token without credentials")
-        data = {"grant_type": "refresh_token", "refresh_token": self.refresh_token}
-        auth = httpx.BasicAuth(self.client_id, self.client_secret)
-        resp = await self._client.post(
-            f"{self.auth_root}/api/token", data=data, auth=auth, timeout=30
-        )
-        resp.raise_for_status()
-        payload = resp.json()
-        self.access_token = payload.get("access_token", self.access_token)
-
-    async def _request(self, method: str, url: str, **kwargs: Any) -> dict[str, Any]:
-        headers = kwargs.pop("headers", {})
-        while True:
-            headers["Authorization"] = f"Bearer {self.access_token}"
-            resp = await self._client.request(
-                method, url, headers=headers, timeout=30, **kwargs
-            )
-            if resp.status_code == 401 and self.refresh_token:
-                await self._refresh()
-                continue
-            if resp.status_code == 429:
-                retry = int(resp.headers.get("Retry-After", "1"))
-                await asyncio.sleep(retry)
-                continue
-            resp.raise_for_status()
-            return resp.json()
-
-    @staticmethod
-    def _to_track_ref(data: dict[str, Any]) -> TrackRef:
-        track = data.get("track") or data
-        return TrackRef(
-            title=track.get("name", ""),
-            artists=[a.get("name") for a in track.get("artists", []) if a.get("name")],
-            isrc=(track.get("external_ids") or {}).get("isrc"),
-            spotify_id=track.get("id"),
-        )
-
-    # ------------------------------------------------------------------
-    # API methods
-    # ------------------------------------------------------------------
     async def get_recently_played(self, limit: int = 50) -> List[TrackRef]:
-        params = {"limit": min(limit, 50)}
-        data = await self._request(
-            "GET", f"{self.api_root}/me/player/recently-played", params=params
-        )
-        return [self._to_track_ref(x) for x in data.get("items", [])]
+        items = await self._client.get_recently_played(limit=limit)
+        return [SpotifyClient.to_track_ref(item) for item in items]
 
     async def get_saved_tracks(self, limit: int = 50) -> List[TrackRef]:
-        url = f"{self.api_root}/me/tracks"
-        params: dict[str, Any] | None = {"limit": min(limit, 50)}
-        out: List[TrackRef] = []
-        while url:
-            data = await self._request("GET", url, params=params)
-            out.extend(self._to_track_ref(x) for x in data.get("items", []))
-            url = data.get("next")
-            params = None
-        return out[:limit]
+        items = await self._client.get_saved_tracks(limit=limit)
+        return [SpotifyClient.to_track_ref(item) for item in items]
 
     async def get_top_items(
         self, type_: str = "tracks", time_range: str = "short_term", limit: int = 20
     ) -> List[TrackRef]:
-        params = {"time_range": time_range, "limit": limit}
-        data = await self._request("GET", f"{self.api_root}/me/top/{type_}", params=params)
-        return [self._to_track_ref(x) for x in data.get("items", [])]
+        items = await self._client.get_top_items(
+            type_=type_, time_range=time_range, limit=limit
+        )
+        return [SpotifyClient.to_track_ref(item) for item in items]
 
     async def audio_features(self, ids: List[str]) -> List[dict[str, Any]]:
-        out: List[dict[str, Any]] = []
-        for i in range(0, len(ids), 100):
-            batch = ids[i : i + 100]
-            params = {"ids": ",".join(batch)}
-            data = await self._request(
-                "GET", f"{self.api_root}/audio-features", params=params
-            )
-            out.extend(x for x in data.get("audio_features", []) if x)
-        return out
+        return await self._client.get_audio_features_batch(ids)

--- a/sidetrack/services/__init__.py
+++ b/sidetrack/services/__init__.py
@@ -3,6 +3,7 @@
 from .listenbrainz import ListenBrainzClient, get_listenbrainz_client
 from .listens import ListenService, get_listen_service
 from .spotify import SpotifyClient, get_spotify_client
+from .lastfm import LastfmClient, get_lastfm_client
 
 __all__ = [
     "ListenService",
@@ -11,4 +12,6 @@ __all__ = [
     "get_spotify_client",
     "ListenBrainzClient",
     "get_listenbrainz_client",
+    "LastfmClient",
+    "get_lastfm_client",
 ]

--- a/sidetrack/services/candidates.py
+++ b/sidetrack/services/candidates.py
@@ -6,7 +6,7 @@ import asyncio
 from dataclasses import dataclass, field, asdict
 from typing import Any, Iterable
 
-from sidetrack.api.clients.lastfm import LastfmClient
+from sidetrack.services.lastfm import LastfmClient
 from .listenbrainz import ListenBrainzClient
 
 from .spotify import SpotifyUserClient

--- a/sidetrack/services/datasync.py
+++ b/sidetrack/services/datasync.py
@@ -22,7 +22,7 @@ from sidetrack.api.config import Settings
 from sidetrack.services.listens import ListenService
 from sidetrack.common.models import Artist, Listen, Track, UserSettings
 from sidetrack.services.base_client import MusicServiceClient
-from sidetrack.api.clients.lastfm import LastfmClient
+from sidetrack.services.lastfm import LastfmClient
 from sidetrack.services.listenbrainz import ListenBrainzClient
 from sidetrack.services.musicbrainz import MusicBrainzService
 from sidetrack.services.spotify import SpotifyClient

--- a/sidetrack/services/models.py
+++ b/sidetrack/services/models.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class TrackRef:
+    """Normalized reference to a track across external services."""
+
+    title: str
+    artists: list[str]
+    isrc: Optional[str] = None
+    spotify_id: Optional[str] = None
+    lastfm_mbid: Optional[str] = None
+
+
+__all__ = ["TrackRef"]

--- a/sidetrack/services/providers/lastfm.py
+++ b/sidetrack/services/providers/lastfm.py
@@ -24,9 +24,9 @@ from typing import Any, Iterable, List
 
 import httpx
 
-from sidetrack.api.clients.lastfm import LastfmClient
 from sidetrack.api.config import get_settings
 from sidetrack.api.db import SessionLocal
+from sidetrack.services.lastfm import LastfmClient
 from sidetrack.services.listens import ListenService, get_listen_service
 
 

--- a/sidetrack/worker/jobs.py
+++ b/sidetrack/worker/jobs.py
@@ -6,7 +6,7 @@ from datetime import date
 
 import httpx
 
-from sidetrack.api.clients.lastfm import LastfmClient
+from sidetrack.services.lastfm import LastfmClient
 from sidetrack.api.db import SessionLocal
 from sidetrack.api.main import aggregate_weeks as aggregate_weeks_service
 from sidetrack.services.listens import get_listen_service

--- a/tests/services/test_datasync.py
+++ b/tests/services/test_datasync.py
@@ -7,7 +7,7 @@ from sidetrack.api.repositories.listen_repository import ListenRepository
 from sidetrack.api.repositories.release_repository import ReleaseRepository
 from sidetrack.api.repositories.track_repository import TrackRepository
 from sidetrack.services.listens import ListenService
-from sidetrack.api.clients.lastfm import LastfmClient
+from sidetrack.services.lastfm import LastfmClient
 from sidetrack.common.models import UserSettings
 from sidetrack.services.datasync import sync_user
 from sidetrack.services.listenbrainz import ListenBrainzClient

--- a/tests/test_lastfm_client.py
+++ b/tests/test_lastfm_client.py
@@ -2,7 +2,7 @@ import asyncio
 import httpx
 import pytest
 
-from sidetrack.api.clients.lastfm import LastfmClient
+from sidetrack.services.lastfm import LastfmClient
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- move the Last.fm API client into sidetrack/services and expose shared parsing helpers
- add TrackRef data model plus ListenBrainz/Spotify helpers and update enrichment adapters to consume the shared clients
- refresh ingestion imports and tests to align with the consolidated provider implementations

## Testing
- pytest -m "unit and not slow and not gpu" -q

------
https://chatgpt.com/codex/tasks/task_e_68c892e0473083338818bb3bfd7f518c