### PR TITLE
Add unified Typer CLI and deprecate module entrypoints

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -57,7 +57,7 @@ services:
         condition: service_started
       db:
         condition: service_healthy
-    command: python -m sidetrack.extraction --schedule "@daily"
+    command: python -m sidetrack extract --schedule "@daily"
 
   jobrunner:
     build:
@@ -85,7 +85,7 @@ services:
         condition: service_healthy
       db:
         condition: service_healthy
-    command: python -m sidetrack.worker.run
+    command: python -m sidetrack worker run
 
   ui:
     build: ./services/ui

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "pgvector==0.3.5",
     "requests==2.32.3",
     "httpx==0.27.0",
+    "typer==0.12.3",
 ]
 
 [build-system]
@@ -35,7 +36,6 @@ api = [
 ]
 
 extractor = [
-    "typer==0.12.3",
     "numpy==1.26.4",
     "scipy==1.13.1",
     "librosa==0.10.2.post1",

--- a/services/extractor/Dockerfile
+++ b/services/extractor/Dockerfile
@@ -13,4 +13,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg \
 COPY --from=builder /usr/local /usr/local
 RUN python -c "import sidetrack; print('extraction runtime deps OK')"
 
-CMD ["python", "-m", "sidetrack.extraction", "--schedule", "@daily"]
+CMD ["python", "-m", "sidetrack", "extract", "--schedule", "@daily"]

--- a/services/jobrunner/Dockerfile
+++ b/services/jobrunner/Dockerfile
@@ -11,4 +11,4 @@ FROM sidetrack/base:dev AS runtime
 COPY --from=builder /usr/local /usr/local
 RUN python -c "import sidetrack; print('jobrunner runtime deps OK')"
 
-CMD ["python", "-m", "sidetrack.jobrunner.run"]
+CMD ["python", "-m", "sidetrack", "schedule"]

--- a/services/worker/Dockerfile
+++ b/services/worker/Dockerfile
@@ -13,4 +13,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends ffmpeg \
 COPY --from=builder /usr/local /usr/local
 RUN python -c "import sidetrack; print('worker runtime deps OK')"
 
-CMD ["python", "-m", "sidetrack.worker.run"]
+CMD ["python", "-m", "sidetrack", "worker", "run"]

--- a/sidetrack/__main__.py
+++ b/sidetrack/__main__.py
@@ -1,0 +1,15 @@
+"""Entry point for ``python -m sidetrack``."""
+
+from __future__ import annotations
+
+from .cli import app
+
+
+def main() -> None:
+    """Execute the Typer application."""
+
+    app()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    main()

--- a/sidetrack/cli.py
+++ b/sidetrack/cli.py
@@ -1,0 +1,217 @@
+"""Unified command line interface for SideTrack services."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from datetime import date, datetime
+from typing import Optional
+
+import click
+import typer
+from typer.core import TyperOption
+from typer import rich_utils as typer_rich_utils
+
+
+_ORIG_MAKE_METAVAR = TyperOption.make_metavar
+
+
+def _typer_option_make_metavar(self: TyperOption, ctx: click.Context | None = None) -> str:
+    if ctx is None:
+        ctx = click.Context(click.Command(self.name or "sidetrack"))
+    return _ORIG_MAKE_METAVAR(self, ctx)
+
+
+TyperOption.make_metavar = _typer_option_make_metavar  # type: ignore[assignment]
+
+
+def _rich_format_help(
+    ctx: click.Context, formatter: click.HelpFormatter, *_args: object, **_kwargs: object
+) -> str:
+    ctx.command.format_help(ctx, formatter)
+    return formatter.getvalue().rstrip("\n")
+
+
+typer_rich_utils.rich_format_help = _rich_format_help  # type: ignore[assignment]
+
+
+app = typer.Typer(
+    add_completion=False,
+    no_args_is_help=True,
+    rich_markup_mode=None,
+    help="SideTrack command line interface.",
+)
+
+
+@app.callback(invoke_without_command=True)
+def main(ctx: typer.Context) -> None:
+    """Top-level callback executed before subcommands."""
+
+
+def _parse_since(value: Optional[str]) -> Optional[datetime]:
+    """Parse ``value`` into a :class:`datetime` when provided."""
+
+    if value is None:
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError as exc:  # pragma: no cover - user input branch
+        raise typer.BadParameter(
+            "Expected ISO 8601 date or datetime, e.g. 2024-01-01 or 2024-01-01T12:00"
+        ) from exc
+
+
+ingest_app = typer.Typer(
+    add_completion=False,
+    help="Utilities for fetching and ingesting listens.",
+)
+
+
+@ingest_app.command("lastfm", help="Fetch listens from Last.fm and ingest them into the database.")
+def ingest_lastfm(
+    user: str = typer.Option(..., "--user", help="Last.fm username to fetch."),
+    as_user: Optional[str] = typer.Option(
+        None,
+        "--as-user",
+        help="Override the target SideTrack user id (defaults to the Last.fm username).",
+    ),
+    since: Optional[str] = typer.Option(
+        None,
+        "--since",
+        help="Earliest listen timestamp to fetch (ISO 8601 date or datetime).",
+    ),
+    database_url: Optional[str] = typer.Option(
+        None,
+        "--database-url",
+        help="Override DATABASE_URL for this invocation.",
+    ),
+) -> None:
+    """Ingest recent listens for ``user`` from Last.fm."""
+
+    from sidetrack.api.config import get_settings
+    from sidetrack.services.ingestion import get_ingester
+
+    if database_url:
+        os.environ["DATABASE_URL"] = database_url
+        get_settings.cache_clear()
+
+    since_dt = _parse_since(since)
+
+    settings = get_settings()
+    ingester = get_ingester("lastfm", api_key=settings.lastfm_api_key)
+    created = asyncio.run(
+        ingester.ingest(lastfm_user=user, as_user=as_user, since=since_dt)
+    )
+
+    typer.echo(
+        f"Ingested {created} listens from Last.fm for {user} → user={as_user or user}"
+    )
+
+
+app.add_typer(ingest_app, name="ingest")
+
+
+@app.command("extract", help="Audio feature extraction tools.")
+def extract(
+    interval: float = typer.Option(
+        10.0,
+        "--interval",
+        help="Seconds between extraction passes",
+        envvar="EXTRACTOR_INTERVAL",
+    ),
+    schedule: Optional[str] = typer.Option(
+        None,
+        "--schedule",
+        help="Cron expression or seconds between passes",
+        envvar="EXTRACTOR_SCHEDULE",
+    ),
+    once: bool = typer.Option(False, help="Run one pass then exit"),
+    batch_size: int = typer.Option(4, help="Tracks to process per pass"),
+) -> None:
+    from sidetrack.extraction.cli import main as extraction_main
+
+    extraction_main(
+        interval=interval,
+        schedule=schedule,
+        once=once,
+        batch_size=batch_size,
+    )
+
+
+@app.command("schedule", help="Start the periodic job scheduler.")
+def schedule() -> None:
+    """Run the lightweight job scheduler."""
+
+    from sidetrack.jobrunner.run import main as jobrunner_main
+
+    jobrunner_main()
+
+
+worker_app = typer.Typer(
+    add_completion=False,
+    no_args_is_help=True,
+    help="Worker process management and job utilities.",
+)
+
+
+@worker_app.command("run", help="Start the RQ worker process.")
+def worker_run() -> None:
+    """Launch the worker that consumes queued jobs."""
+
+    from sidetrack.worker.run import main as worker_main
+
+    worker_main()
+
+
+jobs_app = typer.Typer(
+    add_completion=False,
+    help="Execute worker jobs manually.",
+)
+
+
+@jobs_app.command("sync-user", help="Synchronise listens for a user across providers.")
+def worker_sync_user(
+    user_id: str = typer.Argument(..., help="Target SideTrack user id."),
+    since: Optional[str] = typer.Option(
+        None,
+        "--since",
+        help="Earliest date to sync listens (YYYY-MM-DD).",
+    ),
+) -> None:
+    from sidetrack.worker.jobs import sync_user
+
+    cursor = None
+    if since:
+        try:
+            cursor = date.fromisoformat(since).isoformat()
+        except ValueError as exc:  # pragma: no cover - user input branch
+            raise typer.BadParameter("--since must be in YYYY-MM-DD format") from exc
+    sync_user(user_id, cursor)
+    typer.echo(f"Completed sync_user job for {user_id}")
+
+
+@jobs_app.command("aggregate-weeks", help="Aggregate weekly insights for a user.")
+def worker_aggregate_weeks(
+    user_id: str = typer.Argument(..., help="Target SideTrack user id."),
+) -> None:
+    from sidetrack.worker.jobs import aggregate_weeks
+
+    aggregate_weeks(user_id)
+    typer.echo(f"Completed aggregate_weeks job for {user_id}")
+
+
+@jobs_app.command("weekly-insights", help="Generate weekly insight events for a user.")
+def worker_weekly_insights(
+    user_id: str = typer.Argument(..., help="Target SideTrack user id."),
+) -> None:
+    from sidetrack.worker.jobs import generate_weekly_insights
+
+    count = generate_weekly_insights(user_id)
+    typer.echo(f"Generated {count} weekly insight events for {user_id}")
+
+
+worker_app.add_typer(jobs_app, name="jobs")
+app.add_typer(worker_app, name="worker")
+
+
+__all__ = ["app"]

--- a/sidetrack/extraction/__main__.py
+++ b/sidetrack/extraction/__main__.py
@@ -1,9 +1,19 @@
 """Entry point for ``python -m sidetrack.extraction``."""
 
+from __future__ import annotations
+
+import warnings
+
 from .cli import app
 
 
 def main() -> None:
+    warnings.warn(
+        "`python -m sidetrack.extraction` is deprecated; use "
+        "`python -m sidetrack extract ...` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     app()
 
 

--- a/sidetrack/extraction/cli.py
+++ b/sidetrack/extraction/cli.py
@@ -4,11 +4,11 @@ Examples
 --------
 Run every 10 seconds (default interval)::
 
-    python -m sidetrack.extraction --schedule 10
+    python -m sidetrack extract --schedule 10
 
 Run on a cron schedule (every 5 minutes)::
 
-    python -m sidetrack.extraction --schedule "*/5 * * * *"
+    python -m sidetrack extract --schedule "*/5 * * * *"
 
 The ``--schedule`` option accepts either a floating-point interval in seconds or a
 standard cron expression. Cron expressions are validated before the extractor starts.

--- a/sidetrack/jobrunner/run.py
+++ b/sidetrack/jobrunner/run.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import time
+import warnings
 from datetime import date, datetime
 
 import redis
@@ -86,4 +87,10 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    warnings.warn(
+        "`python -m sidetrack.jobrunner.run` is deprecated; use "
+        "`python -m sidetrack schedule` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     main()

--- a/sidetrack/services/providers/lastfm.py
+++ b/sidetrack/services/providers/lastfm.py
@@ -10,8 +10,8 @@ Environment
 - LASTFM_API_KEY must be set (public reads only; no secret required)
 
 Examples
-- python -m sidetrack.services.providers.lastfm --user mylastfm --since 2024-01-01
-- python -m sidetrack.services.providers.lastfm --user mylastfm --as-user some_user
+- python -m sidetrack ingest lastfm --user mylastfm --since 2024-01-01
+- python -m sidetrack ingest lastfm --user mylastfm --as-user some_user
 """
 
 from __future__ import annotations
@@ -19,6 +19,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import os
+import warnings
 from datetime import datetime
 from typing import Any, Iterable, List
 
@@ -109,4 +110,10 @@ def main(argv: Iterable[str] | None = None) -> None:
 
 
 if __name__ == "__main__":  # pragma: no cover - manual/CLI usage
+    warnings.warn(
+        "`python -m sidetrack.services.providers.lastfm` is deprecated; use "
+        "`python -m sidetrack ingest lastfm` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     main()

--- a/sidetrack/worker/run.py
+++ b/sidetrack/worker/run.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import threading
 import time
+import warnings
 
 import redis
 from rq import Connection, Queue, Worker
@@ -35,4 +36,10 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    warnings.warn(
+        "`python -m sidetrack.worker.run` is deprecated; use "
+        "`python -m sidetrack worker run` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     main()


### PR DESCRIPTION
## Summary
- add a new Typer-driven `sidetrack.cli` that exposes ingest, extract, schedule, and worker commands from a single entry point
- route existing module entry points through the new CLI with deprecation warnings and refresh container commands/docs to use the unified interface
- promote Typer to a core dependency so the CLI is always available

## Testing
- pytest -m "unit and not slow and not gpu" -q

------
https://chatgpt.com/codex/tasks/task_e_68c89cd6242083338213737e37fa026d