### PR TITLE
Centralize service logging configuration

### DIFF
--- a/sidetrack/common/logging.py
+++ b/sidetrack/common/logging.py
@@ -1,9 +1,38 @@
+"""Logging utilities shared across SideTrack services."""
+
+from __future__ import annotations
+
 import logging
+from typing import Union
 
 
-def setup_logging(level: int = logging.INFO) -> None:
+_DEFAULT_FORMAT = "%(asctime)s %(levelname)s %(name)s: %(message)s"
+
+
+def _resolve_level(level: Union[int, str, None]) -> int:
+    if level is None:
+        return logging.INFO
+    if isinstance(level, str):
+        numeric_level = logging.getLevelName(level.upper())
+        if isinstance(numeric_level, int):
+            return numeric_level
+        raise ValueError(f"Unknown log level: {level}")
+    return int(level)
+
+
+def setup_logging(level: Union[int, str, None] = None, *, force: bool = False) -> None:
     """Configure standard logging with a simple, readable format."""
+
+    resolved_level = _resolve_level(level)
+    root_logger = logging.getLogger()
+    root_logger.setLevel(resolved_level)
+
+    if root_logger.handlers and not force:
+        return
+
     logging.basicConfig(
-        level=level,
-        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        level=resolved_level,
+        format=_DEFAULT_FORMAT,
+        datefmt="%Y-%m-%d %H:%M:%S",
+        force=force,
     )

--- a/sidetrack/jobrunner/run.py
+++ b/sidetrack/jobrunner/run.py
@@ -13,13 +13,13 @@ from rq import Queue
 from sqlalchemy import select
 
 from sidetrack.api.db import SessionLocal
+from sidetrack.common.logging import setup_logging
 from sidetrack.common.models import UserAccount
 from sidetrack.worker import jobs as worker_jobs
 
 from .config import get_settings
 
-logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s:%(message)s")
-logger = logging.getLogger("jobrunner")
+logger = logging.getLogger("sidetrack.jobrunner")
 
 settings = get_settings()
 connection = redis.from_url(settings.redis_url)
@@ -79,6 +79,7 @@ def schedule_jobs() -> None:
 
 
 def main() -> None:
+    setup_logging()
     schedule_jobs()
     logger.info("started")
     while True:

--- a/sidetrack/worker/jobs.py
+++ b/sidetrack/worker/jobs.py
@@ -23,8 +23,7 @@ from sidetrack.extraction import compute_embeddings
 
 from .config import get_settings
 
-logging.basicConfig(level=logging.INFO, format="%(levelname)s:%(name)s:%(message)s")
-logger = logging.getLogger("worker")
+logger = logging.getLogger("sidetrack.worker.jobs")
 
 
 KEYS = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"]

--- a/sidetrack/worker/run.py
+++ b/sidetrack/worker/run.py
@@ -10,6 +10,8 @@ import warnings
 import redis
 from rq import Connection, Queue, Worker
 
+from sidetrack.common.logging import setup_logging
+
 # Import job functions so the worker process knows about them.
 from . import jobs  # noqa: F401
 from .config import get_settings
@@ -17,6 +19,7 @@ from .config import get_settings
 
 def main() -> None:
     """Start an RQ worker listening to analysis queues."""
+    setup_logging()
     settings = get_settings()
     connection = redis.from_url(settings.redis_url)
     logger = logging.getLogger("sidetrack.worker")


### PR DESCRIPTION
## Summary
- extend `sidetrack.common.logging.setup_logging` to normalise level input and avoid reconfiguring existing handlers
- remove in-module `logging.basicConfig` calls from the job runner and worker services
- initialise logging for the worker entry point using the shared helper

## Testing
- pip install -e ".[api,jobrunner,worker,dev]"
- pytest -m "unit and not slow and not gpu" -q

------
https://chatgpt.com/codex/tasks/task_e_68c8aa85d2588333ba9cf1bc4daf3c0d