### PR TITLE
Rename extractor references to extraction package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,13 @@
 ## Testing
 
-1. Install dependencies (skip heavy extractor extras):
+1. Install dependencies (skip heavy extraction extras):
    ```bash
    pip install -e ".[api,jobrunner,worker,dev]"
    ```
-   Install the extractor extras **only** when running extractor-specific
+   Install the extraction extras **only** when running extraction-specific
    code or tests:
    ```bash
-   pip install -e ".[extractor]"
+   pip install -e ".[extraction]"
    ```
 2. Run unit tests:
    ```bash

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Pull listens from Spotify or Last.fm (with ListenBrainz as a fallback) → resol
 - db: Postgres 16 + TimescaleDB (primary store)
 - cache: Redis 7 (queues, rate limiting)
 - api: FastAPI
-- extractor: audio features/embeddings (Librosa + optional models)
+- extraction: audio features/embeddings (Librosa + optional models)
 - jobrunner: periodic scheduling via queue (ingest, tags sync, aggregates)
 - worker: background jobs (RQ)
 - ui: Next.js dashboard
@@ -36,7 +36,7 @@ docker build -f services/base/Dockerfile -t sidetrack-base .
 docker compose up -d --build
 ```
 
-The extractor uses GPU automatically when available (NVIDIA runtime), and falls back to CPU.
+The extraction service uses GPU automatically when available (NVIDIA runtime) and falls back to CPU.
 
 ---
 
@@ -79,8 +79,8 @@ Developer tooling (optional):
 ```bash
 python3.11 -m venv .venv && source .venv/bin/activate
 pip install -e ".[api,jobrunner,worker,dev]"
-# Install heavy extractor extras only when needed
-# pip install -e ".[extractor]"
+# Install heavy extraction extras only when needed
+# pip install -e ".[extraction]"
 pre-commit install && pre-commit run --all-files
 ```
 
@@ -270,8 +270,8 @@ Set up a virtual environment and install the test dependencies:
 ```bash
 python3.11 -m venv .venv && source .venv/bin/activate
 pip install -e ".[api,jobrunner,worker,dev]"
-# Install extractor extras only for extractor-related tests
-# pip install -e ".[extractor]"
+# Install extraction extras only for extraction-related tests
+# pip install -e ".[extraction]"
 pytest -m "unit and not slow and not gpu" -q
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ api = [
     "fastapi-limiter==0.1.6",
 ]
 
-extractor = [
+extraction = [
     "numpy==1.26.4",
     "scipy==1.13.1",
     "librosa==0.10.2.post1",

--- a/scripts/bench_extractor.py
+++ b/scripts/bench_extractor.py
@@ -74,7 +74,7 @@ def run_benchmark(n_tracks: int, models: Iterable[str]) -> dict[str, float]:
 # CLI
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Benchmark extractor performance")
+    parser = argparse.ArgumentParser(description="Benchmark extraction performance")
     parser.add_argument("--tracks", type=int, default=1, help="number of tracks")
     parser.add_argument(
         "--models", nargs="*", default=["dummy"], help="model names to benchmark"

--- a/services/base/Dockerfile
+++ b/services/base/Dockerfile
@@ -23,7 +23,7 @@ COPY sidetrack ./sidetrack
 # downloaded packages persist across builds.
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip wheel --wheel-dir /wheels \
-    '.[api]' '.[worker]' '.[jobrunner]' '.[extractor]' \
+    '.[api]' '.[worker]' '.[jobrunner]' '.[extraction]' \
     && ls -l /wheels
 
 # Verify critical dependency wheels exist to support offline installs later

--- a/services/extractor/Dockerfile
+++ b/services/extractor/Dockerfile
@@ -1,10 +1,10 @@
 # syntax=docker/dockerfile:1
 
-# Build stage: install extractor extras using cached wheels
+# Build stage: install extraction extras using cached wheels
 FROM sidetrack/base:dev AS builder
 RUN apt-get update && apt-get install -y --no-install-recommends build-essential \
     && rm -rf /var/lib/apt/lists/*
-RUN pip install --no-cache-dir --no-index --find-links /wheels 'sidetrack[extractor]'
+RUN pip install --no-cache-dir --no-index --find-links /wheels 'sidetrack[extraction]'
 
 # Runtime stage: minimal image with ffmpeg and installed packages
 FROM sidetrack/base:dev AS runtime

--- a/sidetrack/api/main.py
+++ b/sidetrack/api/main.py
@@ -163,7 +163,7 @@ def _enqueue_analysis(track_id: int, settings: Settings) -> None:
     """Enqueue an analysis job for the given track id."""
 
     q = Queue("analysis", connection=_get_redis_connection(settings))
-    q.enqueue("extraction.pipeline.analyze_track", track_id)
+    q.enqueue("sidetrack.extraction.pipeline.analyze_track", track_id)
 
 
 def _week_start(dt: datetime) -> date:
@@ -192,13 +192,13 @@ async def health(db: AsyncSession = Depends(get_db)):
     except Exception as exc:  # pragma: no cover
         details["redis"] = f"error: {exc.__class__.__name__}"
         status = "degraded"
-    # Extractor check
+    # Extraction check
     try:
         from sidetrack.extraction import pipeline  # noqa: F401
 
-        details["extractor"] = "ok"
+        details["extraction"] = "ok"
     except Exception as exc:  # pragma: no cover
-        details["extractor"] = f"error: {exc.__class__.__name__}"
+        details["extraction"] = f"error: {exc.__class__.__name__}"
         status = "degraded"
     # Enrichment check
     try:

--- a/sidetrack/config.py
+++ b/sidetrack/config.py
@@ -16,7 +16,7 @@ import numpy as np
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-try:  # optional torch for extractor configuration
+try:  # optional torch for extraction configuration
     import torch
 except Exception:  # pragma: no cover
     torch = None  # type: ignore
@@ -36,7 +36,7 @@ def _get_bool(name: str, default: bool = False) -> bool:
 
 @dataclass
 class ExtractionConfig:
-    """Configuration for the audio feature extractor."""
+    """Configuration for the audio feature extraction pipeline."""
 
     embedding_model: str | None = os.getenv("EMBEDDING_MODEL", "openl3")
     use_clap: bool = _get_bool("USE_CLAP", False)

--- a/sidetrack/extraction/cli.py
+++ b/sidetrack/extraction/cli.py
@@ -11,7 +11,7 @@ Run on a cron schedule (every 5 minutes)::
     python -m sidetrack extract --schedule "*/5 * * * *"
 
 The ``--schedule`` option accepts either a floating-point interval in seconds or a
-standard cron expression. Cron expressions are validated before the extractor starts.
+standard cron expression. Cron expressions are validated before extraction starts.
 """
 
 from __future__ import annotations

--- a/sidetrack/extraction/dsp.py
+++ b/sidetrack/extraction/dsp.py
@@ -23,7 +23,7 @@ def resample_audio(y: np.ndarray, orig_sr: int, target_sr: int) -> np.ndarray:
     if orig_sr == target_sr:
         return y
     if librosa is None:
-        raise ImportError("librosa is required for resampling; install sidetrack[extractor]")
+        raise ImportError("librosa is required for resampling; install sidetrack[extraction]")
     return librosa.resample(y, orig_sr=orig_sr, target_sr=target_sr)
 
 
@@ -42,7 +42,7 @@ def excerpt_audio(y: np.ndarray, sr: int, seconds: float | None) -> np.ndarray:
         return y
 
     if librosa is None:
-        raise ImportError("librosa is required for excerpting; install sidetrack[extractor]")
+        raise ImportError("librosa is required for excerpting; install sidetrack[extraction]")
 
     # Compute frame-wise RMS energy and locate the frame with the maximum
     # value.  Use this frame's centre as the centre of the excerpt.
@@ -60,7 +60,7 @@ def excerpt_audio(y: np.ndarray, sr: int, seconds: float | None) -> np.ndarray:
 
 def melspectrogram(track_id: int, y: np.ndarray, sr: int, cache_dir: Path) -> np.ndarray:
     if librosa is None:
-        raise ImportError("librosa is required for spectrograms; install sidetrack[extractor]")
+        raise ImportError("librosa is required for spectrograms; install sidetrack[extraction]")
 
     start = time.perf_counter()
     mel = load_melspec(track_id, cache_dir)

--- a/sidetrack/extraction/features.py
+++ b/sidetrack/extraction/features.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 def extract_features(track_id: int, y: np.ndarray, sr: int, cache_dir) -> dict:
     if librosa is None:
         raise ImportError(
-            "librosa is required for feature extraction; install sidetrack[extractor]"
+            "librosa is required for feature extraction; install sidetrack[extraction]"
         )
 
     start = time.perf_counter()

--- a/sidetrack/extraction/io.py
+++ b/sidetrack/extraction/io.py
@@ -38,7 +38,7 @@ def decode(track_id: int, path: str, cache_dir: Path) -> tuple[np.ndarray, int]:
     """Decode ``path`` into a waveform, optionally caching the result."""
 
     if sf is None:
-        raise ImportError("soundfile is required for audio decoding; install sidetrack[extractor]")
+        raise ImportError("soundfile is required for audio decoding; install sidetrack[extraction]")
 
     start = time.perf_counter()
     cp = cache_path(cache_dir, track_id, "raw", "npz")

--- a/tests/api/test_health.py
+++ b/tests/api/test_health.py
@@ -7,6 +7,6 @@ async def test_health_ok(app_client):
     assert resp.status_code == 200
     data = resp.json()
     assert data["status"] in {"ok", "degraded"}
-    assert "extractor" in data
+    assert "extraction" in data
     assert "enrichment" in data
 


### PR DESCRIPTION
## Summary
- rename the optional dependency group to `extraction` and update documentation/instructions
- refresh extraction error messages and CLI wording to point to `sidetrack[extraction]`
- ensure the API enqueues `sidetrack.extraction.pipeline.analyze_track` and reports an `extraction` health key

## Testing
- `pytest -m "unit and not slow and not gpu" -q`


------
https://chatgpt.com/codex/tasks/task_e_68c8b8fbe78083339b3c1590e23214f9