### PR TITLE
Use Redis-backed queue metadata for job runner

### DIFF
--- a/services/jobrunner/test_jobrunner.py
+++ b/services/jobrunner/test_jobrunner.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import pytest
 import schedule
 
@@ -13,9 +15,45 @@ def test_all_jobs_run(monkeypatch):
 
     run = importlib.import_module("sidetrack.jobrunner.run")
 
+    class _Job:
+        def __init__(self, job_id: str) -> None:
+            self.id = job_id
+            self.enqueued_at = datetime.utcnow()
+            self.started_at = None
+            self.ended_at = None
+            self._status = "queued"
+
+        def get_status(self, refresh: bool = False) -> str:  # pragma: no cover - stub
+            return self._status
+
+    class _FakeRedis:
+        def __init__(self) -> None:
+            self.hashes: dict[str, dict[str, str]] = {}
+
+        def hget(self, name: str, key: str) -> str | None:
+            return self.hashes.get(name, {}).get(key)
+
+        def hset(self, name: str, key: str, value: str) -> None:
+            self.hashes.setdefault(name, {})[key] = value
+
+        def hdel(self, name: str, key: str) -> None:  # pragma: no cover - stub
+            self.hashes.get(name, {}).pop(key, None)
+
     class _Queue:
+        def __init__(self) -> None:
+            self.connection = _FakeRedis()
+            self._jobs: dict[str, _Job] = {}
+            self._counter = 0
+
         def enqueue(self, func, user_id, cursor=None):
-            calls.append((func.__name__, user_id))
+            self._counter += 1
+            job = _Job(f"job-{self._counter}")
+            self._jobs[job.id] = job
+            calls.append((func.__name__, user_id, cursor))
+            return job
+
+        def fetch_job(self, job_id: str):  # pragma: no cover - stub
+            return self._jobs.get(job_id)
 
     monkeypatch.setattr(run, "queue", _Queue())
     monkeypatch.setattr(run, "fetch_user_ids", lambda: ["u1", "u2"])
@@ -24,14 +62,14 @@ def test_all_jobs_run(monkeypatch):
     run.schedule_jobs()
     schedule.run_all(delay_seconds=0)
 
-    expected = [
+    expected = {
         ("sync_user", "u1"),
         ("sync_user", "u2"),
         ("aggregate_weeks", "u1"),
         ("aggregate_weeks", "u2"),
-    ]
-    for item in expected:
-        assert item in calls
+    }
+    seen = {(name, user) for name, user, _ in calls}
+    assert expected == seen
 
 
 def test_schedule_jobs_idempotent(monkeypatch):

--- a/sidetrack/api/routers/ops.py
+++ b/sidetrack/api/routers/ops.py
@@ -86,7 +86,7 @@ def list_schedules() -> dict[str, list[dict[str, str | None]]]:
         job_type = tag_map.get("job")
         if not user_id or not job_type:
             continue
-        state = jobrunner_run.JOB_STATE.get((user_id, job_type), {})
+        state = jobrunner_run.get_job_state(user_id, job_type)
         last_run = state.get("last_run")
         out.append(
             {


### PR DESCRIPTION
## Summary
- persist job runner state, cursor, and last job metadata in Redis via queue helpers
- surface job state through a helper consumed by the ops schedule endpoint
- update job runner tests to stub Redis/queue interactions under the new semantics

## Testing
- pytest -m "unit and not slow and not gpu" -q

------
https://chatgpt.com/codex/tasks/task_e_68c8bf94b28483339ae7e1fd8190b01a