### PR TITLE
Convert jobrunner user fetch to async

### DIFF
--- a/services/jobrunner/test_jobrunner.py
+++ b/services/jobrunner/test_jobrunner.py
@@ -55,7 +55,11 @@ def test_all_jobs_run(monkeypatch):
         def fetch_job(self, job_id: str):  # pragma: no cover - stub
             return self._jobs.get(job_id)
 
+    async def _fake_fetch_user_ids() -> list[str]:
+        return ["u1", "u2"]
+
     monkeypatch.setattr(run, "queue", _Queue())
+    monkeypatch.setattr(run, "fetch_user_ids_async", _fake_fetch_user_ids)
     monkeypatch.setattr(run, "fetch_user_ids", lambda: ["u1", "u2"])
 
     schedule.clear()
@@ -78,6 +82,11 @@ def test_schedule_jobs_idempotent(monkeypatch):
     import importlib
 
     run = importlib.import_module("sidetrack.jobrunner.run")
+
+    async def _fake_fetch_user_ids() -> list[str]:
+        return ["u1", "u2"]
+
+    monkeypatch.setattr(run, "fetch_user_ids_async", _fake_fetch_user_ids)
     monkeypatch.setattr(run, "fetch_user_ids", lambda: ["u1", "u2"])
     schedule.clear()
     run.schedule_jobs()

--- a/tests/api/test_ops_schedules.py
+++ b/tests/api/test_ops_schedules.py
@@ -69,9 +69,13 @@ async def test_ops_schedules(monkeypatch):
             return self._jobs.get(job_id)
 
     schedule.clear()
-    monkeypatch.setattr(jobrunner_run, "fetch_user_ids", lambda: ["u1"])
+
+    async def _fake_fetch_user_ids() -> list[str]:
+        return ["u1"]
+
+    monkeypatch.setattr(jobrunner_run, "fetch_user_ids_async", _fake_fetch_user_ids)
     monkeypatch.setattr(jobrunner_run, "queue", _Queue())
-    jobrunner_run.schedule_jobs()
+    await jobrunner_run.schedule_jobs_async()
     schedule.run_all(delay_seconds=0)
 
     app = api_main.app


### PR DESCRIPTION
## Summary
- add an async implementation for `fetch_user_ids` with a sync wrapper in the jobrunner
- expose an async `schedule_jobs_async` helper that reuses the new async fetch logic
- update jobrunner and ops schedule tests to use the async helpers and `pytest-asyncio`

## Testing
- pytest -m "unit and not slow and not gpu" -q

------
https://chatgpt.com/codex/tasks/task_e_68c8dbfcd0988333808c1d303ed1d76c