### PR TITLE
Add session scope helpers and reuse them in workers and tests

### DIFF
--- a/services/api/tests/test_analyze_batch.py
+++ b/services/api/tests/test_analyze_batch.py
@@ -4,7 +4,7 @@ import pytest
 
 from sidetrack.api import main
 from sidetrack.api.schemas.tracks import AnalyzeBatchResponse
-from sidetrack.api.db import SessionLocal
+from sidetrack.db import async_session_scope
 from sidetrack.common.models import Feature
 from tests.factories import TrackFactory
 
@@ -13,7 +13,7 @@ pytestmark = pytest.mark.unit
 
 @pytest.mark.asyncio
 async def test_analyze_batch_schedules(async_client, monkeypatch):
-    async with SessionLocal() as db:
+    async with async_session_scope() as db:
         t1 = TrackFactory(path_local="a.wav")
         t2 = TrackFactory(path_local="b.wav")
         db.add_all([t1, t2])
@@ -39,7 +39,7 @@ async def test_analyze_batch_schedules(async_client, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_analyze_batch_skips_existing(async_client, monkeypatch):
-    async with SessionLocal() as db:
+    async with async_session_scope() as db:
         t1 = TrackFactory(path_local="a.wav")
         t2 = TrackFactory(path_local="b.wav")
         db.add_all([t1, t2])

--- a/services/api/tests/test_analyze_track.py
+++ b/services/api/tests/test_analyze_track.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 import pytest
 
 from sidetrack.api import main
-from sidetrack.api.db import SessionLocal
+from sidetrack.db import async_session_scope
 from sidetrack.api.schemas.tracks import AnalyzeTrackResponse
 from tests.factories import TrackFactory
 
@@ -12,7 +12,7 @@ pytestmark = pytest.mark.unit
 
 @pytest.mark.asyncio
 async def test_analyze_track_schedules_job(async_client, monkeypatch):
-    async with SessionLocal() as db:
+    async with async_session_scope() as db:
         tr = TrackFactory(path_local="song.mp3")
         db.add(tr)
         await db.flush()
@@ -43,7 +43,7 @@ async def test_analyze_track_not_found(async_client):
 
 @pytest.mark.asyncio
 async def test_analyze_track_missing_path(async_client):
-    async with SessionLocal() as db:
+    async with async_session_scope() as db:
         tr = TrackFactory()
         db.add(tr)
         await db.flush()

--- a/services/api/tests/test_musicbrainz_ingest.py
+++ b/services/api/tests/test_musicbrainz_ingest.py
@@ -5,9 +5,9 @@ import pytest_asyncio
 from sqlalchemy import func, select
 
 from sidetrack.api import main as main_mod
-from sidetrack.api.db import SessionLocal
 from sidetrack.api.schemas.musicbrainz import MusicbrainzIngestResponse
 from sidetrack.common.models import Artist, Release, Track
+from sidetrack.db import async_session_scope
 
 pytestmark = pytest.mark.integration
 
@@ -53,7 +53,7 @@ async def test_ingest_musicbrainz_dedup(mb_client):
     data = MusicbrainzIngestResponse.model_validate(resp.json())
     assert data.tracks >= 2
 
-    async with SessionLocal() as session:
+    async with async_session_scope() as session:
         assert (await session.scalar(select(func.count()).select_from(Artist))) == 1
         assert (await session.scalar(select(func.count()).select_from(Release))) == 1
         assert (await session.scalar(select(func.count()).select_from(Track))) >= 2

--- a/services/api/tests/test_outliers.py
+++ b/services/api/tests/test_outliers.py
@@ -3,8 +3,8 @@ from datetime import UTC, datetime
 import pytest
 
 from sidetrack.api.constants import AXES, DEFAULT_METHOD
-from sidetrack.api.db import SessionLocal
 from sidetrack.common.models import Artist, Listen, MoodScore
+from sidetrack.db import async_session_scope
 from tests.factories import TrackFactory
 
 pytestmark = pytest.mark.integration
@@ -12,7 +12,7 @@ pytestmark = pytest.mark.integration
 
 async def _add_track(title: str, artist: str, value: float) -> int:
     """Create track with uniform mood scores and a listen."""
-    async with SessionLocal() as db:
+    async with async_session_scope() as db:
         art = Artist(name=artist)
         db.add(art)
         await db.commit()

--- a/services/api/tests/test_track_features.py
+++ b/services/api/tests/test_track_features.py
@@ -1,13 +1,13 @@
 import pytest
 
-from sidetrack.api.db import SessionLocal
+from sidetrack.db import async_session_scope
 from tests.factories import EmbeddingFactory, FeatureFactory, TrackFactory
 
 pytestmark = pytest.mark.integration
 
 
 async def _create_track_with_features() -> int:
-    async with SessionLocal() as db:
+    async with async_session_scope() as db:
         tr = TrackFactory()
         db.add(tr)
         await db.flush()

--- a/services/extractor/tests/test_features.py
+++ b/services/extractor/tests/test_features.py
@@ -2,11 +2,11 @@ import numpy as np
 import pytest
 import soundfile as sf
 
-from sidetrack.api.db import SessionLocal
 from sidetrack.common.models import Feature
 from sidetrack.config import ExtractionConfig
 from sidetrack.extraction.pipeline import analyze_track
 from tests.factories import TrackFactory
+from sidetrack.db import session_scope
 
 pytestmark = pytest.mark.integration
 
@@ -14,7 +14,7 @@ pytestmark = pytest.mark.integration
 def test_analyze_track(tmp_path):
     wav = tmp_path / "a.wav"
     sf.write(wav, np.zeros(1024), 22050)
-    with SessionLocal() as db:
+    with session_scope() as db:
         from sidetrack.common.models import Base
 
         Base.metadata.create_all(db.bind)
@@ -26,6 +26,6 @@ def test_analyze_track(tmp_path):
     cfg = ExtractionConfig()
     cfg.set_seed(0)
     fid = analyze_track(tid, cfg)
-    with SessionLocal() as db:
+    with session_scope() as db:
         feat = db.get(Feature, fid)
         assert feat and feat.track_id == tid

--- a/sidetrack/db/__init__.py
+++ b/sidetrack/db/__init__.py
@@ -1,0 +1,5 @@
+"""Database utility helpers."""
+
+from .utils import async_session_scope, session_scope
+
+__all__ = ["async_session_scope", "session_scope"]

--- a/sidetrack/db/utils.py
+++ b/sidetrack/db/utils.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+from contextlib import asynccontextmanager, contextmanager, suppress
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Session
+
+from sidetrack.api.db import SessionLocal
+
+
+@contextmanager
+def session_scope(*, commit: bool = False) -> Iterator[Session]:
+    """Yield a synchronous :class:`Session` and ensure it is closed.
+
+    Parameters
+    ----------
+    commit:
+        When ``True`` the session is committed when the context exits
+        successfully. Any exception triggers a rollback before the
+        exception is re-raised.
+    """
+
+    session = SessionLocal(async_session=False)
+    try:
+        yield session
+        if commit:
+            session.commit()
+    except BaseException:
+        with suppress(Exception):
+            session.rollback()
+        raise
+    finally:
+        with suppress(Exception):
+            session.close()
+
+
+@asynccontextmanager
+async def async_session_scope(*, commit: bool = False) -> AsyncIterator[AsyncSession]:
+    """Yield an :class:`AsyncSession` and ensure it is closed.
+
+    Parameters
+    ----------
+    commit:
+        When ``True`` the session is committed on successful exit. Any
+        exception triggers an async rollback before the exception is
+        re-raised.
+    """
+
+    session = SessionLocal(async_session=True)
+    try:
+        yield session
+        if commit:
+            await session.commit()
+    except BaseException:
+        with suppress(Exception):
+            await session.rollback()
+        raise
+    finally:
+        with suppress(Exception):
+            await session.close()

--- a/sidetrack/extraction/pipeline.py
+++ b/sidetrack/extraction/pipeline.py
@@ -10,9 +10,9 @@ from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session
 
-from sidetrack.api.db import SessionLocal
 from sidetrack.common.models import Embedding, Feature, Track
 from sidetrack.config import ExtractionConfig
+from sidetrack.db import session_scope
 
 from . import io, dsp, features as feat_mod, stems, scoring
 from sidetrack.extraction import compute_embeddings
@@ -74,7 +74,7 @@ def analyze_tracks(db: Session, track_ids: Iterable[int], cfg: ExtractionConfig,
 def analyze_track(track_id: int, cfg: ExtractionConfig, redis_conn=None) -> int:
     """Run the modular extraction pipeline for ``track_id`` and return feature id."""
 
-    with SessionLocal() as db:
+    with session_scope() as db:
         processed = analyze_tracks(db, [track_id], cfg, redis_conn=redis_conn)
         if not processed:
             raise ValueError("track missing")

--- a/sidetrack/jobrunner/run.py
+++ b/sidetrack/jobrunner/run.py
@@ -12,9 +12,9 @@ import schedule
 from rq import Queue
 from sqlalchemy import select
 
-from sidetrack.api.db import SessionLocal
 from sidetrack.common.logging import setup_logging
 from sidetrack.common.models import UserAccount
+from sidetrack.db import session_scope
 from sidetrack.worker import jobs as worker_jobs
 
 from .config import get_settings
@@ -33,7 +33,7 @@ CURSORS: dict[tuple[str, str], str] = {}
 def fetch_user_ids() -> list[str]:
     """Return all registered user ids from the database."""
     try:
-        with SessionLocal(async_session=False) as db:
+        with session_scope() as db:
             stmt = select(UserAccount.user_id)
             return list(db.execute(stmt).scalars().all())
     except Exception:  # pragma: no cover - db errors


### PR DESCRIPTION
## Summary
- add `session_scope` and `async_session_scope` helpers under `sidetrack/db`
- update the job runner, worker jobs, and extraction pipeline to use the new helpers
- reuse the context helpers throughout service tests and fixtures

## Testing
- pytest -m "unit and not slow and not gpu" -q

------
https://chatgpt.com/codex/tasks/task_e_68c8b55ae0308333b373ff7a7ca200d3