### PR TITLE
Refactor UI navigation to share nav config

### DIFF
--- a/services/ui/components/MobileNav.tsx
+++ b/services/ui/components/MobileNav.tsx
@@ -2,29 +2,17 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import clsx from 'clsx';
-import * as Icons from 'lucide-react';
-import nav from '../nav.json';
-import useFeatureFlag from '../hooks/useFeatureFlag';
-
-type NavItem = {
-  path: string;
-  label: string;
-  icon: keyof typeof Icons;
-  featureFlag?: string | null;
-};
-
-const items = nav as NavItem[];
+import { useNavItems } from '../lib/nav';
 
 export default function MobileNav() {
   const pathname = usePathname();
-  const visibleItems = items.filter((item) => useFeatureFlag(item.featureFlag));
+  const visibleItems = useNavItems();
   return (
     <nav
       className="fixed bottom-0 left-0 right-0 z-40 flex border-t border-white/10 bg-black/70 p-2 backdrop-blur md:hidden"
       aria-label="Primary"
     >
       {visibleItems.map((item, idx) => {
-        const Icon = Icons[item.icon];
         const active = pathname === item.path || pathname.startsWith(`${item.path}/`);
         return (
           <Link
@@ -38,7 +26,7 @@ export default function MobileNav() {
               active ? 'text-emerald-300' : 'text-muted-foreground hover:text-foreground',
             )}
           >
-            <Icon size={18} />
+            <item.icon size={18} />
             <span className="text-xs">{item.label}</span>
           </Link>
         );

--- a/services/ui/components/layout/Sidebar.tsx
+++ b/services/ui/components/layout/Sidebar.tsx
@@ -2,17 +2,10 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Home, Sparkles, Compass, BarChart3, Settings, Menu } from 'lucide-react';
+import { Menu } from 'lucide-react';
 import clsx from 'clsx';
 import ThemeToggle from '../common/ThemeToggle';
-
-const navItems = [
-  { href: '/', label: 'Home', icon: Home },
-  { href: '/recommendations', label: 'Recommendations', icon: Sparkles },
-  { href: '/explore', label: 'Explore', icon: Compass },
-  { href: '/insights', label: 'Insights', icon: BarChart3 },
-  { href: '/settings', label: 'Settings', icon: Settings },
-];
+import { useNavItems } from '../../lib/nav';
 
 export default function Sidebar({
   collapsed,
@@ -22,6 +15,7 @@ export default function Sidebar({
   setCollapsed: (v: boolean) => void;
 }) {
   const pathname = usePathname();
+  const navItems = useNavItems();
 
   return (
     <aside
@@ -45,11 +39,11 @@ export default function Sidebar({
       </div>
       <nav className="flex-1 space-y-1 px-2">
         {navItems.map((item) => {
-          const active = pathname === item.href || pathname.startsWith(item.href + '/');
+          const active = pathname === item.path || pathname.startsWith(item.path + '/');
           return (
-            <div key={item.href} className="relative group">
+            <div key={item.path} className="relative group">
               <Link
-                href={item.href}
+                href={item.path}
                 className={clsx(
                   'relative flex items-center gap-3 rounded-md px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-white/10 hover:text-foreground focus:outline-none focus:ring-2 focus:ring-emerald-500',
                   active && 'bg-white/10 text-foreground',

--- a/services/ui/lib/nav.ts
+++ b/services/ui/lib/nav.ts
@@ -1,0 +1,32 @@
+'use client';
+
+import * as Icons from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+
+import nav from '../nav.json';
+import useFeatureFlag from '../hooks/useFeatureFlag';
+
+type RawNavItem = {
+  path: string;
+  label: string;
+  icon: keyof typeof Icons;
+  featureFlag?: string | null;
+};
+
+export type NavItem = {
+  path: string;
+  label: string;
+  icon: LucideIcon;
+};
+
+export function useNavItems(): NavItem[] {
+  const items = nav as RawNavItem[];
+
+  return items
+    .filter((item) => useFeatureFlag(item.featureFlag))
+    .map(({ path, label, icon }) => ({
+      path,
+      label,
+      icon: Icons[icon],
+    }));
+}


### PR DESCRIPTION
## Summary
- add a navigation helper that reads `nav.json` and filters items by feature flags
- refactor the sidebar and mobile nav components to consume the shared helper for labels, paths, and icons

## Testing
- npm test
- npm run lint *(fails: Failed to load config "prettier" to extend from; referenced from root .eslintrc.cjs)*

------
https://chatgpt.com/codex/tasks/task_e_68c8e346ea48833393f80990c7f81805