### PR TITLE
Add global route progress indicator

### DIFF
--- a/services/ui/app/layout.tsx
+++ b/services/ui/app/layout.tsx
@@ -9,6 +9,7 @@ import { Inter } from 'next/font/google';
 import Providers from './providers';
 import ThemeProvider from '../components/ThemeProvider';
 import AppShell from '../components/layout/AppShell';
+import RouteProgress from '../components/RouteProgress';
 
 const inter = Inter({ subsets: ['latin'], variable: '--font-sans' });
 
@@ -18,6 +19,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body className={`${inter.variable} font-sans antialiased`}>
         <ThemeProvider>
           <Providers>
+            <RouteProgress />
             <PageTransition>
               <AppShell>{children}</AppShell>
             </PageTransition>


### PR DESCRIPTION
## Summary
- render the RouteProgress component once from the app layout so navigation shows a progress bar
- rely on the existing lib/nprogress module to include the CSS when the progress bar mounts

## Testing
- npm run dev
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68c8e56cc4908333a61eda16e22e30b1