### PR TITLE
Add not found page for UI app

### DIFF
--- a/services/ui/app/not-found.test.tsx
+++ b/services/ui/app/not-found.test.tsx
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/react';
+
+import NotFound from './not-found';
+
+describe('NotFound page', () => {
+  it('renders a helpful message and link home', () => {
+    render(<NotFound />);
+
+    expect(screen.getByRole('heading', { name: /page not found/i })).toBeInTheDocument();
+
+    const homeLink = screen.getByRole('link', { name: /return home/i });
+    expect(homeLink).toBeInTheDocument();
+    expect(homeLink).toHaveAttribute('href', '/');
+  });
+});

--- a/services/ui/app/not-found.tsx
+++ b/services/ui/app/not-found.tsx
@@ -1,0 +1,20 @@
+import Link from 'next/link';
+
+import { Button } from '../components/ui/button';
+import { Typography } from '../components/ui/Typography';
+
+export default function NotFound() {
+  return (
+    <section className="flex min-h-[60vh] flex-col items-center justify-center gap-6 px-4 text-center">
+      <Typography as="h1" variant="h1" className="text-3xl sm:text-4xl">
+        Page not found
+      </Typography>
+      <Typography className="max-w-md text-muted-foreground">
+        We couldn't find the page you're looking for. Head back home to continue exploring your insights.
+      </Typography>
+      <Button asChild>
+        <Link href="/">Return home</Link>
+      </Button>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add a tailored app router `not-found` page styled with shared UI components
- cover the new page with a Jest test to ensure the message and home link render

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8e6a7ac1c833384c93fa465d7b8f9