### PR TITLE
Add drag interactions for RecCard

### DIFF
--- a/services/ui/components/recs/RecActions.tsx
+++ b/services/ui/components/recs/RecActions.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { motion, useTransform, type MotionValue } from 'framer-motion';
 import { Button } from '../ui/button';
 import { useToast } from '../ToastProvider';
 import { Dialog, DialogContent, DialogTrigger } from '../ui/dialog';
@@ -8,39 +9,72 @@ interface Props {
   onLike: () => void | Promise<void>;
   onSkip: () => void | Promise<void>;
   onHideArtist: () => void | Promise<void>;
+  likeProgress: MotionValue<number>;
+  skipProgress: MotionValue<number>;
+  hideProgress: MotionValue<number>;
 }
 
-export default function RecActions({ onLike, onSkip, onHideArtist }: Props) {
+const MotionButton = motion(Button);
+
+export default function RecActions({
+  onLike,
+  onSkip,
+  onHideArtist,
+  likeProgress,
+  skipProgress,
+  hideProgress,
+}: Props) {
   const { show } = useToast();
+
+  const likeScale = useTransform(likeProgress, [0, 1], [1, 1.06]);
+  const likeY = useTransform(likeProgress, (value) => -6 * value);
+  const likeShadow = useTransform(likeProgress, (value) =>
+    `0 0 0 ${12 * value}px rgba(74, 222, 128, ${0.35 * value})`,
+  );
+
+  const skipScale = useTransform(skipProgress, [0, 1], [1, 1.06]);
+  const skipY = useTransform(skipProgress, (value) => -6 * value);
+  const skipShadow = useTransform(skipProgress, (value) =>
+    `0 0 0 ${12 * value}px rgba(56, 189, 248, ${0.35 * value})`,
+  );
+
+  const hideScale = useTransform(hideProgress, [0, 1], [1, 1.06]);
+  const hideY = useTransform(hideProgress, (value) => -6 * value);
+  const hideShadow = useTransform(hideProgress, (value) =>
+    `0 0 0 ${12 * value}px rgba(248, 113, 113, ${0.4 * value})`,
+  );
 
   const ActionButtons = () => (
     <>
-      <Button
+      <MotionButton
+        style={{ scale: likeScale, y: likeY, boxShadow: likeShadow }}
         onClick={async () => {
           await onLike();
           show({ title: 'Saved', kind: 'success' });
         }}
       >
         Like
-      </Button>
-      <Button
+      </MotionButton>
+      <MotionButton
         variant="outline"
+        style={{ scale: skipScale, y: skipY, boxShadow: skipShadow }}
         onClick={async () => {
           await onSkip();
           show({ title: 'Skipped', kind: 'info' });
         }}
       >
         Skip
-      </Button>
-      <Button
+      </MotionButton>
+      <MotionButton
         variant="ghost"
+        style={{ scale: hideScale, y: hideY, boxShadow: hideShadow }}
         onClick={async () => {
           await onHideArtist();
           show({ title: 'Artist hidden', kind: 'success' });
         }}
       >
         Hide artist
-      </Button>
+      </MotionButton>
     </>
   );
 

--- a/services/ui/components/recs/RecCard.test.tsx
+++ b/services/ui/components/recs/RecCard.test.tsx
@@ -1,0 +1,172 @@
+import React from 'react';
+import { act } from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent, { PointerEventsCheckLevel } from '@testing-library/user-event';
+import RecCard, { type Rec } from './RecCard';
+import ToastProvider from '../ToastProvider';
+
+jest.mock('framer-motion', () => {
+  const motion = (Component: React.ComponentType<any>) =>
+    React.forwardRef<HTMLDivElement, any>((props, ref) => <Component ref={ref} {...props} />);
+
+  motion.div = React.forwardRef<HTMLDivElement, any>((props, ref) => {
+    const {
+      children,
+      onDragEnd,
+      style,
+      dragConstraints,
+      dragElastic,
+      dragMomentum,
+      dragSnapToOrigin,
+      ...rest
+    } = props;
+    const startRef = React.useRef<number | null>(null);
+
+    const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+      startRef.current = event.clientX;
+      rest.onPointerDown?.(event);
+    };
+
+    const handlePointerUp = (event: React.PointerEvent<HTMLDivElement>) => {
+      rest.onPointerUp?.(event);
+      if (startRef.current !== null) {
+        const offset = event.clientX - startRef.current;
+        onDragEnd?.(event, {
+          offset: { x: offset, y: 0 },
+          delta: { x: offset, y: 0 },
+          point: { x: event.clientX, y: event.clientY },
+          velocity: { x: 0, y: 0 },
+        });
+        startRef.current = null;
+      }
+    };
+
+    const resolvedStyle = style && 'x' in style ? { ...style, transform: undefined } : style;
+
+    return (
+      <div
+        ref={ref}
+        {...rest}
+        style={resolvedStyle}
+        data-drag-constraints={dragConstraints ? 'mock' : undefined}
+        data-drag-elastic={dragElastic ? 'mock' : undefined}
+        data-drag-momentum={dragMomentum ? 'mock' : undefined}
+        data-drag-snap={dragSnapToOrigin ? 'mock' : undefined}
+        onPointerDown={handlePointerDown}
+        onPointerUp={handlePointerUp}
+      >
+        {children}
+      </div>
+    );
+  });
+
+  return {
+    __esModule: true,
+    motion,
+    useMotionValue: (initial: number) => {
+      let value = initial;
+      return {
+        set: (v: number) => {
+          value = v;
+        },
+        get: () => value,
+      };
+    },
+    useTransform: () => 0,
+  };
+});
+
+jest.mock('../../lib/artwork', () => ({
+  getArtworkUrl: jest.fn(() => Promise.resolve(null)),
+}));
+
+const baseRec: Rec = {
+  title: 'Test Track',
+  artist: 'Test Artist',
+};
+
+const renderCard = async () => {
+  const onLike = jest.fn();
+  const onSkip = jest.fn();
+  const onHideArtist = jest.fn();
+
+  await act(async () => {
+    render(
+      <ToastProvider>
+        <RecCard rec={baseRec} onLike={onLike} onSkip={onSkip} onHideArtist={onHideArtist} />
+      </ToastProvider>,
+    );
+  });
+
+  return {
+    card: screen.getByTestId('rec-card'),
+    onLike,
+    onSkip,
+    onHideArtist,
+  };
+};
+
+const dragCard = async (
+  card: HTMLElement,
+  deltaX: number,
+  user = userEvent.setup({ pointerEventsCheck: PointerEventsCheckLevel.Never }),
+) => {
+  const startX = 150;
+  await user.pointer([
+    { target: card, coords: { clientX: startX, clientY: 0 }, keys: '[MouseLeft>]' },
+    { target: card, coords: { clientX: startX + deltaX, clientY: 0 } },
+    { target: card, coords: { clientX: startX + deltaX, clientY: 0 }, keys: '[/MouseLeft]' },
+  ]);
+};
+
+describe('RecCard drag gestures', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls onLike when dragged to the right beyond the threshold', async () => {
+    const { card, onLike, onSkip, onHideArtist } = await renderCard();
+    const user = userEvent.setup({ pointerEventsCheck: PointerEventsCheckLevel.Never });
+
+    await dragCard(card, 180, user);
+
+    await waitFor(() => expect(onLike).toHaveBeenCalledTimes(1));
+    expect(onSkip).not.toHaveBeenCalled();
+    expect(onHideArtist).not.toHaveBeenCalled();
+  });
+
+  it('calls onSkip when dragged to the left beyond the skip threshold', async () => {
+    const { card, onLike, onSkip, onHideArtist } = await renderCard();
+    const user = userEvent.setup({ pointerEventsCheck: PointerEventsCheckLevel.Never });
+
+    await dragCard(card, -140, user);
+
+    await waitFor(() => expect(onSkip).toHaveBeenCalledTimes(1));
+    expect(onLike).not.toHaveBeenCalled();
+    expect(onHideArtist).not.toHaveBeenCalled();
+  });
+
+  it('calls onHideArtist when dragged far to the left', async () => {
+    const { card, onLike, onSkip, onHideArtist } = await renderCard();
+    const user = userEvent.setup({ pointerEventsCheck: PointerEventsCheckLevel.Never });
+
+    await dragCard(card, -260, user);
+
+    await waitFor(() => expect(onHideArtist).toHaveBeenCalledTimes(1));
+    expect(onLike).not.toHaveBeenCalled();
+    expect(onSkip).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when released before reaching a threshold', async () => {
+    const { card, onLike, onSkip, onHideArtist } = await renderCard();
+    const user = userEvent.setup({ pointerEventsCheck: PointerEventsCheckLevel.Never });
+
+    await dragCard(card, 30, user);
+
+    await waitFor(() => {
+      expect(onLike).not.toHaveBeenCalled();
+      expect(onSkip).not.toHaveBeenCalled();
+      expect(onHideArtist).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/services/ui/components/recs/RecCard.tsx
+++ b/services/ui/components/recs/RecCard.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import Image from 'next/image';
-import { useEffect, useRef, useState } from 'react';
+import { motion, useMotionValue, useTransform, type PanInfo } from 'framer-motion';
+import { useEffect, useMemo, useState } from 'react';
 import BecauseChips from './BecauseChips';
 import RecActions from './RecActions';
 import Skeleton from '../Skeleton';
@@ -23,10 +24,62 @@ interface Props {
   onHideArtist: () => void;
 }
 
+const LIKE_THRESHOLD = 120;
+const SKIP_THRESHOLD = 100;
+const HIDE_THRESHOLD = 220;
+
+const clamp = (value: number, min = 0, max = 1) => Math.min(Math.max(value, min), max);
+
 export default function RecCard({ rec, onLike, onSkip, onHideArtist }: Props) {
   const [img, setImg] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
-  const startX = useRef<number | null>(null);
+  const x = useMotionValue(0);
+
+  const likeProgress = useTransform(x, (value) => (value <= 0 ? 0 : clamp(value / LIKE_THRESHOLD)));
+  const skipProgress = useTransform(x, (value) => {
+    if (value >= 0) return 0;
+    const magnitude = Math.abs(value);
+    if (magnitude <= SKIP_THRESHOLD) {
+      return clamp(magnitude / SKIP_THRESHOLD);
+    }
+    if (magnitude >= HIDE_THRESHOLD) {
+      return 0;
+    }
+    const between = (magnitude - SKIP_THRESHOLD) / (HIDE_THRESHOLD - SKIP_THRESHOLD);
+    return clamp(1 - between);
+  });
+  const hideProgress = useTransform(x, (value) => {
+    if (value >= 0) return 0;
+    const magnitude = Math.abs(value);
+    if (magnitude <= SKIP_THRESHOLD) {
+      return 0;
+    }
+    if (magnitude >= HIDE_THRESHOLD) {
+      return 1;
+    }
+    const between = (magnitude - SKIP_THRESHOLD) / (HIDE_THRESHOLD - SKIP_THRESHOLD);
+    return clamp(between);
+  });
+
+  const dragConstraints = useMemo(() => ({ left: -HIDE_THRESHOLD - 80, right: LIKE_THRESHOLD + 80 }), []);
+
+  const handleDragEnd = (_: MouseEvent | TouchEvent | PointerEvent, info: PanInfo) => {
+    const offsetX = info.offset.x;
+    if (offsetX > LIKE_THRESHOLD) {
+      onLike();
+      x.set(0);
+      return;
+    }
+    if (offsetX < -HIDE_THRESHOLD) {
+      onHideArtist();
+      x.set(0);
+      return;
+    }
+    if (offsetX < -SKIP_THRESHOLD) {
+      onSkip();
+    }
+    x.set(0);
+  };
 
   useEffect(() => {
     setLoading(true);
@@ -36,18 +89,16 @@ export default function RecCard({ rec, onLike, onSkip, onHideArtist }: Props) {
   }, [rec.spotify_id, rec.recording_mbid]);
 
   return (
-    <div
+    <motion.div
+      data-testid="rec-card"
       className="space-y-4 rounded-lg border p-4 touch-pan-y"
-      onPointerDown={(e) => {
-        startX.current = e.clientX;
-      }}
-      onPointerUp={(e) => {
-        if (startX.current === null) return;
-        const diff = e.clientX - startX.current;
-        if (diff > 40) onLike();
-        if (diff < -40) onSkip();
-        startX.current = null;
-      }}
+      drag="x"
+      dragConstraints={dragConstraints}
+      dragElastic={0.2}
+      dragMomentum={false}
+      dragSnapToOrigin
+      onDragEnd={handleDragEnd}
+      style={{ x }}
     >
       {loading ? (
         <Skeleton className="h-[300px]" />
@@ -65,8 +116,15 @@ export default function RecCard({ rec, onLike, onSkip, onHideArtist }: Props) {
         <p className="text-sm text-muted-foreground">{rec.artist}</p>
       </div>
       {rec.reasons && rec.reasons.length > 0 && <BecauseChips reasons={rec.reasons} />}
-      <RecActions onLike={onLike} onSkip={onSkip} onHideArtist={onHideArtist} />
-    </div>
+      <RecActions
+        onLike={onLike}
+        onSkip={onSkip}
+        onHideArtist={onHideArtist}
+        likeProgress={likeProgress}
+        skipProgress={skipProgress}
+        hideProgress={hideProgress}
+      />
+    </motion.div>
   );
 }
 


### PR DESCRIPTION
## Summary
- replace RecCard pointer listeners with a framer-motion drag implementation that supports like, skip, and hide thresholds
- animate RecActions buttons in response to drag progress so the pending action is highlighted
- add RecCard drag tests using user-event with a lightweight framer-motion mock

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8f21d2aac8333a5b07016d194e466