### PR TITLE
Improve dialog accessibility

### DIFF
--- a/services/ui/components/mixtape/MixtapeModal.tsx
+++ b/services/ui/components/mixtape/MixtapeModal.tsx
@@ -53,7 +53,7 @@ export default function MixtapeModal({ open, onOpenChange, tracks }: Props) {
             <span>{length}</span>
           </label>
           <div className="flex flex-col gap-2 sm:flex-row">
-            <Button onClick={exportM3U} className="flex-1">
+            <Button onClick={exportM3U} className="flex-1" autoFocus>
               Export M3U
             </Button>
             <Button

--- a/services/ui/components/recs/RecActions.tsx
+++ b/services/ui/components/recs/RecActions.tsx
@@ -44,9 +44,10 @@ export default function RecActions({
     `0 0 0 ${12 * value}px rgba(248, 113, 113, ${0.4 * value})`,
   );
 
-  const ActionButtons = () => (
+  const ActionButtons = ({ focusFirst = false }: { focusFirst?: boolean }) => (
     <>
       <MotionButton
+        autoFocus={focusFirst}
         style={{ scale: likeScale, y: likeY, boxShadow: likeShadow }}
         onClick={async () => {
           await onLike();
@@ -89,7 +90,7 @@ export default function RecActions({
         </DialogTrigger>
         <DialogContent className="md:hidden bottom-0 left-0 right-0 top-auto translate-x-0 translate-y-0 max-w-full rounded-t-lg p-4">
           <div className="grid gap-2">
-            <ActionButtons />
+            <ActionButtons focusFirst />
           </div>
         </DialogContent>
       </Dialog>

--- a/services/ui/components/ui/dialog.tsx
+++ b/services/ui/components/ui/dialog.tsx
@@ -5,46 +5,107 @@ import { cn } from '../../lib/utils';
 const Dialog = DialogPrimitive.Root;
 const DialogTrigger = DialogPrimitive.Trigger;
 
+type DialogA11yContextValue = {
+  setTitleId: (id: string | undefined) => void;
+  setDescriptionId: (id: string | undefined) => void;
+};
+
+const DialogA11yContext = React.createContext<DialogA11yContextValue | null>(null);
+
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, ...props }, ref) => (
-  <DialogPrimitive.Portal>
-    <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/80" />
-    <DialogPrimitive.Content
-      ref={ref}
-      className={cn(
-        'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border border-border bg-background p-6 shadow-lg',
-        className,
-      )}
-      {...props}
-    />
-  </DialogPrimitive.Portal>
-));
+>(({ className, children, ...contentProps }, ref) => {
+  const [labelId, setLabelId] = React.useState<string | undefined>();
+  const [descriptionId, setDescriptionId] = React.useState<string | undefined>();
+
+  const {
+    ['aria-labelledby']: ariaLabelledByProp,
+    ['aria-describedby']: ariaDescribedByProp,
+    ...restContentProps
+  } = contentProps;
+
+  const contextValue = React.useMemo(
+    () => ({
+      setTitleId: setLabelId,
+      setDescriptionId,
+    }),
+    [setLabelId, setDescriptionId],
+  );
+
+  const ariaLabelledBy = ariaLabelledByProp ?? labelId;
+  const ariaDescribedBy = ariaDescribedByProp ?? descriptionId;
+
+  return (
+    <DialogA11yContext.Provider value={contextValue}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-black/80" />
+        <DialogPrimitive.Content
+          ref={ref}
+          className={cn(
+            'fixed left-1/2 top-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border border-border bg-background p-6 shadow-lg',
+            className,
+          )}
+          aria-labelledby={ariaLabelledBy}
+          aria-describedby={ariaDescribedBy}
+          {...restContentProps}
+        >
+          {children}
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogA11yContext.Provider>
+  );
+});
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
 const DialogTitle = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Title>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
->(({ className, ...props }, ref) => (
-  <DialogPrimitive.Title
-    ref={ref}
-    className={cn('text-lg font-semibold leading-none tracking-tight', className)}
-    {...props}
-  />
-));
+>(({ className, id: idProp, ...props }, ref) => {
+  const context = React.useContext(DialogA11yContext);
+  const autoId = React.useId();
+  const id = idProp ?? autoId;
+
+  React.useEffect(() => {
+    if (!context) return;
+    context.setTitleId(id);
+    return () => context.setTitleId(undefined);
+  }, [context, id]);
+
+  return (
+    <DialogPrimitive.Title
+      ref={ref}
+      id={id}
+      className={cn('text-lg font-semibold leading-none tracking-tight', className)}
+      {...props}
+    />
+  );
+});
 DialogTitle.displayName = DialogPrimitive.Title.displayName;
 
 const DialogDescription = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Description>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
->(({ className, ...props }, ref) => (
-  <DialogPrimitive.Description
-    ref={ref}
-    className={cn('text-sm text-muted-foreground', className)}
-    {...props}
-  />
-));
+>(({ className, id: idProp, ...props }, ref) => {
+  const context = React.useContext(DialogA11yContext);
+  const autoId = React.useId();
+  const id = idProp ?? autoId;
+
+  React.useEffect(() => {
+    if (!context) return;
+    context.setDescriptionId(id);
+    return () => context.setDescriptionId(undefined);
+  }, [context, id]);
+
+  return (
+    <DialogPrimitive.Description
+      ref={ref}
+      id={id}
+      className={cn('text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  );
+});
 DialogDescription.displayName = DialogPrimitive.Description.displayName;
 
 export { Dialog, DialogTrigger, DialogContent, DialogTitle, DialogDescription };


### PR DESCRIPTION
## Summary
- ensure dialog content exposes aria-labelledby and aria-describedby hooks wired to dialog titles and descriptions
- autofocus the primary action in mixtape and recommendation dialogs for improved keyboard access

## Testing
- `npm test`
- `NODE_PATH=/workspace/SideTrack/services/ui/node_modules npm run lint` *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c8f9af35788333b7e1f2371649e8a9