### PR TITLE
feat(ui): centralize API error handling with toast integration

### DIFF
--- a/services/ui/components/HeaderActions.tsx
+++ b/services/ui/components/HeaderActions.tsx
@@ -16,7 +16,7 @@ export default function HeaderActions() {
     setSyncing(true);
     toast.show({ title: 'Sync started', description: 'Fetching listens…', kind: 'info' });
     try {
-      await apiFetch('/api/lastfm/sync', { method: 'POST' });
+      await apiFetch('/api/lastfm/sync', { method: 'POST', suppressErrorToast: true });
       toast.show({ title: 'Sync complete', description: 'Listens updated', kind: 'success' });
     } catch {
       toast.show({ title: 'Sync failed', description: 'Please try again later', kind: 'error' });

--- a/services/ui/components/inspect/ArtistPanel.tsx
+++ b/services/ui/components/inspect/ArtistPanel.tsx
@@ -26,11 +26,7 @@ export default function ArtistPanel({ artistId }: { artistId: number }) {
     (async () => {
       try {
         const res = await apiFetch(`/inspect/artist/${artistId}`);
-        if (res.ok) {
-          setData((await res.json()) as ArtistData);
-        } else {
-          setData({});
-        }
+        setData((await res.json()) as ArtistData);
       } catch {
         setData({});
       }
@@ -40,10 +36,8 @@ export default function ArtistPanel({ artistId }: { artistId: number }) {
   const handleAddFive = async () => {
     try {
       const res = await apiFetch(`/similar/artist/${artistId}?limit=5`);
-      if (res.ok) {
-        const items = (await res.json()) as SimilarArtist[];
-        items.slice(0, 5).forEach((a) => addToMixtape({ track_id: a.artist_id, title: a.name }));
-      }
+      const items = (await res.json()) as SimilarArtist[];
+      items.slice(0, 5).forEach((a) => addToMixtape({ track_id: a.artist_id, title: a.name }));
     } catch {
       /* noop */
     }

--- a/services/ui/components/inspect/TrackPanel.tsx
+++ b/services/ui/components/inspect/TrackPanel.tsx
@@ -28,11 +28,7 @@ export default function TrackPanel({ trackId }: { trackId: number }) {
     (async () => {
       try {
         const res = await apiFetch(`/inspect/track/${trackId}`);
-        if (res.ok) {
-          setData((await res.json()) as TrackData);
-        } else {
-          setData({});
-        }
+        setData((await res.json()) as TrackData);
       } catch {
         setData({});
       }
@@ -42,10 +38,8 @@ export default function TrackPanel({ trackId }: { trackId: number }) {
   const handleAddFive = async () => {
     try {
       const res = await apiFetch(`/similar/track/${trackId}?limit=5`);
-      if (res.ok) {
-        const items = (await res.json()) as AlsoListened[];
-        items.slice(0, 5).forEach((t) => addToMixtape({ track_id: t.track_id, title: t.title }));
-      }
+      const items = (await res.json()) as AlsoListened[];
+      items.slice(0, 5).forEach((t) => addToMixtape({ track_id: t.track_id, title: t.title }));
     } catch {
       /* noop */
     }

--- a/services/ui/components/layout/Header.tsx
+++ b/services/ui/components/layout/Header.tsx
@@ -1,13 +1,11 @@
 'use client';
 
-import { useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Disc3 } from 'lucide-react';
 
 import { apiFetch } from '../../lib/api';
 import { useAuth } from '../../lib/auth';
 import { useSources } from '../../lib/sources';
-import { showToast } from '../../lib/toast';
 import Skeleton from '../Skeleton';
 import HeaderActions from '../HeaderActions';
 import Breadcrumbs from '../common/Breadcrumbs';
@@ -33,7 +31,6 @@ function parseNowPlaying(value: unknown): NowPlaying {
 export default function Header() {
   const { data: sources } = useSources();
   const { userId } = useAuth();
-  const lastError = useRef<string | null>(null);
 
   const { data: nowPlaying, isPending } = useQuery<NowPlaying>({
     queryKey: ['nowPlaying'],
@@ -41,19 +38,8 @@ export default function Header() {
       try {
         const response = await apiFetch('/api/spotify/now');
         const json = await response.json();
-        const result = parseNowPlaying(json);
-        lastError.current = null;
-        return result;
-      } catch (error) {
-        const message = error instanceof Error ? error.message : 'Unknown error';
-        if (lastError.current !== message) {
-          showToast({
-            title: 'Unable to load now playing',
-            description: message,
-            kind: 'error',
-          });
-          lastError.current = message;
-        }
+        return parseNowPlaying(json);
+      } catch {
         return FALLBACK_NOW_PLAYING;
       }
     },

--- a/services/ui/components/radar/InfluencePanel.tsx
+++ b/services/ui/components/radar/InfluencePanel.tsx
@@ -30,11 +30,7 @@ export default function InfluencePanel({
         const res = await apiFetch(
           `/cohorts/influence?metric=${encodeURIComponent(metric)}&window=${encodeURIComponent(window)}`
         );
-        if (res.ok) {
-          setItems((await res.json()) as Influence[]);
-        } else {
-          setItems([]);
-        }
+        setItems((await res.json()) as Influence[]);
       } catch {
         setItems([]);
       }

--- a/services/ui/components/settings/DataControls.tsx
+++ b/services/ui/components/settings/DataControls.tsx
@@ -11,8 +11,7 @@ export default function DataControls() {
 
   async function resetFeedback() {
     try {
-      const res = await apiFetch('/api/feedback/reset', { method: 'POST' });
-      if (!res.ok) throw new Error('bad');
+      await apiFetch('/api/feedback/reset', { method: 'POST', suppressErrorToast: true });
       show({ title: 'Feedback reset', kind: 'success' });
     } catch {
       show({ title: 'Failed to reset feedback', kind: 'error' });
@@ -21,10 +20,10 @@ export default function DataControls() {
 
   async function forgetArtist() {
     try {
-      const res = await apiFetch(`/api/feedback/forget?artist=${encodeURIComponent(artist)}`, {
+      await apiFetch(`/api/feedback/forget?artist=${encodeURIComponent(artist)}`, {
         method: 'POST',
+        suppressErrorToast: true,
       });
-      if (!res.ok) throw new Error('bad');
       show({ title: `Forgot ${artist}`, kind: 'success' });
       setArtist('');
     } catch {
@@ -34,8 +33,7 @@ export default function DataControls() {
 
   async function exportDefaults() {
     try {
-      const res = await apiFetch('/api/settings/export');
-      if (!res.ok) throw new Error('bad');
+      await apiFetch('/api/settings/export', { suppressErrorToast: true });
       show({ title: 'Exported defaults', kind: 'success' });
     } catch {
       show({ title: 'Failed to export defaults', kind: 'error' });

--- a/services/ui/components/settings/RankerControls.tsx
+++ b/services/ui/components/settings/RankerControls.tsx
@@ -14,12 +14,12 @@ export default function RankerControls() {
 
   async function handleSave() {
     try {
-      const res = await apiFetch('/api/ranker/settings', {
+      await apiFetch('/api/ranker/settings', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ discovery, energy, tempo, avoid }),
+        suppressErrorToast: true,
       });
-      if (!res.ok) throw new Error('bad');
       show({ title: 'Ranker settings saved', kind: 'success' });
     } catch {
       show({ title: 'Failed to save ranker settings', kind: 'error' });

--- a/services/ui/components/settings/SourceCard.tsx
+++ b/services/ui/components/settings/SourceCard.tsx
@@ -42,9 +42,11 @@ export default function SourceCard({
   async function handleConnect() {
     try {
       const callback = `${window.location.origin}/${id}/callback`;
-      const res = await apiFetch(`${connectUrl}?callback=${encodeURIComponent(callback)}`);
+      const res = await apiFetch(`${connectUrl}?callback=${encodeURIComponent(callback)}`, {
+        suppressErrorToast: true,
+      });
       const data = await res.json().catch(() => ({}));
-      if (res.ok && data.url) {
+      if (data.url) {
         window.location.href = data.url as string;
       } else {
         show({ title: `Failed to connect ${name}`, kind: 'error' });
@@ -56,8 +58,7 @@ export default function SourceCard({
 
   async function handleDisconnect() {
     try {
-      const res = await apiFetch(disconnectUrl, { method: 'DELETE' });
-      if (!res.ok) throw new Error('bad');
+      await apiFetch(disconnectUrl, { method: 'DELETE', suppressErrorToast: true });
       setAndNotify('disconnected');
       show({ title: `Disconnected ${name}`, kind: 'success' });
     } catch {
@@ -67,8 +68,7 @@ export default function SourceCard({
 
   async function handleTest() {
     try {
-      const res = await apiFetch(testUrl);
-      if (!res.ok) throw new Error('bad');
+      const res = await apiFetch(testUrl, { suppressErrorToast: true });
       // Try to reflect connection status when testUrl provides it (e.g. /api/settings)
       try {
         const data = (await res.json()) as {

--- a/services/ui/components/similar/NeighborsDrawer.tsx
+++ b/services/ui/components/similar/NeighborsDrawer.tsx
@@ -20,11 +20,7 @@ export default function NeighborsDrawer({ trackId, open, onClose }: Props) {
     (async () => {
       try {
         const res = await apiFetch(`/api/similar/track/${trackId}`);
-        if (res.ok) {
-          setNeighbors((await res.json()) as Neighbor[]);
-        } else {
-          setNeighbors([]);
-        }
+        setNeighbors((await res.json()) as Neighbor[]);
       } catch {
         setNeighbors([]);
       }

--- a/services/ui/lib/api.ts
+++ b/services/ui/lib/api.ts
@@ -1,38 +1,187 @@
 import { getUserId } from './auth';
 
+type ApiErrorPayload = unknown;
+
+export class ApiError extends Error {
+  status: number;
+  statusText: string;
+  url: string;
+  title?: string;
+  payload?: ApiErrorPayload;
+
+  constructor({
+    message,
+    status,
+    statusText,
+    url,
+    title,
+    payload,
+    cause,
+  }: {
+    message: string;
+    status: number;
+    statusText: string;
+    url: string;
+    title?: string;
+    payload?: ApiErrorPayload;
+    cause?: unknown;
+  }) {
+    super(message, { cause });
+    this.name = 'ApiError';
+    this.status = status;
+    this.statusText = statusText;
+    this.url = url;
+    this.title = title;
+    this.payload = payload;
+  }
+}
+
+export type ApiErrorInterceptor = (error: ApiError, context: { url: string; init: RequestInit }) => void;
+
+let errorInterceptor: ApiErrorInterceptor | null = null;
+
+export function setApiErrorInterceptor(fn: ApiErrorInterceptor | null) {
+  errorInterceptor = fn;
+  return () => {
+    if (errorInterceptor === fn) {
+      errorInterceptor = null;
+    }
+  };
+}
+
 function getTokenFromCookie(): string {
   if (typeof document === 'undefined') return '';
   const m = document.cookie.match(/(?:^|; )at=([^;]+)/);
   return m ? decodeURIComponent(m[1]) : '';
 }
 
+function extractDetail(value: unknown): string | undefined {
+  if (value == null) return undefined;
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value)) {
+    const parts = value
+      .map((item) => extractDetail(item))
+      .filter((item): item is string => typeof item === 'string' && item.length > 0);
+    return parts.length ? parts.join(', ') : undefined;
+  }
+  if (typeof value === 'object') {
+    const parts = Object.values(value)
+      .map((item) => extractDetail(item))
+      .filter((item): item is string => typeof item === 'string' && item.length > 0);
+    return parts.length ? parts.join(', ') : undefined;
+  }
+  return String(value);
+}
+
+async function parseErrorResponse(res: Response) {
+  const contentType = res.headers.get('content-type') || '';
+  if (contentType.includes('application/json')) {
+    try {
+      return await res.json();
+    } catch {
+      return undefined;
+    }
+  }
+  try {
+    const text = await res.text();
+    return text.length ? text : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeError(
+  status: number,
+  statusText: string,
+  payload: ApiErrorPayload,
+): { message: string; title?: string } {
+  const fallback = statusText || `Request failed with status ${status}`;
+  if (!payload) return { message: fallback };
+  if (typeof payload === 'string') return { message: payload };
+  if (Array.isArray(payload)) {
+    const joined = payload
+      .map((item) => (typeof item === 'string' ? item : extractDetail(item)))
+      .filter((item): item is string => typeof item === 'string' && item.length > 0);
+    return { message: joined.length ? joined.join(', ') : fallback };
+  }
+  if (typeof payload === 'object') {
+    const record = payload as Record<string, unknown>;
+    const title = typeof record.title === 'string' ? record.title : undefined;
+    const detailSources: unknown[] = [record.detail, record.message, record.error, record.errors];
+    for (const source of detailSources) {
+      const detail = extractDetail(source);
+      if (detail) {
+        return { message: detail, title };
+      }
+    }
+    return { message: fallback, title };
+  }
+  return { message: fallback };
+}
+
+function notifyError(error: ApiError, context: { url: string; init: RequestInit }, suppressToast: boolean) {
+  if (!suppressToast && errorInterceptor) {
+    errorInterceptor(error, context);
+  }
+}
+
 export const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'https://sidetrack.network/api';
 
-export async function apiFetch(path: string, init: RequestInit = {}) {
-  const headers = new Headers(init.headers);
+export type ApiFetchOptions = RequestInit & { suppressErrorToast?: boolean };
+
+export async function apiFetch(path: string, init: ApiFetchOptions = {}) {
+  const { suppressErrorToast = false, ...requestInit } = init;
+  const headers = new Headers(requestInit.headers);
   const uid = getUserId();
   if (uid) headers.set('X-User-Id', uid);
   if (!headers.has('Authorization')) {
     const at = getTokenFromCookie();
     if (at) headers.set('Authorization', `Bearer ${at}`);
   }
-  const finalInit: RequestInit = { ...init, headers };
+  const finalInit: RequestInit = { ...requestInit, headers };
   const url = path.startsWith('/api/') ? path : `${API_BASE}${path}`;
 
   try {
     const res = await fetch(url, finalInit);
     if (!res.ok) {
-      let message = res.statusText;
-      try {
-        const data = await res.json();
-        message = (data && (data.detail || data.message)) || message;
-      } catch {
-        // ignore json parse errors
-      }
-      throw new Error(`${res.status} ${message}`);
+      const payload = await parseErrorResponse(res);
+      const { message, title } = normalizeError(res.status, res.statusText, payload);
+      const error = new ApiError({
+        message,
+        status: res.status,
+        statusText: res.statusText,
+        url,
+        title,
+        payload,
+      });
+      notifyError(error, { url, init: finalInit }, suppressErrorToast);
+      throw error;
     }
     return res;
-  } catch (err: any) {
-    throw new Error(err?.message || 'Network error');
+  } catch (err) {
+    if (err instanceof ApiError) {
+      throw err;
+    }
+    if (err instanceof DOMException && err.name === 'AbortError') {
+      const error = new ApiError({
+        message: 'The request was aborted.',
+        status: 0,
+        statusText: 'Request aborted',
+        url,
+        title: 'Request aborted',
+        cause: err,
+      });
+      throw error;
+    }
+    const error = new ApiError({
+      message: err instanceof Error && err.message ? err.message : 'Network error',
+      status: 0,
+      statusText: 'Network error',
+      url,
+      title: 'Network error',
+      cause: err,
+    });
+    notifyError(error, { url, init: finalInit }, suppressErrorToast);
+    throw error;
   }
 }


### PR DESCRIPTION
## Summary
- add an ApiError class, fetch interceptor, and optional toast suppression in `apiFetch`
- wire the global API error interceptor into ToastProvider with duplicate suppression and session-expired messaging
- update pages and client components to use the new API error handling, suppressing default toasts when showing custom ones

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c8ff7c24c48333ba508a42d8d00eb1