### PR TITLE
Add reusable page skeleton for loading states

### DIFF
--- a/services/ui/app/account/page.test.tsx
+++ b/services/ui/app/account/page.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import AccountPage from './page';
+import ToastProvider from '../../components/ToastProvider';
+import { AuthProvider } from '../../lib/auth';
+
+describe('Account page', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+    document.cookie = 'uid=test';
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('shows skeleton while account data is loading', async () => {
+    let resolveFetch: ((value: Response) => void) | undefined;
+    (global.fetch as jest.Mock).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve;
+        }),
+    );
+
+    render(
+      <ToastProvider>
+        <AuthProvider>
+          <AccountPage />
+        </AuthProvider>
+      </ToastProvider>,
+    );
+
+    expect(screen.getByRole('status', { name: /loading account/i })).toBeInTheDocument();
+
+    await waitFor(() => expect(fetch).toHaveBeenCalled());
+
+    resolveFetch?.({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: () =>
+        Promise.resolve({
+          user_id: 'test-user',
+          lastfmUser: 'tester',
+          lastfmConnected: true,
+        }),
+    } as unknown as Response);
+
+    await waitFor(() =>
+      expect(screen.queryByRole('status', { name: /loading account/i })).not.toBeInTheDocument(),
+    );
+    expect(await screen.findByText(/Logged in as test-user/i)).toBeInTheDocument();
+  });
+});

--- a/services/ui/app/account/page.tsx
+++ b/services/ui/app/account/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { Button } from '../../components/ui/button';
 import ChartContainer from '../../components/ChartContainer';
 import FilterBar from '../../components/FilterBar';
-import Skeleton from '../../components/Skeleton';
+import PageSkeleton from '../../components/layout/PageSkeleton';
 import { useToast } from '../../components/ToastProvider';
 import { useAuth } from '../../lib/auth';
 import { apiFetch } from '../../lib/api';
@@ -69,6 +69,17 @@ export default function AccountPage() {
     }
   }
 
+  if (loading) {
+    return (
+      <PageSkeleton
+        aria-label="Loading account"
+        className="@container space-y-6"
+        sections={1}
+        sectionClassName="h-24"
+      />
+    );
+  }
+
   return (
     <section className="@container space-y-6">
       <div className="flex items-center justify-between">
@@ -87,13 +98,11 @@ export default function AccountPage() {
       </div>
       {tab === 'profile' ? (
         <ChartContainer title="Profile">
-          {loading ? <Skeleton className="h-5 w-40" /> : <p>Logged in as {user}</p>}
+          <p>Logged in as {user}</p>
         </ChartContainer>
       ) : (
         <ChartContainer title="Last.fm">
-          {loading ? (
-            <Skeleton className="h-5 w-40" />
-          ) : lfmConnected ? (
+          {lfmConnected ? (
             <div className="flex items-center gap-2">
               <span>Connected as {lfmUser}</span>
               <Button type="button" onClick={handleDisconnect}>

--- a/services/ui/app/settings/page.tsx
+++ b/services/ui/app/settings/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import PageSkeleton from '../../components/layout/PageSkeleton';
 import SourceCard, { SourceStatus } from '../../components/settings/SourceCard';
 import RankerControls from '../../components/settings/RankerControls';
 import DataControls from '../../components/settings/DataControls';
@@ -18,6 +19,7 @@ export default function SettingsPage() {
   // Keep hook to ensure auth provider mounts; value unused
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { userId } = useAuth();
+  const [isLoading, setIsLoading] = useState(true);
   const [connectedUsers, setConnectedUsers] = useState<{ spotify: string; lastfm: string }>({
     spotify: '',
     lastfm: '',
@@ -31,6 +33,7 @@ export default function SettingsPage() {
 
   useEffect(() => {
     let active = true;
+    setIsLoading(true);
     (async () => {
       try {
         const res = await apiFetch('/api/settings');
@@ -48,12 +51,25 @@ export default function SettingsPage() {
         });
       } catch {
         // errors are surfaced through ToastProvider
+      } finally {
+        if (active) setIsLoading(false);
       }
     })();
     return () => {
       active = false;
     };
   }, []);
+
+  if (isLoading) {
+    return (
+      <PageSkeleton
+        aria-label="Loading settings"
+        className="space-y-10"
+        sections={4}
+        sectionClassName="h-40"
+      />
+    );
+  }
 
   return (
     <div className="space-y-10">

--- a/services/ui/components/layout/PageSkeleton.tsx
+++ b/services/ui/components/layout/PageSkeleton.tsx
@@ -1,0 +1,39 @@
+import type { HTMLAttributes } from 'react';
+
+import Skeleton from '../Skeleton';
+import { cn } from '../../lib/utils';
+
+interface PageSkeletonProps extends HTMLAttributes<HTMLElement> {
+  sections?: number;
+  sectionClassName?: string;
+}
+
+export default function PageSkeleton({
+  sections = 3,
+  className,
+  sectionClassName,
+  'aria-label': ariaLabel = 'Loading page',
+  ...props
+}: PageSkeletonProps) {
+  const label = ariaLabel ?? 'Loading page';
+
+  return (
+    <section
+      className={cn('space-y-6', className)}
+      aria-busy="true"
+      aria-label={label}
+      aria-live="polite"
+      role="status"
+      {...props}
+    >
+      <span className="sr-only">{label}</span>
+      <div className="space-y-2">
+        <Skeleton className="h-8 w-32 max-w-full" />
+        <Skeleton className="h-4 w-48 max-w-full" />
+      </div>
+      {Array.from({ length: sections }).map((_, index) => (
+        <Skeleton key={index} className={cn('h-32', sectionClassName)} />
+      ))}
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable PageSkeleton component with heading placeholders
- render the skeleton in account and settings pages while data loads
- cover the loading UI with new Jest tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c903af3ed88333bd1ae91b36ad6e74