### PR TITLE
Update NavRail animations and accessibility

### DIFF
--- a/services/ui/components/NavRail.tsx
+++ b/services/ui/components/NavRail.tsx
@@ -4,27 +4,19 @@ import { usePathname } from 'next/navigation';
 import clsx from 'clsx';
 import { motion } from 'framer-motion';
 import * as Tooltip from '@radix-ui/react-tooltip';
-import * as Icons from 'lucide-react';
-import nav from '../nav.json';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+import { useNavItems } from '../lib/nav';
 import { useNav } from './NavContext';
 import Avatar from './ui/Avatar';
-import useFeatureFlag from '../hooks/useFeatureFlag';
 
-const { ChevronLeft, ChevronRight } = Icons;
-
-type NavItem = {
-  path: string;
-  label: string;
-  icon: keyof typeof Icons;
-  featureFlag?: string | null;
-};
-
-const items = nav as NavItem[];
+const motionSpring = { type: 'spring', stiffness: 300, damping: 20 } as const;
+const labelSpring = { type: 'spring', stiffness: 260, damping: 25 } as const;
 
 export default function NavRail() {
   const pathname = usePathname();
   const { collapsed, setCollapsed } = useNav();
-  const visibleItems = items.filter((item) => useFeatureFlag(item.featureFlag));
+  const items = useNavItems();
   return (
     <div className="flex h-full flex-col gap-2 p-3 glass">
       <div className="flex items-center gap-2 px-2 py-3">
@@ -33,8 +25,8 @@ export default function NavRail() {
       </div>
       <Tooltip.Provider>
         <nav className="flex flex-col gap-2" aria-label="Primary">
-          {visibleItems.map((item, idx) => {
-            const Icon = Icons[item.icon];
+          {items.map((item, idx) => {
+            const Icon = item.icon;
             const active = pathname === item.path || pathname.startsWith(`${item.path}/`);
             return (
               <Tooltip.Root key={item.path}>
@@ -45,26 +37,44 @@ export default function NavRail() {
                     aria-current={active ? 'page' : undefined}
                     accessKey={(idx + 1).toString()}
                     className={clsx(
-                      'relative flex h-11 items-center gap-3 rounded-lg px-4 text-sm transition-colors',
-                      active
-                        ? 'text-emerald-300'
-                        : 'text-muted-foreground hover:text-foreground hover:bg-white/5',
+                      'group relative flex h-11 items-center gap-3 rounded-lg px-4 text-sm transition-colors',
+                      'text-muted-foreground hover:text-foreground hover:bg-white/5',
+                      'aria-[current=page]:text-emerald-300',
+                      'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 focus-visible:ring-offset-2 focus-visible:ring-offset-background',
                     )}
                   >
                     {active && (
                       <motion.span
                         layoutId="nav-active"
                         className="absolute inset-0 -z-10 rounded-lg bg-emerald-500/10"
-                        transition={{ type: 'spring', stiffness: 300, damping: 20 }}
+                        transition={motionSpring}
                       />
                     )}
                     <motion.div
                       className="flex items-center gap-3"
-                      whileHover={{ x: 2 }}
-                      transition={{ type: 'spring', stiffness: 300, damping: 20 }}
+                      initial={false}
+                      animate={{ x: active ? 2 : 0 }}
+                      whileHover={{ x: 4 }}
+                      transition={motionSpring}
                     >
-                      <Icon size={18} />
-                      {!collapsed && <span>{item.label}</span>}
+                      <motion.div
+                        initial={false}
+                        animate={{ scale: active ? 1.05 : 1 }}
+                        transition={motionSpring}
+                        className="flex items-center justify-center"
+                      >
+                        <Icon size={18} />
+                      </motion.div>
+                      {!collapsed && (
+                        <motion.div
+                          initial={false}
+                          animate={{ opacity: active ? 1 : 0.75 }}
+                          transition={labelSpring}
+                          className="whitespace-nowrap"
+                        >
+                          {item.label}
+                        </motion.div>
+                      )}
                     </motion.div>
                   </Link>
                 </Tooltip.Trigger>


### PR DESCRIPTION
## Summary
- source nav rail entries from the shared `useNavItems` helper
- add focus-visible and aria-current aware styling to the nav links
- animate icons and labels with motion wrappers when the nav item is active

## Testing
- npm run lint *(fails: existing TypeScript lint errors in unrelated files)*
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68c9093d3f888333963a80df0bf411a3