### PR TITLE
Use dynamic imports for explore panels

### DIFF
--- a/services/ui/.eslintrc.cjs
+++ b/services/ui/.eslintrc.cjs
@@ -1,0 +1,6 @@
+const path = require('path');
+
+// Ensure ESLint resolves plugins from this package's node_modules.
+module.paths.push(path.resolve(__dirname, 'node_modules'));
+
+module.exports = require('../../.eslintrc.cjs');

--- a/services/ui/app/explore/page.tsx
+++ b/services/ui/app/explore/page.tsx
@@ -1,12 +1,34 @@
 'use client';
+
+import dynamic from 'next/dynamic';
 import { useSearchParams } from 'next/navigation';
-import { useEffect, useRef } from 'react';
-import Tabs from '../../components/explore/Tabs';
+import { useEffect, useRef, type ReactNode } from 'react';
+
+import ChartSkeleton from '../../components/ChartSkeleton';
+import Skeleton from '../../components/Skeleton';
+import { Card } from '../../components/ui/card';
 import Filters from '../../components/explore/Filters';
-import TrajectoryPanel from '../../components/explore/TrajectoryPanel';
-import MoodsPanel from '../../components/explore/MoodsPanel';
-import RadarPanel from '../../components/explore/RadarPanel';
-import OutliersPanel from '../../components/explore/OutliersPanel';
+import Tabs from '../../components/explore/Tabs';
+
+const TrajectoryPanel = dynamic(() => import('../../components/explore/TrajectoryPanel'), {
+  loading: () => <TrajectoryPanelFallback />,
+  ssr: false,
+});
+
+const MoodsPanel = dynamic(() => import('../../components/explore/MoodsPanel'), {
+  loading: () => <MoodsPanelFallback />,
+  ssr: false,
+});
+
+const RadarPanel = dynamic(() => import('../../components/explore/RadarPanel'), {
+  loading: () => <RadarPanelFallback />,
+  ssr: false,
+});
+
+const OutliersPanel = dynamic(() => import('../../components/explore/OutliersPanel'), {
+  loading: () => <OutliersPanelFallback />,
+  ssr: false,
+});
 
 export default function ExplorePage() {
   const searchParams = useSearchParams();
@@ -36,6 +58,114 @@ export default function ExplorePage() {
       <Tabs onTabChange={handleTabChange} />
       <Filters />
       {panel}
+    </section>
+  );
+}
+
+function PanelHeading({ title, description }: { title: string; description?: string }) {
+  return (
+    <div className="flex items-center justify-between">
+      <div>
+        <h2 className="text-xl font-semibold">{title}</h2>
+        {description && <p className="text-sm text-muted-foreground">{description}</p>}
+      </div>
+    </div>
+  );
+}
+
+function ChartCardSkeleton({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  children: ReactNode;
+}) {
+  return (
+    <Card variant="glass" className="p-4">
+      <section>
+        <div className="mb-3 flex items-center justify-between gap-4">
+          <div>
+            <h3 className="text-sm font-medium">{title}</h3>
+            {subtitle && <p className="text-xs text-muted-foreground">{subtitle}</p>}
+          </div>
+        </div>
+        <div className="min-h-[clamp(120px,25vh,160px)]">{children}</div>
+      </section>
+    </Card>
+  );
+}
+
+function TrajectoryPanelFallback() {
+  return (
+    <section className="@container space-y-6">
+      <PanelHeading
+        title="Taste Trajectory"
+        description="Weekly points (x = valence, y = energy)"
+      />
+      <ChartCardSkeleton title="Trajectory" subtitle="Recent weekly bubbles and positions">
+        <ChartSkeleton />
+      </ChartCardSkeleton>
+    </section>
+  );
+}
+
+function MoodsPanelFallback() {
+  return (
+    <section className="@container space-y-6">
+      <PanelHeading title="Moods" description="Stacked axes over the last 12 weeks" />
+      <div className="flex gap-2 overflow-x-auto py-2">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <Skeleton key={index} className="h-6 w-20 rounded-full" />
+        ))}
+      </div>
+      <ChartCardSkeleton title="Mood streamgraph" subtitle="Axes stacked by week">
+        <ChartSkeleton className="h-[clamp(240px,40vh,340px)]" />
+      </ChartCardSkeleton>
+      <ChartCardSkeleton title="Mixtape candidates" subtitle="k-medoids picks">
+        <div className="space-y-2">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <Skeleton key={index} className="h-4 w-full" />
+          ))}
+        </div>
+      </ChartCardSkeleton>
+    </section>
+  );
+}
+
+function RadarPanelFallback() {
+  return (
+    <section className="@container space-y-6 md:flex md:space-x-6">
+      <div className="md:flex-1 space-y-6">
+        <PanelHeading title="Weekly Radar" />
+        <ChartCardSkeleton title="Radar" subtitle="Current week vs baseline">
+          <ChartSkeleton />
+        </ChartCardSkeleton>
+      </div>
+      <Card variant="glass" className="md:w-64 space-y-3 p-4">
+        <h3 className="text-lg font-semibold">Top Contributors</h3>
+        <div className="space-y-2">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <Skeleton key={index} className="h-10 w-full" />
+          ))}
+        </div>
+      </Card>
+    </section>
+  );
+}
+
+function OutliersPanelFallback() {
+  return (
+    <section className="@container space-y-6">
+      <PanelHeading title="Outliers" />
+      <ChartCardSkeleton title="Outliers" subtitle="Far from your recent centroid">
+        <div className="space-y-2">
+          {Array.from({ length: 5 }).map((_, index) => (
+            <Skeleton key={index} className="h-4 w-full" />
+          ))}
+        </div>
+      </ChartCardSkeleton>
     </section>
   );
 }

--- a/services/ui/components/NavRail.tsx
+++ b/services/ui/components/NavRail.tsx
@@ -4,6 +4,7 @@ import { usePathname } from 'next/navigation';
 import clsx from 'clsx';
 import { motion } from 'framer-motion';
 import * as Tooltip from '@radix-ui/react-tooltip';
+import type { LucideIcon } from 'lucide-react';
 import * as Icons from 'lucide-react';
 import nav from '../nav.json';
 import { useNav } from './NavContext';
@@ -34,7 +35,7 @@ export default function NavRail() {
       <Tooltip.Provider>
         <nav className="flex flex-col gap-2" aria-label="Primary">
           {visibleItems.map((item, idx) => {
-            const Icon = Icons[item.icon];
+            const Icon = Icons[item.icon] as LucideIcon;
             const active = pathname === item.path || pathname.startsWith(`${item.path}/`);
             return (
               <Tooltip.Root key={item.path}>

--- a/services/ui/components/ThemeProvider.tsx
+++ b/services/ui/components/ThemeProvider.tsx
@@ -6,7 +6,7 @@ import { Theme, ThemeContext } from './ThemeContext';
 function ThemeContextBridge({ children }: { children: ReactNode }) {
   const { resolvedTheme, theme: storedTheme, setTheme } = useNextTheme();
 
-  const activeTheme = useMemo(() => {
+  const activeTheme = useMemo<Theme>(() => {
     if (resolvedTheme === 'dark' || resolvedTheme === 'light') return resolvedTheme;
     if (storedTheme === 'dark' || storedTheme === 'light') return storedTheme;
     return 'dark';


### PR DESCRIPTION
## Summary
- load the explore dashboard panels (trajectory, moods, radar, outliers) with `next/dynamic` and add matching skeleton fallbacks so the page stays responsive while chunks stream in
- add a local ESLint shim so `next build` can resolve the root config plugins when run from services/ui, and tighten the NavRail/ThemeProvider typings uncovered during the build

## Testing
- npm test
- npm run build -- --no-lint *(fails: existing type errors in components/charts/MoodsStreamgraph.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c9092f18208333b40ce94e5896b604