### PR TITLE
Improve nav animations and accessibility

### DIFF
--- a/services/ui/components/NavRail.tsx
+++ b/services/ui/components/NavRail.tsx
@@ -4,37 +4,49 @@ import { usePathname } from 'next/navigation';
 import clsx from 'clsx';
 import { motion } from 'framer-motion';
 import * as Tooltip from '@radix-ui/react-tooltip';
-import * as Icons from 'lucide-react';
-import nav from '../nav.json';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+import { useNavItems } from '../lib/nav';
 import { useNav } from './NavContext';
 import Avatar from './ui/Avatar';
-import useFeatureFlag from '../hooks/useFeatureFlag';
-
-const { ChevronLeft, ChevronRight } = Icons;
-
-type NavItem = {
-  path: string;
-  label: string;
-  icon: keyof typeof Icons;
-  featureFlag?: string | null;
-};
-
-const items = nav as NavItem[];
 
 export default function NavRail() {
   const pathname = usePathname();
   const { collapsed, setCollapsed } = useNav();
-  const visibleItems = items.filter((item) => useFeatureFlag(item.featureFlag));
+  const navItems = useNavItems();
+
   return (
-    <div className="flex h-full flex-col gap-2 p-3 glass">
-      <div className="flex items-center gap-2 px-2 py-3">
-        <Avatar size={32} />
-        {!collapsed && <strong className="text-lg">SideTrack</strong>}
+    <motion.div
+      className={clsx(
+        'glass flex h-full flex-col gap-2 p-3 overflow-hidden',
+        collapsed && 'items-center',
+      )}
+      initial={false}
+      animate={{ width: collapsed ? 64 : 240 }}
+      transition={{ type: 'spring', stiffness: 260, damping: 26 }}
+    >
+      <div className="flex w-full items-center gap-2 px-2 py-3">
+        <Avatar
+          size={32}
+          className={clsx(
+            'transition-opacity duration-300 ease-in-out',
+            collapsed ? 'opacity-90' : 'opacity-100',
+          )}
+        />
+        <span
+          className={clsx(
+            'overflow-hidden text-lg font-semibold tracking-wide text-foreground/90 transition-[max-width,opacity] duration-300 ease-in-out',
+            collapsed ? 'max-w-0 opacity-0' : 'max-w-[160px] opacity-100',
+          )}
+          aria-hidden={collapsed ? 'true' : 'false'}
+        >
+          SideTrack
+        </span>
       </div>
       <Tooltip.Provider>
         <nav className="flex flex-col gap-2" aria-label="Primary">
-          {visibleItems.map((item, idx) => {
-            const Icon = Icons[item.icon];
+          {navItems.map((item, idx) => {
+            const Icon = item.icon;
             const active = pathname === item.path || pathname.startsWith(`${item.path}/`);
             return (
               <Tooltip.Root key={item.path}>
@@ -45,10 +57,11 @@ export default function NavRail() {
                     aria-current={active ? 'page' : undefined}
                     accessKey={(idx + 1).toString()}
                     className={clsx(
-                      'relative flex h-11 items-center gap-3 rounded-lg px-4 text-sm transition-colors',
+                      'relative flex h-11 items-center rounded-lg px-4 text-sm transition-colors',
+                      collapsed ? 'justify-center gap-0' : 'gap-3',
                       active
                         ? 'text-emerald-300'
-                        : 'text-muted-foreground hover:text-foreground hover:bg-white/5',
+                        : 'text-muted-foreground hover:bg-white/5 hover:text-foreground',
                     )}
                   >
                     {active && (
@@ -59,12 +72,29 @@ export default function NavRail() {
                       />
                     )}
                     <motion.div
-                      className="flex items-center gap-3"
+                      className={clsx(
+                        'flex items-center',
+                        collapsed ? 'justify-center gap-0' : 'gap-3',
+                      )}
                       whileHover={{ x: 2 }}
                       transition={{ type: 'spring', stiffness: 300, damping: 20 }}
                     >
-                      <Icon size={18} />
-                      {!collapsed && <span>{item.label}</span>}
+                      <Icon
+                        size={18}
+                        className={clsx(
+                          'transition-opacity duration-300 ease-in-out',
+                          collapsed ? 'opacity-90' : 'opacity-100',
+                        )}
+                      />
+                      <span
+                        className={clsx(
+                          'whitespace-nowrap overflow-hidden transition-[max-width,opacity] duration-300 ease-in-out',
+                          collapsed ? 'max-w-0 opacity-0' : 'max-w-[160px] opacity-100',
+                        )}
+                        aria-hidden={collapsed ? 'true' : 'false'}
+                      >
+                        {item.label}
+                      </span>
                     </motion.div>
                   </Link>
                 </Tooltip.Trigger>
@@ -85,14 +115,24 @@ export default function NavRail() {
         </nav>
       </Tooltip.Provider>
       <button
+        type="button"
         onClick={() => setCollapsed(!collapsed)}
         aria-label={collapsed ? 'Expand navigation' : 'Collapse navigation'}
+        aria-expanded={!collapsed}
         accessKey="b"
-        className="mt-auto flex h-11 items-center gap-2 px-4 text-sm text-muted-foreground"
+        className="mt-auto flex h-11 w-full items-center justify-center gap-2 rounded-lg text-sm text-muted-foreground transition-colors duration-200 hover:bg-white/5 hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
       >
         {collapsed ? <ChevronRight size={16} /> : <ChevronLeft size={16} />}
-        {!collapsed && <span>Collapse</span>}
+        <span
+          className={clsx(
+            'overflow-hidden transition-[max-width,opacity] duration-300 ease-in-out',
+            collapsed ? 'max-w-0 opacity-0' : 'max-w-[80px] opacity-100',
+          )}
+          aria-hidden={collapsed ? 'true' : 'false'}
+        >
+          Collapse
+        </span>
       </button>
-    </div>
+    </motion.div>
   );
 }

--- a/services/ui/components/layout/Sidebar.test.tsx
+++ b/services/ui/components/layout/Sidebar.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React, { useState } from 'react';
+
+import Sidebar from './Sidebar';
+
+jest.mock('next/navigation', () => ({
+  __esModule: true,
+  usePathname: () => '/',
+}));
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: React.forwardRef<HTMLAnchorElement, React.ComponentPropsWithoutRef<'a'>>(
+    ({ children, ...props }, ref) => (
+      <a ref={ref} {...props}>
+        {children}
+      </a>
+    ),
+  ),
+}));
+
+jest.mock('../common/ThemeToggle', () => ({
+  __esModule: true,
+  default: () => <div data-testid="theme-toggle" />,
+}));
+
+describe('Sidebar', () => {
+  beforeEach(() => {
+    window.innerWidth = 1024;
+    process.env.NEXT_PUBLIC_FEATURE_FLAGS = 'recommendations';
+  });
+
+  afterEach(() => {
+    delete process.env.NEXT_PUBLIC_FEATURE_FLAGS;
+  });
+
+  function SidebarHarness() {
+    const [collapsed, setCollapsed] = useState(false);
+    return <Sidebar collapsed={collapsed} setCollapsed={setCollapsed} />;
+  }
+
+  it('toggles aria-expanded state and label visibility', async () => {
+    const user = userEvent.setup();
+    render(<SidebarHarness />);
+
+    const toggleButton = screen.getByRole('button', { name: /sidebar/i });
+    expect(toggleButton).toHaveAttribute('aria-expanded', 'true');
+
+    const homeLabel = screen.getByText('Home');
+    expect(homeLabel).toHaveAttribute('aria-hidden', 'false');
+
+    await user.click(toggleButton);
+
+    expect(toggleButton).toHaveAttribute('aria-expanded', 'false');
+    expect(toggleButton).toHaveAccessibleName('Expand sidebar');
+    expect(homeLabel).toHaveAttribute('aria-hidden', 'true');
+  });
+});

--- a/services/ui/components/layout/Sidebar.tsx
+++ b/services/ui/components/layout/Sidebar.tsx
@@ -21,23 +21,31 @@ export default function Sidebar({
     <aside
       className={clsx(
         'relative shrink-0 flex flex-col border-r border-white/10 bg-white/5 backdrop-blur-md supports-[backdrop-filter]:bg-white/5',
-        collapsed ? 'w-16' : 'w-16 md:w-60',
-        'transition-[width,background-color] duration-300',
+        collapsed ? 'w-16' : 'w-64 md:w-60',
+        'transition-[width,background-color] duration-300 ease-in-out',
       )}
     >
       <div className="flex items-center justify-between px-3 py-3">
-        {!collapsed && (
-          <span className="text-sm font-semibold tracking-wide text-foreground/90">SideTrack</span>
-        )}
+        <span
+          className={clsx(
+            'overflow-hidden text-sm font-semibold tracking-wide text-foreground/90 transition-[max-width,opacity] duration-300 ease-in-out',
+            collapsed ? 'max-w-0 opacity-0' : 'max-w-[160px] opacity-100',
+          )}
+          aria-hidden={collapsed ? 'true' : 'false'}
+        >
+          SideTrack
+        </span>
         <button
+          type="button"
           onClick={() => setCollapsed(!collapsed)}
           aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-          className="hidden h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-white/10 hover:text-foreground focus:outline-none focus:ring-2 focus:ring-emerald-500 md:inline-flex"
+          aria-expanded={!collapsed}
+          className="flex h-9 w-9 items-center justify-center rounded-md text-muted-foreground transition-colors duration-200 hover:bg-white/10 hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500"
         >
           <Menu size={16} />
         </button>
       </div>
-      <nav className="flex-1 space-y-1 px-2">
+      <nav className="flex-1 space-y-1 px-2" aria-label="Primary">
         {navItems.map((item) => {
           const active = pathname === item.path || pathname.startsWith(item.path + '/');
           return (
@@ -45,7 +53,8 @@ export default function Sidebar({
               <Link
                 href={item.path}
                 className={clsx(
-                  'relative flex items-center gap-3 rounded-md px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-white/10 hover:text-foreground focus:outline-none focus:ring-2 focus:ring-emerald-500',
+                  'relative flex items-center rounded-md px-3 py-2 text-sm text-muted-foreground transition-colors hover:bg-white/10 hover:text-foreground focus:outline-none focus:ring-2 focus:ring-emerald-500',
+                  collapsed ? 'justify-center gap-0' : 'gap-3',
                   active && 'bg-white/10 text-foreground',
                 )}
                 aria-label={item.label}
@@ -56,8 +65,22 @@ export default function Sidebar({
                     aria-hidden
                   />
                 )}
-                <item.icon size={18} />
-                {!collapsed && <span className="hidden md:inline">{item.label}</span>}
+                <item.icon
+                  size={18}
+                  className={clsx(
+                    'shrink-0 transition-opacity duration-300 ease-in-out',
+                    collapsed ? 'opacity-90' : 'opacity-100',
+                  )}
+                />
+                <span
+                  className={clsx(
+                    'whitespace-nowrap overflow-hidden transition-[max-width,opacity] duration-300 ease-in-out',
+                    collapsed ? 'max-w-0 opacity-0' : 'max-w-[160px] opacity-100',
+                  )}
+                  aria-hidden={collapsed ? 'true' : 'false'}
+                >
+                  {item.label}
+                </span>
               </Link>
               {collapsed && (
                 <span


### PR DESCRIPTION
## Summary
- animate the sidebar width and nav labels/icons with smooth transitions while exposing an aria-expanded toggle for accessibility
- update the nav rail to source items from the shared config and share the animated opacity behaviors
- add a unit test covering the sidebar toggle state and label visibility

## Testing
- `NODE_PATH=$(pwd)/node_modules npm run lint` *(fails: existing lint violations in unrelated files)*
- `NODE_PATH=$(pwd)/node_modules npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c90923d9448333aae96d5871827052