### PR TITLE
Document test workflows and add UI test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test.unit test.int test.contract test.all test.slow test.e2e
+.PHONY: test.unit test.int test.contract test.all test.slow test.e2e test-ui
 
 test.unit:
 	pytest -m "unit and not slow and not gpu"
@@ -17,3 +17,6 @@ test.slow:
 
 test.e2e:
 	pytest -m "e2e"
+
+test-ui:
+	cd services/ui && npm run lint && CI=1 npm test

--- a/README.md
+++ b/README.md
@@ -265,6 +265,8 @@ http://localhost:3000
 
 ## Testing
 
+### Backend (FastAPI, job runner, worker)
+
 Set up a virtual environment and install the test dependencies:
 
 ```bash
@@ -274,6 +276,20 @@ pip install -e ".[api,jobrunner,worker,dev]"
 # pip install -e ".[extraction]"
 pytest -m "unit and not slow and not gpu" -q
 ```
+
+### Frontend (Next.js dashboard)
+
+Install Node modules (`npm install`) once, then run the lint and unit test suites
+inside `services/ui` before opening a PR:
+
+```bash
+cd services/ui
+npm run lint
+npm test
+```
+
+`make test-ui` is a convenience wrapper that runs the lint and Jest suites from
+the repository root.
 
 See [`tests/README.md`](tests/README.md) for the full pyramid, speed budget and
 fixture layout.


### PR DESCRIPTION
## Summary
- document backend backend test setup plus frontend lint/test expectations in the README
- add a make test-ui helper that runs the Next.js lint and Jest commands from the repo root

## Testing
- pytest -m "unit and not slow and not gpu" -q

------
https://chatgpt.com/codex/tasks/task_e_68c910a6e8e48333ad941b5c40705e9c