### PR TITLE
Fix UI typing and chart interactions

### DIFF
--- a/services/ui/components/NavRail.tsx
+++ b/services/ui/components/NavRail.tsx
@@ -8,7 +8,6 @@ import * as Tooltip from '@radix-ui/react-tooltip';
 import type { LucideIcon } from 'lucide-react';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import * as Icons from 'lucide-react';
-import nav from '../nav.json';
 import { useNavItems } from '../lib/nav';
 
 import { useNav } from './NavContext';

--- a/services/ui/components/charts/RadarChart.tsx
+++ b/services/ui/components/charts/RadarChart.tsx
@@ -9,6 +9,10 @@ import {
   Filler,
   Tooltip,
   Legend,
+  type ActiveElement,
+  type ChartData,
+  type ChartEvent,
+  type ChartOptions,
 } from 'chart.js';
 import { motion } from 'framer-motion';
 import { useInspector } from '../../hooks/useInspector';
@@ -23,7 +27,7 @@ type RadarChartProps = {
 export default function RadarChart({ axes, baseline }: RadarChartProps) {
   const labels = Object.keys(axes);
   const { inspect } = useInspector();
-  const data = {
+  const data: ChartData<'radar'> = {
     labels,
     datasets: [
       {
@@ -43,11 +47,11 @@ export default function RadarChart({ axes, baseline }: RadarChartProps) {
     ],
   };
 
-  const options = {
+  const options: ChartOptions<'radar'> = {
     responsive: true,
     animation: { duration: 500 },
-    onClick: (_: any, elements: any) => {
-      if (elements && elements.length) {
+    onClick: (_event: ChartEvent, elements: ActiveElement[]) => {
+      if (elements.length > 0) {
         const idx = elements[0].index;
         const label = labels[idx];
         inspect({ type: 'radar', axis: label, value: axes[label] });
@@ -74,7 +78,6 @@ export default function RadarChart({ axes, baseline }: RadarChartProps) {
       transition={{ duration: 0.4 }}
       className="w-full aspect-[4/3]"
     >
-      {/* @ts-ignore */}
       <Radar data={data} options={options} />
     </motion.div>
   );

--- a/services/ui/components/forms/ZForm.tsx
+++ b/services/ui/components/forms/ZForm.tsx
@@ -1,16 +1,17 @@
 import * as React from 'react';
 import { useForm, FormProvider, type SubmitHandler } from 'react-hook-form';
-import { z, type ZodType } from 'zod';
+import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { cn } from '../../lib/utils';
 
-interface ZFormProps<TSchema extends ZodType<any, any>> extends React.HTMLAttributes<HTMLFormElement> {
+interface ZFormProps<TSchema extends z.ZodTypeAny>
+  extends React.HTMLAttributes<HTMLFormElement> {
   schema: TSchema;
   defaultValues?: z.infer<TSchema>;
   onSubmit: SubmitHandler<z.infer<TSchema>>;
 }
 
-function ZForm<TSchema extends ZodType<any, any>>({
+function ZForm<TSchema extends z.ZodTypeAny>({
   schema,
   defaultValues,
   onSubmit,
@@ -27,7 +28,7 @@ function ZForm<TSchema extends ZodType<any, any>>({
     if (defaultValues) {
       form.reset(defaultValues);
     }
-  }, [defaultValues]);
+  }, [defaultValues, form]);
 
   return (
     <FormProvider {...form}>

--- a/services/ui/components/ui/Avatar.tsx
+++ b/services/ui/components/ui/Avatar.tsx
@@ -1,6 +1,5 @@
 import Image from 'next/image';
 import type { HTMLAttributes } from 'react';
-import dynamic from 'next/dynamic';
 import { cn } from '../../lib/utils';
 import { User as UserIcon } from 'lucide-react';
 

--- a/services/ui/lib/sources.ts
+++ b/services/ui/lib/sources.ts
@@ -27,14 +27,20 @@ export function chipFromReason(reason: Reason): { source: Source['type']; text: 
     case 'spotify':
       return { source: 'spotify', text: 'vibe match: energy + tempo' };
     case 'lastfm':
-      return { source: 'lastfm', text: `tag overlap: ${(reason as any).tags?.join(', ')}` };
+      return {
+        source: 'lastfm',
+        text: `tag overlap: ${reason.tags.length > 0 ? reason.tags.join(', ') : 'none'}`,
+      };
     case 'lb':
-      return { source: 'lb', text: `co-listened with ${(reason as any).artist}` };
+      return { source: 'lb', text: `co-listened with ${reason.artist}` };
     case 'mb':
-      const r = reason as any;
-      return { source: 'mb', text: `same label: ${r.label}, era: ${r.yearRange}` };
-    default:
-      return { source: 'spotify', text: '' };
+      return { source: 'mb', text: `same label: ${reason.label}, era: ${reason.yearRange}` };
   }
+
+  return assertNever(reason);
+}
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled recommendation reason: ${JSON.stringify(value)}`);
 }
 


### PR DESCRIPTION
## Summary
- remove leftover unused imports and make shared form components type-safe to avoid relying on `any`
- type the radar chart configuration and click handling so inspector interactions work without suppressing TypeScript
- normalize recommendation reason labels and update motion mocks used in RecCard tests to better reflect runtime behavior

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c911fe4dc08333a1e7d73c4f9a1806