### PR TITLE
Implement cohort influence aggregation

### DIFF
--- a/sidetrack/api/routers/cohorts.py
+++ b/sidetrack/api/routers/cohorts.py
@@ -1,38 +1,330 @@
 """Cohort-related API endpoints."""
 
-from fastapi import APIRouter, Depends, Query
-from sqlalchemy.ext.asyncio import AsyncSession
+from __future__ import annotations
 
+import math
+from collections import defaultdict
+from datetime import UTC, datetime, timedelta
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import and_, func, literal, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Session
+
+from sidetrack.common.models import Artist, Listen, MoodScore, Release, Track
+
+from ..constants import AXES, DEFAULT_METHOD
 from ..db import get_db
 from ..security import get_current_user
 
 router = APIRouter(prefix="/cohorts")
 
 
+def _round6(value: float) -> float:
+    return float(round(float(value), 6))
+
+
+def _parse_window(window: str) -> timedelta:
+    """Parse a window string like ``12w`` into a timedelta."""
+
+    default = timedelta(weeks=12)
+    if not window:
+        return default
+
+    try:
+        if window.endswith("w"):
+            weeks = int(window[:-1])
+            return timedelta(weeks=max(weeks, 1))
+        if window.endswith("m"):
+            months = int(window[:-1])
+            return timedelta(weeks=max(months * 4, 1))
+        if window.endswith("d"):
+            days = int(window[:-1])
+            return timedelta(days=max(days, 1))
+        # interpret raw integers as weeks
+        weeks = int(window)
+        return timedelta(weeks=max(weeks, 1))
+    except ValueError:
+        return default
+
+
+def _floor_week(dt: datetime) -> datetime:
+    dt = dt.astimezone(UTC)
+    start = dt - timedelta(days=dt.weekday())
+    return start.replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+async def _scalar(
+    db: Session | AsyncSession, stmt
+):  # -> Any (SQLAlchemy scalar return type)
+    if isinstance(db, AsyncSession):
+        return await db.scalar(stmt)
+    return db.scalar(stmt)
+
+
+async def _execute(db: Session | AsyncSession, stmt):
+    if isinstance(db, AsyncSession):
+        return await db.execute(stmt)
+    return db.execute(stmt)
+
+
+def _confidence(listens: int, metric_samples: int) -> float:
+    if listens <= 0:
+        return 0.0
+    if metric_samples > 0:
+        conf = 1.0 - math.exp(-metric_samples / 3.0)
+    else:
+        conf = (1.0 - math.exp(-listens / 6.0)) * 0.6
+    return _round6(min(conf, 1.0))
+
+
+def _score(
+    listens: int,
+    metric_sum: float,
+    metric_samples: int,
+    global_avg: float,
+    total_listens: int,
+) -> float:
+    if listens <= 0 or total_listens <= 0:
+        return 0.0
+    weight = listens / total_listens
+    if metric_samples > 0:
+        avg = metric_sum / metric_samples
+        contribution = (avg - global_avg) * weight
+        return _round6(abs(contribution))
+    # fall back to activity share when we lack mood data
+    return _round6(weight * 0.1)
+
+
+def _make_bins(start_week: datetime, end_week: datetime, max_points: int = 12) -> list[list[datetime]]:
+    weeks: list[datetime] = []
+    current = start_week
+    while current <= end_week:
+        weeks.append(current)
+        current += timedelta(weeks=1)
+    if not weeks:
+        weeks.append(start_week)
+
+    bin_size = max(1, math.ceil(len(weeks) / max_points))
+    return [weeks[i : i + bin_size] for i in range(0, len(weeks), bin_size)]
+
+
+def _build_trend(
+    week_data: dict[datetime, tuple[int, float, int]],
+    bins: list[list[datetime]],
+    total_listens: int,
+) -> list[float]:
+    values: list[float] = []
+    for chunk in bins:
+        listens = 0
+        metric_sum = 0.0
+        metric_samples = 0
+        for week in chunk:
+            if week in week_data:
+                l, ms, cnt = week_data[week]
+                listens += l
+                metric_sum += ms
+                metric_samples += cnt
+        if metric_samples > 0:
+            values.append(_round6(metric_sum / metric_samples))
+        elif listens > 0 and total_listens > 0:
+            values.append(_round6(listens / total_listens))
+        else:
+            values.append(0.0)
+    return values
+
+
+def _artist_key(artist_id: int | None) -> tuple[str, str | int]:
+    return ("artist", artist_id if artist_id is not None else "__unknown__")
+
+
 @router.get("/influence")
 async def list_influence(
     metric: str = Query("energy"),
     window: str = Query("12w"),
-    db: AsyncSession = Depends(get_db),
+    db: Session | AsyncSession = Depends(get_db),
     user_id: str = Depends(get_current_user),
 ):
     """Return top artist/label contributions for the given metric."""
 
-    # In lieu of a real implementation, return placeholder data. A future
-    # version will compute these scores from listening history.
-    return [
-        {
-            "name": "Artist A",
-            "type": "artist",
-            "score": 0.8,
-            "confidence": 0.9,
-            "trend": [0.3, 0.5, 0.7, 0.8],
-        },
-        {
-            "name": "Label X",
-            "type": "label",
-            "score": 0.6,
-            "confidence": 0.85,
-            "trend": [0.2, 0.4, 0.5, 0.6],
-        },
-    ]
+    metric = (metric or "").lower()
+    if metric not in AXES:
+        metric = "energy"
+
+    now = datetime.now(UTC)
+    span = _parse_window(window)
+    since = now - span
+
+    base_filters = [Listen.user_id == user_id, Listen.played_at >= since, Listen.played_at <= now]
+
+    total_listens = int(await _scalar(
+        db, select(func.count()).select_from(Listen).where(*base_filters)
+    ) or 0)
+    if total_listens == 0:
+        return []
+
+    mood_join = and_(
+        MoodScore.track_id == Listen.track_id,
+        MoodScore.axis == metric,
+        MoodScore.method == DEFAULT_METHOD,
+    )
+
+    sum_result = await _execute(
+        db,
+        select(func.sum(MoodScore.value), func.count(MoodScore.value))
+        .select_from(Listen)
+        .join(MoodScore, mood_join)
+        .where(*base_filters),
+    )
+    mood_sum, mood_count = sum_result.first() or (None, None)
+    metric_samples = int(mood_count or 0)
+    global_avg = float(mood_sum) / metric_samples if metric_samples else 0.5
+
+    artist_name = func.coalesce(Artist.name, literal("Unknown Artist"))
+    artist_totals_result = await _execute(
+        db,
+        select(
+            Track.artist_id.label("artist_id"),
+            artist_name.label("artist_name"),
+            func.count().label("listen_count"),
+            func.sum(MoodScore.value).label("metric_sum"),
+            func.count(MoodScore.value).label("metric_count"),
+        )
+        .select_from(Listen)
+        .join(Track, Track.track_id == Listen.track_id)
+        .join(Artist, Artist.artist_id == Track.artist_id, isouter=True)
+        .join(MoodScore, mood_join, isouter=True)
+        .where(*base_filters)
+        .group_by(Track.artist_id, artist_name),
+    )
+    artist_totals = list(artist_totals_result)
+
+    label_name_expr = func.coalesce(Release.label, literal("Unknown Label"))
+    label_totals_result = await _execute(
+        db,
+        select(
+            label_name_expr.label("label_name"),
+            func.count().label("listen_count"),
+            func.sum(MoodScore.value).label("metric_sum"),
+            func.count(MoodScore.value).label("metric_count"),
+        )
+        .select_from(Listen)
+        .join(Track, Track.track_id == Listen.track_id)
+        .join(Release, Release.release_id == Track.release_id, isouter=True)
+        .join(MoodScore, mood_join, isouter=True)
+        .where(*base_filters)
+        .group_by(label_name_expr),
+    )
+    label_totals = list(label_totals_result)
+
+    week_col = func.date_trunc("week", Listen.played_at).label("week")
+    artist_weeks_result = await _execute(
+        db,
+        select(
+            Track.artist_id.label("artist_id"),
+            week_col,
+            func.count().label("listen_count"),
+            func.sum(MoodScore.value).label("metric_sum"),
+            func.count(MoodScore.value).label("metric_count"),
+        )
+        .select_from(Listen)
+        .join(Track, Track.track_id == Listen.track_id)
+        .join(MoodScore, mood_join, isouter=True)
+        .where(*base_filters)
+        .group_by(Track.artist_id, week_col),
+    )
+    artist_weeks = list(artist_weeks_result)
+
+    label_weeks_result = await _execute(
+        db,
+        select(
+            label_name_expr.label("label_name"),
+            week_col,
+            func.count().label("listen_count"),
+            func.sum(MoodScore.value).label("metric_sum"),
+            func.count(MoodScore.value).label("metric_count"),
+        )
+        .select_from(Listen)
+        .join(Track, Track.track_id == Listen.track_id)
+        .join(Release, Release.release_id == Track.release_id, isouter=True)
+        .join(MoodScore, mood_join, isouter=True)
+        .where(*base_filters)
+        .group_by(label_name_expr, week_col),
+    )
+    label_weeks = list(label_weeks_result)
+
+    start_week = _floor_week(since)
+    end_week = _floor_week(now)
+    bins = _make_bins(start_week, end_week)
+
+    artist_week_data: dict[tuple[str, str | int], dict[datetime, tuple[int, float, int]]] = defaultdict(dict)
+    for row in artist_weeks:
+            week = row.week
+            if week is None:
+                continue
+            if week.tzinfo is None:
+                week = week.replace(tzinfo=UTC)
+            key = _artist_key(row.artist_id)
+            artist_week_data[key][week] = (
+                int(row.listen_count or 0),
+                float(row.metric_sum or 0.0),
+                int(row.metric_count or 0),
+            )
+
+    label_week_data: dict[str, dict[datetime, tuple[int, float, int]]] = defaultdict(dict)
+    for row in label_weeks:
+            week = row.week
+            if week is None:
+                continue
+            if week.tzinfo is None:
+                week = week.replace(tzinfo=UTC)
+            name = row.label_name or "Unknown Label"
+            label_week_data[name][week] = (
+                int(row.listen_count or 0),
+                float(row.metric_sum or 0.0),
+                int(row.metric_count or 0),
+            )
+
+    results: list[dict[str, object]] = []
+
+    if artist_totals:
+        for row in artist_totals:
+            listens = int(row.listen_count or 0)
+            if listens <= 0:
+                continue
+            key = _artist_key(row.artist_id)
+            name = (row.artist_name or "Unknown Artist").strip() or "Unknown Artist"
+            metric_sum = float(row.metric_sum or 0.0)
+            metric_count = int(row.metric_count or 0)
+            trend = _build_trend(artist_week_data.get(key, {}), bins, total_listens)
+            results.append(
+                {
+                    "name": name,
+                    "type": "artist",
+                    "score": _score(listens, metric_sum, metric_count, global_avg, total_listens),
+                    "confidence": _confidence(listens, metric_count),
+                    "trend": trend,
+                }
+            )
+
+    if label_totals:
+        for row in label_totals:
+            listens = int(row.listen_count or 0)
+            if listens <= 0:
+                continue
+            name = (row.label_name or "Unknown Label").strip() or "Unknown Label"
+            metric_sum = float(row.metric_sum or 0.0)
+            metric_count = int(row.metric_count or 0)
+            trend = _build_trend(label_week_data.get(name, {}), bins, total_listens)
+            results.append(
+                {
+                    "name": name,
+                    "type": "label",
+                    "score": _score(listens, metric_sum, metric_count, global_avg, total_listens),
+                    "confidence": _confidence(listens, metric_count),
+                    "trend": trend,
+                }
+            )
+
+    results.sort(key=lambda item: item["score"], reverse=True)
+    return results[:12]

--- a/tests/api/test_cohorts.py
+++ b/tests/api/test_cohorts.py
@@ -1,0 +1,104 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from sidetrack.api.constants import DEFAULT_METHOD
+from sidetrack.common.models import Artist, Listen, MoodScore, Release, Track
+
+
+@pytest.fixture
+def user_id():
+    return "cohort-user"
+
+
+def test_cohort_influence_with_mood_data(client, session, user_id):
+    now = datetime.now(UTC)
+
+    artist1 = Artist(name="Artist One")
+    artist2 = Artist(name="Artist Two")
+    artist3 = Artist(name="Artist Three")
+    session.add_all([artist1, artist2, artist3])
+    session.flush()
+
+    release1 = Release(title="R1", label="Label X", artist_id=artist1.artist_id)
+    release2 = Release(title="R2", label="Label Y", artist_id=artist2.artist_id)
+    release3 = Release(title="R3", label="Label Z", artist_id=artist3.artist_id)
+    session.add_all([release1, release2, release3])
+    session.flush()
+
+    track1 = Track(title="T1", artist_id=artist1.artist_id, release_id=release1.release_id)
+    track2 = Track(title="T2", artist_id=artist2.artist_id, release_id=release2.release_id)
+    track3 = Track(title="T3", artist_id=artist3.artist_id, release_id=release3.release_id)
+    session.add_all([track1, track2, track3])
+    session.flush()
+
+    session.add_all(
+        [
+            MoodScore(track_id=track1.track_id, axis="energy", method=DEFAULT_METHOD, value=0.82),
+            MoodScore(track_id=track2.track_id, axis="energy", method=DEFAULT_METHOD, value=0.25),
+            MoodScore(track_id=track3.track_id, axis="energy", method=DEFAULT_METHOD, value=0.9),
+        ]
+    )
+
+    session.add_all(
+        [
+            Listen(user_id=user_id, track_id=track1.track_id, played_at=now - timedelta(days=3)),
+            Listen(user_id=user_id, track_id=track1.track_id, played_at=now - timedelta(days=9)),
+            Listen(user_id=user_id, track_id=track2.track_id, played_at=now - timedelta(days=18)),
+            Listen(user_id=user_id, track_id=track3.track_id, played_at=now - timedelta(days=24)),
+        ]
+    )
+
+    session.commit()
+
+    resp = client.get(
+        "/api/v1/cohorts/influence?metric=energy&window=12w", headers={"X-User-Id": user_id}
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data
+
+    artist_item = next(item for item in data if item["type"] == "artist" and item["name"] == "Artist One")
+    assert pytest.approx(0.06125, rel=1e-3) == artist_item["score"]
+    assert pytest.approx(0.48658, rel=1e-3) == artist_item["confidence"]
+    assert len(artist_item["trend"]) > 0
+    assert any(val > 0 for val in artist_item["trend"])
+
+    label_item = next(item for item in data if item["type"] == "label" and item["name"] == "Label X")
+    assert pytest.approx(0.06125, rel=1e-3) == label_item["score"]
+    assert pytest.approx(0.48658, rel=1e-3) == label_item["confidence"]
+    assert len(label_item["trend"]) > 0
+    assert any(val > 0 for val in label_item["trend"])
+
+
+def test_cohort_influence_handles_missing_mood(client, session, user_id):
+    now = datetime.now(UTC)
+
+    artist = Artist(name="No Mood Artist")
+    session.add(artist)
+    session.flush()
+
+    track = Track(title="Raw Track", artist_id=artist.artist_id)
+    session.add(track)
+    session.flush()
+
+    session.add_all(
+        [
+            Listen(user_id=user_id, track_id=track.track_id, played_at=now - timedelta(days=2)),
+            Listen(user_id=user_id, track_id=track.track_id, played_at=now - timedelta(days=8)),
+            Listen(user_id=user_id, track_id=track.track_id, played_at=now - timedelta(days=15)),
+        ]
+    )
+    session.commit()
+
+    resp = client.get("/api/v1/cohorts/influence", headers={"X-User-Id": user_id})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data
+
+    artist_item = next(item for item in data if item["type"] == "artist" and item["name"] == "No Mood Artist")
+    assert pytest.approx(0.1, rel=1e-3) == artist_item["score"]
+    assert artist_item["confidence"] > 0
+    assert all(0.0 <= val <= 1.0 for val in artist_item["trend"]) and any(
+        val > 0 for val in artist_item["trend"]
+    )


### PR DESCRIPTION
## Summary
- aggregate cohort influence data by artist and label, computing contribution, confidence, and trend values
- add helper utilities to parse windows, normalise buckets, and support sync/async SQLAlchemy sessions
- cover artist/label scoring and sparse-data fallbacks with API tests

## Testing
- pytest -m "unit and not slow and not gpu" -q

------
https://chatgpt.com/codex/tasks/task_e_68c9bec948188333947ead63256ef3f4