### PR TITLE
Implement ListenBrainz ingester pagination and tests

### DIFF
--- a/sidetrack/services/providers/listenbrainz.py
+++ b/sidetrack/services/providers/listenbrainz.py
@@ -4,11 +4,33 @@ from __future__ import annotations
 
 from typing import Any, List
 
+import httpx
+
+from sidetrack.services.listenbrainz import ListenBrainzClient
+
+
+class _ProviderListenBrainzClient(ListenBrainzClient):
+    """Concrete ListenBrainz client for ingestion purposes."""
+
+    def auth_url(self, callback: str) -> str:  # pragma: no cover - CLI usage
+        raise NotImplementedError("ListenBrainz token auth is handled externally")
+
 
 class ListenBrainzIngester:
     """Fetch listens from the ListenBrainz API."""
 
-    def fetch_recent(self, user: str, token: str | None = None, since: float | None = None) -> List[dict[str, Any]]:
+    def __init__(self, *, page_size: int = 500) -> None:
+        if page_size <= 0:
+            raise ValueError("page_size must be positive")
+        # ListenBrainz caps count at 1000 per request.
+        self.page_size = min(page_size, 1000)
+
+    async def fetch_recent(
+        self,
+        user: str,
+        token: str | None = None,
+        since: float | None = None,
+    ) -> List[dict[str, Any]]:
         """Return recent listens for ``user``.
 
         Parameters
@@ -20,4 +42,95 @@ class ListenBrainzIngester:
         since:
             Optional unix timestamp for the earliest listen to return.
         """
-        raise NotImplementedError
+
+        headers = {"Authorization": f"Token {token}"} if token else None
+        min_ts = int(since) + 1 if since is not None else None
+        listens: list[dict[str, Any]] = []
+
+        async with httpx.AsyncClient() as client:
+            lb_client = _ProviderListenBrainzClient(client)
+            url = f"{lb_client.base_url}/user/{user}/listens"
+            offset = 0
+
+            while True:
+                params: dict[str, Any] = {"count": self.page_size, "offset": offset}
+                if min_ts is not None:
+                    params["min_ts"] = min_ts
+
+                resp = await lb_client._get(url, params=params, headers=headers)
+                data = resp.json()
+                payload = data.get("payload")
+                raw_listens: list[Any]
+                if isinstance(payload, dict):
+                    raw_listens = payload.get("listens") or []
+                else:
+                    raw_listens = data.get("listens") or []
+
+                if not isinstance(raw_listens, list) or not raw_listens:
+                    break
+
+                oldest_ts: int | None = None
+                for raw in raw_listens:
+                    if not isinstance(raw, dict):
+                        continue
+                    raw_ts = raw.get("listened_at")
+                    if isinstance(raw_ts, (int, float)):
+                        ts = int(raw_ts)
+                        if oldest_ts is None or ts < oldest_ts:
+                            oldest_ts = ts
+                    normalised = self._normalise_listen(raw, user)
+                    if normalised is None:
+                        continue
+                    if since is not None and normalised["listened_at"] <= since:
+                        continue
+                    listens.append(normalised)
+
+                if len(raw_listens) < self.page_size:
+                    break
+                if since is not None and oldest_ts is not None and oldest_ts <= since:
+                    break
+                offset += len(raw_listens)
+
+        return listens
+
+    @staticmethod
+    def _normalise_listen(listen: dict[str, Any], user: str) -> dict[str, Any] | None:
+        """Convert a ListenBrainz payload row to a ListenService compatible dict."""
+
+        listened_at = listen.get("listened_at")
+        try:
+            listened_at_int = int(listened_at)
+        except (TypeError, ValueError):
+            return None
+
+        raw_metadata = listen.get("track_metadata")
+        metadata = dict(raw_metadata) if isinstance(raw_metadata, dict) else {}
+
+        if "track_name" not in metadata and metadata.get("title"):
+            metadata["track_name"] = metadata.get("title")
+        if "artist_name" not in metadata and metadata.get("artist"):
+            metadata["artist_name"] = metadata.get("artist")
+
+        mbid_mapping = metadata.get("mbid_mapping")
+        if not isinstance(mbid_mapping, dict):
+            mbid_mapping = None
+
+        recording_mbid = None
+        if mbid_mapping:
+            recording_mbid = mbid_mapping.get("recording_mbid")
+
+        additional_info = metadata.get("additional_info")
+        if recording_mbid is None and isinstance(additional_info, dict):
+            recording_mbid = additional_info.get("recording_mbid")
+
+        if recording_mbid:
+            existing = mbid_mapping or {}
+            metadata["mbid_mapping"] = {**existing, "recording_mbid": recording_mbid}
+        elif mbid_mapping is not None:
+            metadata["mbid_mapping"] = dict(mbid_mapping)
+
+        return {
+            "track_metadata": metadata,
+            "listened_at": listened_at_int,
+            "user_name": listen.get("user_name") or user,
+        }

--- a/tests/services/test_listenbrainz_provider.py
+++ b/tests/services/test_listenbrainz_provider.py
@@ -1,0 +1,84 @@
+import httpx
+import pytest
+
+from sidetrack.services.providers.listenbrainz import ListenBrainzIngester
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetch_recent_paginates_and_normalises(respx_mock):
+    page_one = [
+        {
+            "listened_at": 300,
+            "track_metadata": {
+                "artist_name": "Artist A",
+                "track_name": "Track A",
+                "additional_info": {"recording_mbid": "rec-1"},
+            },
+        },
+        {
+            "listened_at": 200,
+            "track_metadata": {
+                "artist_name": "Artist B",
+                "title": "Track B",
+            },
+        },
+    ]
+    page_two = [
+        {
+            "listened_at": 150,
+            "track_metadata": {
+                "artist": "Artist C",
+                "track_name": "Track C",
+                "mbid_mapping": {"recording_mbid": "rec-3"},
+            },
+        }
+    ]
+
+    route = respx_mock.get("https://api.listenbrainz.org/1/user/tester/listens")
+    route.side_effect = [
+        httpx.Response(200, json={"payload": {"listens": page_one}}),
+        httpx.Response(200, json={"payload": {"listens": page_two}}),
+    ]
+
+    ingester = ListenBrainzIngester(page_size=2)
+    listens = await ingester.fetch_recent("tester", since=99)
+
+    assert [row["listened_at"] for row in listens] == [300, 200, 150]
+    assert listens[0]["track_metadata"]["mbid_mapping"]["recording_mbid"] == "rec-1"
+    assert listens[1]["track_metadata"]["track_name"] == "Track B"
+    assert listens[2]["track_metadata"]["artist_name"] == "Artist C"
+    assert all(row["user_name"] == "tester" for row in listens)
+
+    assert route.call_count == 2
+    first_query = dict(route.calls[0].request.url.params)
+    second_query = dict(route.calls[1].request.url.params)
+    assert first_query["count"] == "2"
+    assert first_query["offset"] == "0"
+    assert first_query["min_ts"] == "100"
+    assert second_query["offset"] == "2"
+    assert second_query["count"] == "2"
+    assert second_query["min_ts"] == "100"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetch_recent_includes_auth_token(respx_mock):
+    payload = {
+        "listened_at": 170,
+        "track_metadata": {
+            "artist_name": "Artist",
+            "track_name": "Title",
+        },
+    }
+
+    route = respx_mock.get("https://api.listenbrainz.org/1/user/alice/listens").mock(
+        return_value=httpx.Response(200, json={"payload": {"listens": [payload]}})
+    )
+
+    ingester = ListenBrainzIngester()
+    listens = await ingester.fetch_recent("alice", token="secret-token")
+
+    assert listens[0]["listened_at"] == 170
+    assert route.called
+    assert route.calls[0].request.headers["Authorization"] == "Token secret-token"


### PR DESCRIPTION
## Summary
- page through ListenBrainz listens with the provider ingester, normalising rows for ListenService
- cover pagination behaviour and token forwarding with provider unit tests

## Testing
- pytest -m "unit and not slow and not gpu" -q

------
https://chatgpt.com/codex/tasks/task_e_68c9cab0015883338ac90fd057cc653c