### PR TITLE
Implement Spotify provider ingestion

### DIFF
--- a/sidetrack/services/providers/spotify.py
+++ b/sidetrack/services/providers/spotify.py
@@ -2,25 +2,86 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Any, List
+
+import httpx
+
+from sidetrack.services.listens import convert_spotify_item
+from sidetrack.services.spotify import SpotifyClient
 
 
 class SpotifyIngester:
-    """Fetch listens from the Spotify API.
+    """Fetch listens from the Spotify API."""
 
-    This class currently serves as a placeholder for future integration.  It
-    exposes a :meth:`fetch_recent` method that should be implemented with real
-    Spotify API calls.
-    """
+    def __init__(self, *, page_size: int = 50) -> None:
+        if page_size <= 0:
+            raise ValueError("page_size must be positive")
+        self.page_size = min(page_size, 50)
 
-    def fetch_recent(self, user_token: str, since: float | None = None) -> List[dict[str, Any]]:
-        """Return recent listens for a user.
+    async def fetch_recent(
+        self,
+        user_token: str,
+        *,
+        user_id: str,
+        since: float | None = None,
+    ) -> List[dict[str, Any]]:
+        """Return recent listens for a user."""
 
-        Parameters
-        ----------
-        user_token:
-            OAuth access token for the user.
-        since:
-            Optional unix timestamp for the earliest listen to return.
-        """
-        raise NotImplementedError
+        threshold: float | None = None
+        if since is not None:
+            threshold = float(since)
+
+        after: datetime | None = None
+        if threshold is not None:
+            after = datetime.fromtimestamp(threshold, tz=timezone.utc)
+
+        listens: list[dict[str, Any]] = []
+        next_url: str | None = None
+
+        async with httpx.AsyncClient() as client:
+            sp_client = SpotifyClient(client)
+
+            while True:
+                if next_url:
+                    data = await sp_client._request("GET", next_url, user_token)
+                else:
+                    data = await sp_client.fetch_recently_played(
+                        user_token,
+                        after=after,
+                        limit=self.page_size,
+                        raw=True,
+                    )
+
+                if not isinstance(data, dict):
+                    break
+
+                items = data.get("items") or []
+                if not isinstance(items, list) or not items:
+                    break
+
+                stop = False
+                for item in items:
+                    row = convert_spotify_item(item, user_id)
+                    if not row:
+                        continue
+
+                    listened_at = row.get("listened_at")
+                    if (
+                        threshold is not None
+                        and listened_at is not None
+                        and listened_at <= threshold
+                    ):
+                        stop = True
+                        continue
+
+                    listens.append(row)
+
+                if stop:
+                    break
+
+                next_url = data.get("next")
+                if not next_url:
+                    break
+
+        return listens

--- a/sidetrack/services/spotify.py
+++ b/sidetrack/services/spotify.py
@@ -124,7 +124,9 @@ class SpotifyClient(MusicServiceClient):
         access_token: str,
         after: datetime | None = None,
         limit: int = 50,
-    ) -> list[dict[str, Any]]:
+        *,
+        raw: bool = False,
+    ) -> list[dict[str, Any]] | dict[str, Any]:
         params: dict[str, Any] = {"limit": min(limit, 50)}
         if after:
             params["after"] = int(after.timestamp() * 1000)
@@ -134,6 +136,8 @@ class SpotifyClient(MusicServiceClient):
             access_token,
             params=params,
         )
+        if raw:
+            return data
         return data.get("items", [])
 
     async def get_audio_features(

--- a/tests/services/test_spotify_provider.py
+++ b/tests/services/test_spotify_provider.py
@@ -1,0 +1,84 @@
+from datetime import datetime, timezone
+
+import httpx
+import pytest
+
+from sidetrack.services.providers.spotify import SpotifyIngester
+from sidetrack.services.spotify import SpotifyClient
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetch_recent_includes_auth_token(respx_mock):
+    payload = {
+        "played_at": "2024-01-01T00:00:00.000Z",
+        "track": {
+            "name": "Song A",
+            "artists": [{"name": "Artist A"}],
+        },
+    }
+
+    route = respx_mock.get(
+        f"{SpotifyClient.api_root}/me/player/recently-played",
+        params={"limit": "2"},
+    ).mock(return_value=httpx.Response(200, json={"items": [payload]}))
+
+    ingester = SpotifyIngester(page_size=2)
+    listens = await ingester.fetch_recent("oauth-token", user_id="alice")
+
+    assert route.called
+    request = route.calls[0].request
+    assert request.headers["Authorization"] == "Bearer oauth-token"
+    assert listens[0]["user_name"] == "alice"
+    assert listens[0]["track_metadata"]["track_name"] == "Song A"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_fetch_recent_filters_since_and_paginates(respx_mock):
+    base = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    first_times = [base.replace(minute=5), base.replace(minute=4)]
+    second_times = [base.replace(minute=3), base.replace(minute=1)]
+
+    def to_payload(ts: datetime, name: str) -> dict:
+        return {
+            "played_at": ts.isoformat().replace("+00:00", "Z"),
+            "track": {
+                "name": name,
+                "artists": [{"name": "Artist"}],
+            },
+        }
+
+    before_cursor = int(second_times[0].timestamp() * 1000)
+    first_page = {
+        "items": [
+            to_payload(first_times[0], "One"),
+            to_payload(first_times[1], "Two"),
+        ],
+        "next": f"{SpotifyClient.api_root}/me/player/recently-played?before={before_cursor}&limit=2",
+    }
+    second_page = {
+        "items": [
+            to_payload(second_times[0], "Three"),
+            to_payload(second_times[1], "Four"),
+        ],
+    }
+
+    after_param = str(int(datetime(2024, 1, 1, 0, 2, tzinfo=timezone.utc).timestamp() * 1000))
+    respx_mock.get(
+        f"{SpotifyClient.api_root}/me/player/recently-played",
+        params={"limit": "2", "after": after_param},
+    ).mock(return_value=httpx.Response(200, json=first_page))
+    next_route = respx_mock.get(first_page["next"]).mock(
+        return_value=httpx.Response(200, json=second_page)
+    )
+
+    ingester = SpotifyIngester(page_size=2)
+    since = datetime(2024, 1, 1, 0, 2, tzinfo=timezone.utc).timestamp()
+    listens = await ingester.fetch_recent("bearer-token", user_id="bob", since=since)
+
+    assert respx_mock.calls.call_count == 2
+    assert next_route.calls[0].request.headers["Authorization"] == "Bearer bearer-token"
+    listened_at_values = [row["listened_at"] for row in listens]
+    assert listened_at_values == [int(ts.timestamp()) for ts in first_times + second_times[:1]]
+    assert all(row["user_name"] == "bob" for row in listens)


### PR DESCRIPTION
## Summary
- implement a concrete SpotifyIngester that pages through recently played tracks, applies ListenBrainz conversion, and honours the optional since filter
- allow SpotifyClient.fetch_recently_played to return the raw payload for provider pagination needs
- add unit tests covering OAuth header propagation and timestamp filtering

## Testing
- `pytest -m "unit and not slow and not gpu" -q`


------
https://chatgpt.com/codex/tasks/task_e_68c9ce32b9b08333956cc8ebdb56b6e7