### PR TITLE
Track listen sources across ingestion

### DIFF
--- a/tests/services/test_listen_service_converters.py
+++ b/tests/services/test_listen_service_converters.py
@@ -41,6 +41,7 @@ async def test_ingest_spotify_rows_converts_and_filters_items():
     assert len(rows) == 3
     assert rows[1]["track_metadata"]["artist_name"] is None
     assert rows[2]["track_metadata"]["track_name"] is None
+    assert service.ingest_lb_rows.await_args.kwargs["source"] == "spotify"
 
 
 @pytest.mark.asyncio
@@ -77,3 +78,4 @@ async def test_ingest_lastfm_rows_converts_and_filters_tracks():
     assert len(rows) == 3
     assert rows[1]["track_metadata"]["artist_name"] is None
     assert rows[2]["track_metadata"]["track_name"] is None
+    assert service.ingest_lb_rows.await_args.kwargs["source"] == "lastfm"


### PR DESCRIPTION
## Summary
- allow `ListenService.ingest_lb_rows` to accept an optional source and inspect row hints so persisted listens record their origin
- ensure the Spotify and Last.fm ingestion helpers propagate their respective sources
- extend listen service tests to assert the stored source values

## Testing
- pytest -m "unit and not slow and not gpu" -q

------
https://chatgpt.com/codex/tasks/task_e_68c9d81e768883339b77c7c242c325f7