### PR TITLE
Enhance MusicBrainz enrichment and ID handling

### DIFF
--- a/sidetrack/common/models.py
+++ b/sidetrack/common/models.py
@@ -53,6 +53,7 @@ class Track(Base):
 
     track_id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     mbid: Mapped[str | None] = mapped_column(String(36), index=True)
+    isrc: Mapped[str | None] = mapped_column(String(16), index=True)
     spotify_id: Mapped[str | None] = mapped_column(String(64), index=True)
     title: Mapped[str] = mapped_column(String(512), index=True)
     artist_id: Mapped[int | None] = mapped_column(ForeignKey("artist.artist_id"))

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -19,6 +19,7 @@ class TrackFactory(factory.Factory):
     release_id = None
     duration = None
     fingerprint = None
+    isrc = None
     spotify_id = None
 
 

--- a/tests/services/test_datasync.py
+++ b/tests/services/test_datasync.py
@@ -11,7 +11,16 @@ from sidetrack.api.repositories.release_repository import ReleaseRepository
 from sidetrack.api.repositories.track_repository import TrackRepository
 from sidetrack.services.listens import ListenService
 from sidetrack.services.lastfm import LastfmClient
-from sidetrack.common.models import Artist, Listen, MBLabel, Release, Track, UserSettings
+from sidetrack.common.models import (
+    Artist,
+    Listen,
+    MBLabel,
+    MBTag,
+    MusicBrainzRecording,
+    Release,
+    Track,
+    UserSettings,
+)
 from sidetrack.services.datasync import enrich_ids, sync_user
 from sidetrack.services.listenbrainz import ListenBrainzClient
 from sidetrack.services.musicbrainz import MusicBrainzService
@@ -44,7 +53,7 @@ async def test_sync_user_triggers_enrichment(async_session, monkeypatch):
 
     mb_service = MusicBrainzService(httpx.AsyncClient())
     mb_calls = {}
-    async def fake_mb(isrc, title=None, artist=None):
+    async def fake_mb(isrc, title=None, artist=None, recording_mbid=None):
         mb_calls[isrc] = (title, artist)
         return {}
     monkeypatch.setattr(mb_service, "recording_by_isrc", fake_mb)
@@ -82,7 +91,12 @@ async def test_enrich_ids_persists_metadata(async_session):
     async_session.add(release)
     await async_session.flush()
 
-    track = Track(title="Song", artist_id=artist.artist_id, release_id=release.release_id)
+    track = Track(
+        title="Song",
+        artist_id=artist.artist_id,
+        release_id=release.release_id,
+        isrc="US1234567890",
+    )
     async_session.add(track)
     await async_session.flush()
 
@@ -96,14 +110,18 @@ async def test_enrich_ids_persists_metadata(async_session):
     await async_session.commit()
 
     class StubMB:
-        async def recording_by_isrc(self, isrc, title=None, artist=None):
+        calls: list[tuple[str | None, str | None, str | None, str | None]] = []
+
+        async def recording_by_isrc(self, isrc, title=None, artist=None, recording_mbid=None):
+            StubMB.calls.append((isrc, title, artist, recording_mbid))
             return {
                 "recording_mbid": "rec-1",
                 "artist_mbid": "art-1",
                 "release_group_mbid": "rg-1",
                 "label": "LabelCo",
                 "year": 2016,
-                "tags": [],
+                "tags": ["Rock", "Dream-Pop"],
+                "isrc": isrc,
             }
 
     result = await enrich_ids("u1", db=async_session, mb_service=StubMB())
@@ -111,9 +129,11 @@ async def test_enrich_ids_persists_metadata(async_session):
     assert result.processed == 1
     assert result.enriched == 1
     assert result.errors == []
+    assert StubMB.calls == [("US1234567890", "Song", "Artist", None)]
 
     refreshed_track = await async_session.get(Track, track.track_id)
     assert refreshed_track.mbid == "rec-1"
+    assert refreshed_track.isrc == "US1234567890"
 
     refreshed_artist = await async_session.get(Artist, artist.artist_id)
     assert refreshed_artist.mbid == "art-1"
@@ -126,6 +146,12 @@ async def test_enrich_ids_persists_metadata(async_session):
     ).scalar_one()
     assert label.primary_label == "LabelCo"
     assert label.era == "10s"
+
+    tags = (
+        await async_session.execute(select(MBTag).where(MBTag.track_id == track.track_id))
+    ).scalars().all()
+    assert {tag.tag for tag in tags} == {"rock", "dream pop"}
+    assert all(tag.score == 1.0 for tag in tags)
 
 
 @pytest.mark.asyncio
@@ -149,7 +175,7 @@ async def test_enrich_ids_collects_errors(async_session):
     await async_session.commit()
 
     class FailingMB:
-        async def recording_by_isrc(self, isrc, title=None, artist=None):
+        async def recording_by_isrc(self, isrc, title=None, artist=None, recording_mbid=None):
             raise RuntimeError("boom")
 
     result = await enrich_ids("u1", db=async_session, mb_service=FailingMB())
@@ -165,3 +191,64 @@ async def test_enrich_ids_collects_errors(async_session):
         await async_session.execute(select(MBLabel).where(MBLabel.track_id == track.track_id))
     ).scalar_one_or_none()
     assert label is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_enrich_ids_updates_mb_recording(async_session, monkeypatch):
+    artist = Artist(name="Artist")
+    async_session.add(artist)
+    await async_session.flush()
+
+    track = Track(title="Song", artist_id=artist.artist_id, isrc="US1111111111")
+    async_session.add(track)
+    await async_session.flush()
+
+    listen = Listen(
+        user_id="u1",
+        track_id=track.track_id,
+        played_at=datetime(2024, 2, 1, tzinfo=timezone.utc),
+        source="test",
+    )
+    async_session.add(listen)
+    await async_session.commit()
+
+    payload = {
+        "isrc": "US1111111111",
+        "recordings": [
+            {
+                "id": "rec-2",
+                "title": "Song",
+                "artist-credit": [{"artist": {"id": "art-2", "name": "Artist"}}],
+                "releases": [
+                    {
+                        "date": "2012-03-01",
+                        "label-info": [{"label": {"name": "Another Label"}}],
+                        "release-group": {"id": "rg-2"},
+                    }
+                ],
+                "tags": [{"name": "Electronic"}],
+                "isrcs": ["US1111111111"],
+            }
+        ],
+    }
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        if "isrc" in str(request.url):
+            return httpx.Response(200, json=payload)
+        return httpx.Response(404)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        mb_service = MusicBrainzService(client, db=async_session)
+        result = await enrich_ids("u1", db=async_session, mb_service=mb_service)
+
+    assert result.processed == 1
+    assert result.enriched == 1
+    record = await async_session.get(MusicBrainzRecording, "US1111111111")
+    assert record is not None
+    assert record.recording_mbid == "rec-2"
+    assert record.artist_mbid == "art-2"
+    assert record.release_group_mbid == "rg-2"
+    assert record.label == "Another Label"
+    assert record.tags == ["Electronic"]


### PR DESCRIPTION
## Summary
- add an ISRC column on tracks and capture Spotify metadata so enrichment has reliable identifiers
- normalize MusicBrainz lookups to skip bogus IDs, persist canonical tags, and log insufficient metadata instead of caching bad values
- extend coverage with API and service tests, including a regression that ensures MusicBrainzRecording rows are updated via the real client

## Testing
- pytest -m "unit and not slow and not gpu" -q

------
https://chatgpt.com/codex/tasks/task_e_68c9dfcf12fc833389b496ea86250b9f