### PR TITLE
Enable Spotify token refresh and ListenBrainz fallbacks

### DIFF
--- a/sidetrack/api/api/v1/recs.py
+++ b/sidetrack/api/api/v1/recs.py
@@ -44,12 +44,23 @@ async def list_recs(
     lb_client: ListenBrainzClient | None = None
     lb_user: str | None = None
     if settings.spotify_recs_enabled and row.spotify_access_token:
-        spotify_service = SpotifyUserClient(client, access_token=row.spotify_access_token)
+        spotify_service = SpotifyUserClient(
+            client,
+            access_token=row.spotify_access_token,
+            client_id=settings.spotify_client_id,
+            client_secret=settings.spotify_client_secret,
+            refresh_token=row.spotify_refresh_token,
+        )
     elif settings.lastfm_similar_enabled and row.lastfm_user:
         lastfm_client = LastfmClient(client, settings.lastfm_api_key, None)
         lastfm_user = row.lastfm_user
     elif settings.lb_cf_enabled and row.listenbrainz_user:
-        lb_client = ListenBrainzClient(client)
+        token = row.listenbrainz_token or settings.listenbrainz_token
+        lb_client = ListenBrainzClient(
+            client,
+            user=row.listenbrainz_user,
+            token=token,
+        )
         lb_user = row.listenbrainz_user
 
     redis_conn = _get_redis_connection(settings)
@@ -90,12 +101,23 @@ async def ranked_recs(
     lb_client: ListenBrainzClient | None = None
     lb_user: str | None = None
     if settings.spotify_recs_enabled and row.spotify_access_token:
-        spotify_service = SpotifyUserClient(client, access_token=row.spotify_access_token)
+        spotify_service = SpotifyUserClient(
+            client,
+            access_token=row.spotify_access_token,
+            client_id=settings.spotify_client_id,
+            client_secret=settings.spotify_client_secret,
+            refresh_token=row.spotify_refresh_token,
+        )
     elif settings.lastfm_similar_enabled and row.lastfm_user:
         lastfm_client = LastfmClient(client, settings.lastfm_api_key, None)
         lastfm_user = row.lastfm_user
     elif settings.lb_cf_enabled and row.listenbrainz_user:
-        lb_client = ListenBrainzClient(client)
+        token = row.listenbrainz_token or settings.listenbrainz_token
+        lb_client = ListenBrainzClient(
+            client,
+            user=row.listenbrainz_user,
+            token=token,
+        )
         lb_user = row.listenbrainz_user
 
     redis_conn = _get_redis_connection(settings)

--- a/sidetrack/services/listenbrainz.py
+++ b/sidetrack/services/listenbrainz.py
@@ -6,7 +6,10 @@ from typing import Any
 
 import httpx
 import logging
+from fastapi import Depends
 from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
+
+from sidetrack.api.config import Settings, get_settings
 
 from .base_client import MusicServiceClient
 from .models import TrackRef
@@ -134,6 +137,12 @@ class ListenBrainzClient(MusicServiceClient):
         return [a for a in artists if isinstance(a, dict)]
 
 
-async def get_listenbrainz_client() -> AsyncGenerator[ListenBrainzClient, None]:
+async def get_listenbrainz_client(
+    settings: Settings = Depends(get_settings),
+) -> AsyncGenerator[ListenBrainzClient, None]:
     async with httpx.AsyncClient() as client:
-        yield ListenBrainzClient(client)
+        yield ListenBrainzClient(
+            client,
+            user=settings.listenbrainz_user,
+            token=settings.listenbrainz_token,
+        )

--- a/sidetrack/services/maintenance.py
+++ b/sidetrack/services/maintenance.py
@@ -133,7 +133,7 @@ async def ingest_listens(
 
     if lb_client and source in {"auto", "listenbrainz"}:
         token = settings.listenbrainz_token
-        lb_user = user_id
+        lb_user = settings.listenbrainz_user or user_id
         if settings_row:
             if settings_row.listenbrainz_token:
                 token = settings_row.listenbrainz_token

--- a/sidetrack/worker/jobs.py
+++ b/sidetrack/worker/jobs.py
@@ -78,7 +78,11 @@ async def _sync_user_service(user_id: str, since: date | None, db) -> None:
                 settings.lastfm_api_secret,
                 min_interval=min_interval,
             ),
-            ListenBrainzClient(lb_http),
+            ListenBrainzClient(
+                lb_http,
+                user=settings.listenbrainz_user,
+                token=settings.listenbrainz_token,
+            ),
         ]
         mb_service = MusicBrainzService(mb_http)
         await datasync_sync_user(

--- a/tests/services/test_maintenance.py
+++ b/tests/services/test_maintenance.py
@@ -1,0 +1,121 @@
+import pytest
+
+from sidetrack.api.config import Settings
+from sidetrack.common.models import UserSettings
+from sidetrack.services.maintenance import ingest_listens
+
+
+class StubDBResult:
+    def __init__(self, row: UserSettings | None) -> None:
+        self._row = row
+
+    def scalar_one_or_none(self) -> UserSettings | None:
+        return self._row
+
+
+class StubDB:
+    def __init__(self, row: UserSettings | None) -> None:
+        self._row = row
+
+    async def execute(self, *_args, **_kwargs) -> StubDBResult:
+        return StubDBResult(self._row)
+
+
+class StubListenService:
+    def __init__(self) -> None:
+        self.calls: list[str | None] = []
+
+    async def ingest_lb_rows(
+        self, listens: list[dict], user_id: str | None = None, *, source: str | None = None
+    ) -> int:
+        self.calls.append(user_id)
+        return len(listens)
+
+
+class StubListenBrainzClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str | None]] = []
+
+    async def fetch_listens(
+        self, user: str, since, token: str | None, limit: int = 500
+    ) -> list[dict]:  # pragma: no cover - signature mirrors real client
+        self.calls.append((user, token))
+        return [{}]
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_ingest_listens_prefers_user_credentials():
+    row = UserSettings(
+        user_id="u1",
+        listenbrainz_user="alice",
+        listenbrainz_token="user-token",
+    )
+    db = StubDB(row)
+    settings = Settings(listenbrainz_token="global-token", listenbrainz_user="global-user")
+    listen_service = StubListenService()
+    lb_client = StubListenBrainzClient()
+
+    result = await ingest_listens(
+        db=db,
+        listen_service=listen_service,
+        user_id="u1",
+        settings=settings,
+        source="listenbrainz",
+        lb_client=lb_client,
+        fallback_to_sample=False,
+    )
+
+    assert result.ingested == 1
+    assert result.source == "listenbrainz"
+    assert lb_client.calls == [("alice", "user-token")]
+    assert listen_service.calls == ["u1"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_ingest_listens_falls_back_to_settings():
+    row = UserSettings(user_id="u2")
+    db = StubDB(row)
+    settings = Settings(listenbrainz_token="global-token", listenbrainz_user="global-user")
+    listen_service = StubListenService()
+    lb_client = StubListenBrainzClient()
+
+    result = await ingest_listens(
+        db=db,
+        listen_service=listen_service,
+        user_id="u2",
+        settings=settings,
+        source="listenbrainz",
+        lb_client=lb_client,
+        fallback_to_sample=False,
+    )
+
+    assert result.ingested == 1
+    assert result.source == "listenbrainz"
+    assert lb_client.calls == [("global-user", "global-token")]
+    assert listen_service.calls == ["u2"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_ingest_listens_handles_missing_credentials():
+    settings = Settings(listenbrainz_user=None, listenbrainz_token=None)
+    listen_service = StubListenService()
+    lb_client = StubListenBrainzClient()
+    db = StubDB(None)
+
+    result = await ingest_listens(
+        db=db,
+        listen_service=listen_service,
+        user_id="u3",
+        settings=settings,
+        source="listenbrainz",
+        lb_client=lb_client,
+        fallback_to_sample=False,
+    )
+
+    assert result.ingested == 1
+    assert result.source == "listenbrainz"
+    assert lb_client.calls == [("u3", None)]
+    assert listen_service.calls == ["u3"]

--- a/tests/services/test_spotify.py
+++ b/tests/services/test_spotify.py
@@ -31,3 +31,37 @@ async def test_get_saved_tracks_stops_at_limit(respx_mock):
 
     assert len(items) == 75
     assert respx_mock.calls.call_count == 2
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_spotify_user_client_refreshes_tokens(respx_mock):
+    me_route = respx_mock.get(f"{SpotifyUserClient.api_root}/me")
+    me_route.side_effect = [
+        httpx.Response(401, json={"error": {"status": 401, "message": "expired"}}),
+        httpx.Response(200, json={"id": "user"}),
+    ]
+
+    refresh_route = respx_mock.post(
+        f"{SpotifyUserClient.auth_root}/api/token",
+    ).respond(
+        200,
+        json={"access_token": "new-access", "refresh_token": "new-refresh"},
+    )
+
+    async with httpx.AsyncClient() as client:
+        service = SpotifyUserClient(
+            client,
+            access_token="expired",
+            client_id="cid",
+            client_secret="secret",
+            refresh_token="refresh-token",
+        )
+
+        result = await service.get_current_user()
+
+        assert result == {"id": "user"}
+        assert service.access_token == "new-access"
+        assert service.refresh_token == "new-refresh"
+        assert me_route.call_count == 2
+        assert refresh_route.called


### PR DESCRIPTION
## Summary
- pull Spotify client credentials and stored refresh tokens into SpotifyUserClient instances used by the recommendation endpoints
- pass ListenBrainz user/token configuration when constructing clients, including the worker helpers, and prefer configured defaults when user settings are missing
- cover Spotify token refresh behaviour and ListenBrainz authentication fallbacks with new unit tests

## Testing
- pytest -m "unit and not slow and not gpu" -q

------
https://chatgpt.com/codex/tasks/task_e_68c9e896d8b083339a0e8d69006f4b95