### PR TITLE
Fix TimescaleDB PGDATA volume mount

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -12,8 +12,9 @@ services:
       - POSTGRES_DB=${POSTGRES_DB}
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+      - PGDATA=/home/postgres/pgdata/data
     volumes:
-      - db_data:/var/lib/postgresql/data
+      - db_data:/home/postgres/pgdata
     ports: ["5432:5432"]
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]


### PR DESCRIPTION
## Summary
- confirmed the HA base image sets `PGDATA` to `/home/postgres/pgdata/data`
- pointed the compose database volume at the TimescaleDB data directory and exposed `PGDATA` explicitly

## Testing
- not run (docker CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cb1f1224748333a25727cf385cfd6d