### PR TITLE
Add Next proxy routes for dashboard insights and heatmap

### DIFF
--- a/services/ui/app/api/dashboard/daypart/heatmap/route.ts
+++ b/services/ui/app/api/dashboard/daypart/heatmap/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'https://sidetrack.network/api';
+
+export async function GET(req: NextRequest) {
+  const headers: Record<string, string> = {};
+  const uid = req.headers.get('x-user-id') || req.cookies.get('uid')?.value || '';
+  if (uid) headers['X-User-Id'] = uid;
+  const at = req.headers.get('authorization') || req.cookies.get('at')?.value || '';
+  if (at && !headers['Authorization'])
+    headers['Authorization'] = at.startsWith('Bearer ') ? at : `Bearer ${at}`;
+
+  const r = await fetch(`${API_BASE}/api/v1/daypart/heatmap`, { headers });
+  const data = await r
+    .json()
+    .catch(() => ({ cells: [], highlights: [] }));
+  return NextResponse.json(data, { status: r.status });
+}

--- a/services/ui/app/api/dashboard/insights/route.ts
+++ b/services/ui/app/api/dashboard/insights/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'https://sidetrack.network/api';
+
+export async function GET(req: NextRequest) {
+  const headers: Record<string, string> = {};
+  const uid = req.headers.get('x-user-id') || req.cookies.get('uid')?.value || '';
+  if (uid) headers['X-User-Id'] = uid;
+  const at = req.headers.get('authorization') || req.cookies.get('at')?.value || '';
+  if (at && !headers['Authorization'])
+    headers['Authorization'] = at.startsWith('Bearer ') ? at : `Bearer ${at}`;
+
+  const upstreamUrl = new URL(`${API_BASE}/api/v1/insights`);
+  req.nextUrl.searchParams.forEach((value, key) => {
+    upstreamUrl.searchParams.set(key, value);
+  });
+  if (!upstreamUrl.searchParams.has('window')) {
+    upstreamUrl.searchParams.set('window', '12w');
+  }
+
+  const r = await fetch(upstreamUrl, { headers });
+  const data = await r.json().catch(() => []);
+  return NextResponse.json(data, { status: r.status });
+}

--- a/services/ui/app/insights/page.test.tsx
+++ b/services/ui/app/insights/page.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+
+import InsightsPage from './page';
+import { apiFetch } from '../../lib/api';
+
+jest.mock('../../lib/api', () => ({
+  apiFetch: jest.fn(),
+}));
+
+jest.mock('../../components/insights/InsightModal', () => ({ insight }: { insight: unknown }) => (
+  <div data-testid="insight-modal" data-open={insight ? 'true' : 'false'} />
+));
+
+describe('InsightsPage', () => {
+  const mockApiFetch = apiFetch as jest.MockedFunction<typeof apiFetch>;
+  const createResponse = (body: unknown) => ({
+    json: () => Promise.resolve(body),
+  }) as unknown as Response;
+
+  beforeEach(() => {
+    mockApiFetch.mockResolvedValue(
+      createResponse([
+        {
+          ts: '2024-06-01T00:00:00Z',
+          type: 'discovery',
+          summary: 'Discovered something new',
+          severity: 2,
+        },
+      ]),
+    );
+  });
+
+  afterEach(() => {
+    mockApiFetch.mockReset();
+  });
+
+  it('renders insights from the API response', async () => {
+    render(<InsightsPage />);
+
+    expect(await screen.findByText('Discovered something new')).toBeInTheDocument();
+    expect(mockApiFetch).toHaveBeenCalledWith('/api/dashboard/insights?window=12w');
+  });
+});

--- a/services/ui/app/insights/page.tsx
+++ b/services/ui/app/insights/page.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import InsightCard, { Insight } from '../../components/insights/InsightCard';
 import InsightModal from '../../components/insights/InsightModal';
 import Skeleton from '../../components/Skeleton';
+import { apiFetch } from '../../lib/api';
 
 export default function InsightsPage() {
   const [insights, setInsights] = useState<Insight[]>([]);
@@ -10,7 +11,7 @@ export default function InsightsPage() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetch('/api/v1/insights?window=12w')
+    apiFetch('/api/dashboard/insights?window=12w')
       .then((r) => r.json())
       .then((d) => setInsights(d))
       .catch(() => setInsights([]))

--- a/services/ui/components/dashboard/DaypartHeatmap.test.tsx
+++ b/services/ui/components/dashboard/DaypartHeatmap.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from '@testing-library/react';
+
+import DaypartHeatmap from './DaypartHeatmap';
+import { apiFetch } from '../../lib/api';
+
+jest.mock('../../lib/api', () => ({
+  apiFetch: jest.fn(),
+}));
+
+jest.mock('react-plotly.js', () => () => <div data-testid="plotly" />);
+
+describe('DaypartHeatmap', () => {
+  const mockApiFetch = apiFetch as jest.MockedFunction<typeof apiFetch>;
+  const createResponse = (body: unknown) => ({
+    json: () => Promise.resolve(body),
+  }) as unknown as Response;
+
+  beforeEach(() => {
+    mockApiFetch.mockResolvedValue(
+      createResponse({
+        cells: [
+          { day: 0, hour: 5, count: 10, energy: 0.6, valence: 0.7, tempo: 120 },
+        ],
+        highlights: [{ day: 0, hour: 5, count: 10, z: 1 }],
+      }),
+    );
+  });
+
+  afterEach(() => {
+    mockApiFetch.mockReset();
+  });
+
+  it('renders highlights from the heatmap response', async () => {
+    render(<DaypartHeatmap />);
+
+    expect(await screen.findByText('Mon 5:00 – 10 listens')).toBeInTheDocument();
+    expect(mockApiFetch).toHaveBeenCalledWith('/api/dashboard/daypart/heatmap');
+  });
+});

--- a/services/ui/components/dashboard/DaypartHeatmap.tsx
+++ b/services/ui/components/dashboard/DaypartHeatmap.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { apiFetch } from '../../lib/api';
 import ChartCard from './ChartCard';
 
 interface Cell {
@@ -30,7 +31,7 @@ export default function DaypartHeatmap() {
   const [data, setData] = useState<HeatmapResponse | null>(null);
 
   useEffect(() => {
-    fetch('/api/v1/daypart/heatmap')
+    apiFetch('/api/dashboard/daypart/heatmap')
       .then((r) => r.json())
       .then((d) => setData(d))
       .catch(() => setData(null));


### PR DESCRIPTION
## Summary
- update the DaypartHeatmap component and insights page to call new dashboard proxy endpoints via apiFetch so auth headers are forwarded
- add Next.js route handlers that forward daypart heatmap and insights requests to the upstream API with existing dashboard header logic
- add Jest tests that cover the happy path parsing for both responses

## Testing
- npm test -- --runInBand
- pytest -m "unit and not slow and not gpu" -q

------
https://chatgpt.com/codex/tasks/task_e_68cb1f2acd90833386c6c4f77b3e6961