### PR TITLE
Add ranked recommendations proxy

### DIFF
--- a/services/ui/app/api/recs/ranked/route.test.ts
+++ b/services/ui/app/api/recs/ranked/route.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server';
+
+describe('recs ranked proxy route', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV, NEXT_PUBLIC_API_BASE: 'https://api.example.test' };
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+    jest.restoreAllMocks();
+  });
+
+  it('forwards the request and returns backend JSON unchanged', async () => {
+    const { GET } = await import('./route');
+
+    const backendPayload = [
+      {
+        id: 'track-1',
+        title: 'First Track',
+      },
+    ];
+
+    const fetchMock = jest.spyOn(global, 'fetch');
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify(backendPayload), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const req = new NextRequest('https://ui.test/api/recs/ranked?new=1', {
+      headers: {
+        'x-user-id': 'user-123',
+        authorization: 'Bearer test-token',
+      },
+    });
+
+    const res = await GET(req);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.example.test/api/v1/recs/ranked?new=1',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          'X-User-Id': 'user-123',
+          Authorization: 'Bearer test-token',
+        }),
+      }),
+    );
+
+    await expect(res.json()).resolves.toEqual(backendPayload);
+    expect(res.status).toBe(200);
+  });
+});
+

--- a/services/ui/app/api/recs/ranked/route.ts
+++ b/services/ui/app/api/recs/ranked/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'https://sidetrack.network/api';
+
+async function proxy(req: NextRequest) {
+  const headers: Record<string, string> = {};
+  const uid = req.headers.get('x-user-id') || req.cookies.get('uid')?.value || '';
+  if (uid) headers['X-User-Id'] = uid;
+  const at = req.headers.get('authorization') || req.cookies.get('at')?.value || '';
+  if (at && !headers['Authorization'])
+    headers['Authorization'] = at.startsWith('Bearer ') ? at : `Bearer ${at}`;
+
+  const search = req.nextUrl.search;
+  const url = `${API_BASE}/api/v1/recs/ranked${search}`;
+
+  const init: RequestInit = { method: req.method, headers };
+
+  const r = await fetch(url, init);
+  const data = await r.json().catch(() => ({}));
+
+  return NextResponse.json(data, { status: r.status });
+}
+
+export async function GET(req: NextRequest) {
+  return proxy(req);
+}
+

--- a/services/ui/app/recommendations/page.tsx
+++ b/services/ui/app/recommendations/page.tsx
@@ -25,7 +25,7 @@ export default function RecommendationsPage() {
     if (filters.freshness) params.set('min_freshness', String(filters.freshness));
     if (filters.diversity) params.set('diversity', String(filters.diversity));
     if (filters.energy) params.set('energy', String(filters.energy));
-    apiFetch(`/api/v1/recs/ranked?${params.toString()}`)
+    apiFetch(`/api/recs/ranked?${params.toString()}`)
       .then((r) => r.json())
       .then((j) => {
         setRecs(j ?? []);


### PR DESCRIPTION
## Summary
- update the recommendations page to read data from a new ranked recs proxy
- add a Next.js API route that forwards ranked recommendation calls to the backend
- add a regression test that ensures the proxy returns backend JSON untouched

## Testing
- npm test -- --runTestsByPath app/api/recs/ranked/route.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cb2822a37c8333b7069865fb2ad24a