### PR TITLE
Add Next.js Last.fm sync proxy route

### DIFF
--- a/services/ui/app/api/lastfm/sync/route.test.ts
+++ b/services/ui/app/api/lastfm/sync/route.test.ts
@@ -1,0 +1,76 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server';
+
+describe('lastfm sync proxy route', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV, NEXT_PUBLIC_API_BASE: 'https://api.example.test' };
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+    jest.restoreAllMocks();
+  });
+
+  it('forwards the request and returns backend JSON unchanged', async () => {
+    const { GET } = await import('./route');
+
+    const fetchMock = jest.spyOn(global, 'fetch');
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ detail: 'ok', updated: 12 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const req = new NextRequest('https://ui.test/api/lastfm/sync?since=2024-01-01', {
+      headers: {
+        'x-user-id': 'user-123',
+        authorization: 'Bearer test-token',
+      },
+    });
+
+    const res = await GET(req);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.example.test/tags/lastfm/sync?since=2024-01-01',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          'X-User-Id': 'user-123',
+          Authorization: 'Bearer test-token',
+        }),
+      }),
+    );
+
+    await expect(res.json()).resolves.toEqual({ detail: 'ok', updated: 12 });
+    expect(res.status).toBe(200);
+  });
+
+  it('propagates backend error status codes', async () => {
+    const { GET } = await import('./route');
+
+    const fetchMock = jest.spyOn(global, 'fetch');
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ detail: 'something went wrong' }), {
+        status: 503,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const req = new NextRequest('https://ui.test/api/lastfm/sync', {
+      headers: {
+        'x-user-id': 'user-123',
+      },
+    });
+
+    const res = await GET(req);
+
+    await expect(res.json()).resolves.toEqual({ detail: 'something went wrong' });
+    expect(res.status).toBe(503);
+  });
+});

--- a/services/ui/app/api/lastfm/sync/route.ts
+++ b/services/ui/app/api/lastfm/sync/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'https://sidetrack.network/api';
+
+export async function GET(req: NextRequest) {
+  const headers: Record<string, string> = {};
+  const uid = req.headers.get('x-user-id') || req.cookies.get('uid')?.value || '';
+  if (uid) headers['X-User-Id'] = uid;
+  const at = req.headers.get('authorization') || req.cookies.get('at')?.value || '';
+  if (at && !headers['Authorization'])
+    headers['Authorization'] = at.startsWith('Bearer ') ? at : `Bearer ${at}`;
+
+  const query = req.nextUrl.searchParams.toString();
+  const target = `${API_BASE}/tags/lastfm/sync${query ? `?${query}` : ''}`;
+
+  const r = await fetch(target, {
+    headers,
+    method: 'GET',
+  });
+
+  const data = await r.json().catch(() => ({}));
+  return NextResponse.json(data, { status: r.status });
+}

--- a/services/ui/components/HeaderActions.tsx
+++ b/services/ui/components/HeaderActions.tsx
@@ -14,10 +14,23 @@ export default function HeaderActions() {
 
   const handleSync = async () => {
     setSyncing(true);
-    toast.show({ title: 'Sync started', description: 'Fetching listens…', kind: 'info' });
+    toast.show({ title: 'Sync started', description: 'Syncing Last.fm tags…', kind: 'info' });
     try {
-      await apiFetch('/api/lastfm/sync', { method: 'POST', suppressErrorToast: true });
-      toast.show({ title: 'Sync complete', description: 'Listens updated', kind: 'success' });
+      const res = await apiFetch('/api/lastfm/sync', { method: 'GET', suppressErrorToast: true });
+      let updatedCount: number | null = null;
+      try {
+        const data = (await res.json()) as { updated?: number };
+        if (typeof data?.updated === 'number') {
+          updatedCount = data.updated;
+        }
+      } catch {
+        // Ignore JSON parsing errors for toast rendering
+      }
+      const description =
+        updatedCount != null
+          ? `Updated ${updatedCount} ${updatedCount === 1 ? 'tag' : 'tags'}`
+          : 'Last.fm tags updated';
+      toast.show({ title: 'Sync complete', description, kind: 'success' });
     } catch {
       toast.show({ title: 'Sync failed', description: 'Please try again later', kind: 'error' });
     } finally {


### PR DESCRIPTION
## Summary
- add a Next.js API route that forwards Last.fm tag sync requests to the FastAPI backend with the caller's auth context
- update the dashboard header sync action to use the new GET proxy and surface the updated tag count when available
- add Jest coverage to ensure the proxy relays success and failure statuses

## Testing
- npm test -- --runTestsByPath app/api/lastfm/sync/route.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cb2a8dfc4c8333a63f149b5af12cb9