### PR TITLE
Add Last.fm scrobble sync from UI

### DIFF
--- a/services/ui/components/HeaderActions.tsx
+++ b/services/ui/components/HeaderActions.tsx
@@ -5,7 +5,7 @@ import * as Tooltip from '@radix-ui/react-tooltip';
 import { useToast } from './ToastProvider';
 import { useTheme } from './ThemeContext';
 import { RefreshCw, Sun, Moon } from 'lucide-react';
-import { apiFetch } from '../lib/api';
+import { syncLastfmScrobbles } from '../lib/lastfmSync';
 
 export default function HeaderActions() {
   const toast = useToast();
@@ -14,22 +14,13 @@ export default function HeaderActions() {
 
   const handleSync = async () => {
     setSyncing(true);
-    toast.show({ title: 'Sync started', description: 'Syncing Last.fm tags…', kind: 'info' });
+    toast.show({ title: 'Sync started', description: 'Ingesting Last.fm scrobbles…', kind: 'info' });
     try {
-      const res = await apiFetch('/api/lastfm/sync', { method: 'GET', suppressErrorToast: true });
-      let updatedCount: number | null = null;
-      try {
-        const data = (await res.json()) as { updated?: number };
-        if (typeof data?.updated === 'number') {
-          updatedCount = data.updated;
-        }
-      } catch {
-        // Ignore JSON parsing errors for toast rendering
-      }
+      const { ingested } = await syncLastfmScrobbles();
       const description =
-        updatedCount != null
-          ? `Updated ${updatedCount} ${updatedCount === 1 ? 'tag' : 'tags'}`
-          : 'Last.fm tags updated';
+        typeof ingested === 'number'
+          ? `Ingested ${ingested} ${ingested === 1 ? 'listen' : 'listens'}`
+          : 'Scrobbles synced';
       toast.show({ title: 'Sync complete', description, kind: 'success' });
     } catch {
       toast.show({ title: 'Sync failed', description: 'Please try again later', kind: 'error' });

--- a/services/ui/lib/lastfmSync.ts
+++ b/services/ui/lib/lastfmSync.ts
@@ -1,0 +1,38 @@
+import { apiFetch } from './api';
+
+export type LastfmSyncResult = {
+  ingested: number | null;
+  since: string;
+};
+
+export function getLastWeekSince(): string {
+  const now = new Date();
+  const oneWeekAgo = new Date(Date.UTC(
+    now.getUTCFullYear(),
+    now.getUTCMonth(),
+    now.getUTCDate(),
+  ));
+  oneWeekAgo.setUTCDate(oneWeekAgo.getUTCDate() - 7);
+  return oneWeekAgo.toISOString().slice(0, 10);
+}
+
+export async function syncLastfmScrobbles({
+  suppressErrorToast = true,
+}: { suppressErrorToast?: boolean } = {}): Promise<LastfmSyncResult> {
+  const since = getLastWeekSince();
+  const searchParams = new URLSearchParams({ source: 'lastfm', since });
+  const res = await apiFetch(`/api/v1/ingest/listens?${searchParams.toString()}`, {
+    method: 'POST',
+    suppressErrorToast,
+  });
+  let ingested: number | null = null;
+  try {
+    const data = (await res.json()) as { ingested?: unknown };
+    if (typeof data?.ingested === 'number') {
+      ingested = data.ingested;
+    }
+  } catch {
+    // Ignore JSON parsing failures; toast messaging does not require payload
+  }
+  return { ingested, since };
+}


### PR DESCRIPTION
## Summary
- add a shared helper that posts to the listen ingestion endpoint for the last week of Last.fm scrobbles
- update the header sync control and the Last.fm card on the settings page to use the ingestion helper and show sync-specific toasts
- extend the settings page test suite to cover the new sync button behaviour

## Testing
- npm test -- --runTestsByPath app/settings/page.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68cb2ed0a25483339470b7ad8d9e7c10