### PR TITLE
Add Last.fm ingest proxy route and tests

### DIFF
--- a/services/ui/app/api/v1/ingest/listens/route.test.ts
+++ b/services/ui/app/api/v1/ingest/listens/route.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @jest-environment node
+ */
+import { NextRequest } from 'next/server';
+
+describe('ingest listens proxy route', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...OLD_ENV, NEXT_PUBLIC_API_BASE: 'https://api.example.test' };
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+    jest.restoreAllMocks();
+  });
+
+  it('forwards POST requests with auth and body to the backend', async () => {
+    const { POST } = await import('./route');
+
+    const payload = { listens: [] };
+    const fetchMock = jest.spyOn(global, 'fetch');
+    fetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ detail: 'ok', ingested: 1 }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const req = new NextRequest(
+      'https://ui.test/api/v1/ingest/listens?source=lastfm&since=2025-09-10',
+      {
+        method: 'POST',
+        headers: {
+          'x-user-id': 'user-123',
+          authorization: 'Bearer test-token',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      },
+    );
+
+    const res = await POST(req);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.example.test/api/v1/ingest/listens?source=lastfm&since=2025-09-10',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          'X-User-Id': 'user-123',
+          Authorization: 'Bearer test-token',
+          'Content-Type': 'application/json',
+        }),
+        body: JSON.stringify(payload),
+      }),
+    );
+
+    await expect(res.json()).resolves.toEqual({ detail: 'ok', ingested: 1 });
+    expect(res.status).toBe(200);
+  });
+});

--- a/services/ui/app/api/v1/ingest/listens/route.ts
+++ b/services/ui/app/api/v1/ingest/listens/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'https://sidetrack.network/api';
+
+function buildAuthHeaders(req: NextRequest): Record<string, string> {
+  const headers: Record<string, string> = {};
+  const uid = req.headers.get('x-user-id') || req.cookies.get('uid')?.value || '';
+  if (uid) headers['X-User-Id'] = uid;
+  const authorization = req.headers.get('authorization') || req.cookies.get('at')?.value || '';
+  if (authorization && !headers['Authorization']) {
+    headers['Authorization'] = authorization.startsWith('Bearer ')
+      ? authorization
+      : `Bearer ${authorization}`;
+  }
+  const contentType = req.headers.get('content-type');
+  if (contentType) headers['Content-Type'] = contentType;
+  return headers;
+}
+
+export async function POST(req: NextRequest) {
+  const headers = buildAuthHeaders(req);
+  const search = req.nextUrl.searchParams.toString();
+  const upstreamUrl = `${API_BASE}/api/v1/ingest/listens${search ? `?${search}` : ''}`;
+  const bodyText = await req.text();
+  const res = await fetch(upstreamUrl, {
+    method: 'POST',
+    headers,
+    body: bodyText.length ? bodyText : undefined,
+  });
+  const data = await res.json().catch(() => ({}));
+  return NextResponse.json(data, { status: res.status });
+}

--- a/tests/services/test_maintenance.py
+++ b/tests/services/test_maintenance.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 import pytest
 
 from sidetrack.api.config import Settings
@@ -23,13 +25,18 @@ class StubDB:
 
 class StubListenService:
     def __init__(self) -> None:
-        self.calls: list[str | None] = []
+        self.lb_calls: list[str | None] = []
+        self.lastfm_calls: list[tuple[list[dict], str]] = []
 
     async def ingest_lb_rows(
         self, listens: list[dict], user_id: str | None = None, *, source: str | None = None
     ) -> int:
-        self.calls.append(user_id)
+        self.lb_calls.append(user_id)
         return len(listens)
+
+    async def ingest_lastfm_rows(self, tracks: list[dict], user_id: str) -> int:
+        self.lastfm_calls.append((tracks, user_id))
+        return len(tracks)
 
 
 class StubListenBrainzClient:
@@ -69,7 +76,7 @@ async def test_ingest_listens_prefers_user_credentials():
     assert result.ingested == 1
     assert result.source == "listenbrainz"
     assert lb_client.calls == [("alice", "user-token")]
-    assert listen_service.calls == ["u1"]
+    assert listen_service.lb_calls == ["u1"]
 
 
 @pytest.mark.asyncio
@@ -94,7 +101,7 @@ async def test_ingest_listens_falls_back_to_settings():
     assert result.ingested == 1
     assert result.source == "listenbrainz"
     assert lb_client.calls == [("global-user", "global-token")]
-    assert listen_service.calls == ["u2"]
+    assert listen_service.lb_calls == ["u2"]
 
 
 @pytest.mark.asyncio
@@ -118,4 +125,46 @@ async def test_ingest_listens_handles_missing_credentials():
     assert result.ingested == 1
     assert result.source == "listenbrainz"
     assert lb_client.calls == [("u3", None)]
-    assert listen_service.calls == ["u3"]
+    assert listen_service.lb_calls == ["u3"]
+
+
+class StubLastfmClient:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, object | None]] = []
+
+    async def fetch_recent_tracks(self, user: str, since):
+        self.calls.append((user, since))
+        return [
+            {"name": "Song", "artist": {"#text": "Artist"}, "date": {"uts": "1704067200"}}
+        ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_ingest_listens_fetches_lastfm_tracks():
+    row = UserSettings(user_id="u4", lastfm_user="alice", lastfm_session_key="session")
+    db = StubDB(row)
+    settings = Settings()
+    listen_service = StubListenService()
+    lf_client = StubLastfmClient()
+
+    result = await ingest_listens(
+        db=db,
+        listen_service=listen_service,
+        user_id="u4",
+        settings=settings,
+        since=date(2024, 1, 1),
+        source="lastfm",
+        lf_client=lf_client,
+        fallback_to_sample=False,
+    )
+
+    assert result.ingested == 1
+    assert result.source == "lastfm"
+    assert lf_client.calls and lf_client.calls[0][0] == "alice"
+    since_arg = lf_client.calls[0][1]
+    assert since_arg is not None
+    assert hasattr(since_arg, "date") and since_arg.date() == date(2024, 1, 1)
+    assert listen_service.lastfm_calls and listen_service.lastfm_calls[0][1] == "u4"
+    tracks_forwarded, _ = listen_service.lastfm_calls[0]
+    assert len(tracks_forwarded) == 1


### PR DESCRIPTION
## Summary
- add a Next.js API proxy for POST /api/v1/ingest/listens so the sync button reaches the backend
- cover Last.fm ingestion in the maintenance service tests with explicit stubs
- verify the new proxy behaviour with a dedicated Jest test

## Testing
- pytest -m "unit and not slow and not gpu" -q
- npm test -- --runTestsByPath app/api/v1/ingest/listens/route.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cb316acbe88333aa83c3742847d4d2